### PR TITLE
Added re-population of UploadableField-properties.

### DIFF
--- a/EventListener/UploaderListener.php
+++ b/EventListener/UploaderListener.php
@@ -54,7 +54,8 @@ class UploaderListener implements EventSubscriber
         return array(
             'prePersist',
             'preUpdate',
-            'postRemove'
+            'postRemove',
+            'postLoad'
         );
     }
     
@@ -99,6 +100,20 @@ class UploaderListener implements EventSubscriber
         
         if ($this->isUploadable($obj)) {
             $this->uploader->remove($obj);
+        }
+    }
+
+    /**
+     * Populates uploadable fields from filename properties
+     * if necessary.
+     *
+     * @param \Doctrine\Common\EventArgs $args
+     */
+    public function postLoad(EventArgs $args)
+    {
+        $obj = $this->adapter->getObjectFromArgs($args);
+        if ($this->isUploadable($obj)) {
+            $this->uploader->populateUploadableFields($obj);
         }
     }
     

--- a/Upload/UploaderInterface.php
+++ b/Upload/UploaderInterface.php
@@ -15,7 +15,17 @@ interface UploaderInterface
      * @param object $obj The object.
      */
     function upload($obj);
-    
+
+    /**
+     * Populates all UploadableField-properties in the object with
+     * a Symfony\Component\HttpFoundation\File\File object representing
+     * their file. The paths of these files are derived from the
+     * corresponding filename properties.
+     *
+     * @param object $obj The object.
+     */
+    function populateUploadableFields($obj);
+
     /**
      * Removes the file associated with the object if configured to
      * do so.


### PR DESCRIPTION
With these changes, `UploadableField`-properties are re-populated with `File`-objects from their corresponding filename-properties after the `Uploadable` object is loaded from the ORM/ODM.

Usually I store uploads outside the webroot, and need to perform other operations on those files rather than just display a link. For this purpose it is handy if `$product->getImage()` (in the example) always returns a `Symfony\Component\HttpFoundation\File\File`-object if a filename is set, even if `$product` was just loaded from the ORM/ODM and therefore only has `$imageName` set. This PR makes this possible.

---

PS: Thanks for your awesome bundle, especially now multiple uploadable fields per entity are supported. It is really useful for a current project, and I will try to contribute some PR's along the way.
