### PR TITLE
Fixed generating gaufrette URI's when running on windows

### DIFF
--- a/Storage/GaufretteStorage.php
+++ b/Storage/GaufretteStorage.php
@@ -86,6 +86,6 @@ class GaufretteStorage extends AbstractStorage
      */
     protected function doResolvePath($dir, $name)
     {
-        return 'gaufrette://' . $dir . DIRECTORY_SEPARATOR . $name;
+        return 'gaufrette://' . $dir . '/' . $name;
     }
 }


### PR DESCRIPTION
There should be only forward slashes in the generated uri's.  
On windows DIRECTORY_SEPARATOR  is an alias for backward slash.
