### PR TITLE
Update Storage/FileSystemStorage.php

### DIFF
--- a/Storage/FileSystemStorage.php
+++ b/Storage/FileSystemStorage.php
@@ -63,7 +63,6 @@ class FileSystemStorage extends AbstractStorage
         }
 
         $uriPrefix = $mapping->getUriPrefix();
-        $parts = explode($uriPrefix, $mapping->getUploadDir($obj, $field));
-        return sprintf('%s/%s', $uriPrefix . array_pop($parts), $name);
+        return sprintf('%s/%s', $uriPrefix . $mapping->getUploadDir($obj, $field), $name);
     }
 }


### PR DESCRIPTION
Fixing `resolveUri`.

Following configuration:

``` yaml
uri_prefix:           /
upload_destination:   media/product/files
```

Returned `/files/acme.png` for file named `acme.png`, when it should've returned `/media/product/files/acme.png`.

I have no idea what this $parts line was for, but it did break a very important part of this bundle!
