### PR TITLE
Fixed a bug, when project root dir contains 'web' (same as webdirname) in the full path

### DIFF
--- a/Templating/Helper/UploaderHelper.php
+++ b/Templating/Helper/UploaderHelper.php
@@ -55,9 +55,8 @@ class UploaderHelper extends Helper
     public function asset($obj, $field)
     {
         $path = $this->storage->resolvePath($obj, $field);
+        $parts = explode($this->webDirName, $path);
 
-        $index = strpos($path, $this->webDirName);
-
-        return substr($path, $index + strlen($this->webDirName));
+        return array_pop($parts);
     }
 }


### PR DESCRIPTION
Fixed a bug, when project root dir contains 'web' (same as webdirname) in the full path
For example, the project is located in '/home/user/web/project'
webdirname is a default 'web'
The resulting dir name will be in this case wrong, because strpos will return you the index of first 'web'.

I think this check should be checked also for '/web/'.
