### PR TITLE
Added compatibility with latest gaufrette version.

### DIFF
--- a/Storage/GaufretteStorage.php
+++ b/Storage/GaufretteStorage.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 use Knp\Bundle\GaufretteBundle\FilesystemMap;
 
-use Gaufrette\FileStream\Local;
+use Gaufrette\Stream\Local as LocalStream;
 use Gaufrette\StreamMode;
 
 /**
@@ -45,7 +45,7 @@ class GaufretteStorage extends AbstractStorage
      *
      * @return \Gaufrette\Filesystem
      */
-    protected function getAdapter($key)
+    protected function getFilesystem($key)
     {
         return $this->filesystemMap->get($key);
     }
@@ -55,10 +55,10 @@ class GaufretteStorage extends AbstractStorage
      */
     protected function doUpload(UploadedFile $file, $dir, $name)
     {
-        $adapter = $this->getAdapter($dir);
+        $filesystem = $this->getFilesystem($dir);
 
-        $src = new Local($file->getPathname());
-        $dst = $adapter->createFileStream($name);
+        $src = new LocalStream($file->getPathname());
+        $dst = $filesystem->createStream($name);
 
         $src->open(new StreamMode('rb+'));
         $dst->open(new StreamMode('ab+'));
@@ -76,7 +76,7 @@ class GaufretteStorage extends AbstractStorage
      */
     protected function doRemove($dir, $name)
     {
-        $adapter = $this->getAdapter($dir);
+        $adapter = $this->getFilesystem($dir);
 
         return $adapter->delete($name);
     }

--- a/Tests/Storage/GaufretteStorageTest.php
+++ b/Tests/Storage/GaufretteStorageTest.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Storage;
+
+use Vich\UploaderBundle\Storage\GaufretteStorage;
+use Vich\UploaderBundle\Tests\DummyEntity;
+
+/**
+ * GaufretteStorageTest.
+ *
+ * @author Leszek Prabucki <leszek.prabucki@gmail.com>
+ */
+class GaufretteStorageTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Vich\UploaderBundle\Mapping\PropertyMappingFactory $factory
+     */
+    protected $factory;
+
+    /**
+     * @var \Knp\Bundle\GaufretteBundle\FilesystemMap $factory
+     */
+    protected $filesystemMap;
+
+    /**
+     * Sets up the test.
+     */
+    public function setUp()
+    {
+        $this->factory = $this->getFactoryMock();
+        $this->filesystemMap = $this->getFilesystemMapMock();
+    }
+
+    /**
+     * Tests the upload method skips a mapping which has a null
+     * uploadable property value.
+     */
+    public function testUploadSkipsMappingOnNullFile()
+    {
+        $obj = new DummyEntity();
+
+        $mapping = $this->getMock('Vich\UploaderBundle\Mapping\PropertyMapping');
+
+        $mapping
+                ->expects($this->once())
+                ->method('getPropertyValue')
+                ->will($this->returnValue(null));
+
+        $mapping
+                ->expects($this->never())
+                ->method('hasNamer');
+
+        $mapping
+                ->expects($this->never())
+                ->method('getNamer');
+
+        $mapping
+                ->expects($this->never())
+                ->method('getFileNameProperty');
+
+        $this->factory
+                ->expects($this->once())
+                ->method('fromObject')
+                ->with($obj)
+                ->will($this->returnValue(array($mapping)));
+
+        $storage = new GaufretteStorage($this->factory, $this->filesystemMap);
+        $storage->upload($obj);
+    }
+
+    /**
+     * Tests the upload method skips a mapping which has an uploadable
+     * field property value that is not an instance of UploadedFile.
+     */
+    public function testUploadSkipsMappingOnNonUploadedFileInstance()
+    {
+        $obj = new DummyEntity();
+
+        $mapping = $this->getMock('Vich\UploaderBundle\Mapping\PropertyMapping');
+
+        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $mapping
+                ->expects($this->once())
+                ->method('getPropertyValue')
+                ->will($this->returnValue($file));
+
+        $mapping
+                ->expects($this->never())
+                ->method('hasNamer');
+
+        $mapping
+                ->expects($this->never())
+                ->method('getNamer');
+
+        $mapping
+                ->expects($this->never())
+                ->method('getFileNameProperty');
+
+        $this->factory
+                ->expects($this->once())
+                ->method('fromObject')
+                ->with($obj)
+                ->will($this->returnValue(array($mapping)));
+
+        $storage = new GaufretteStorage($this->factory, $this->filesystemMap);
+        $storage->upload($obj);
+    }
+
+    /**
+     * Test the remove method does not remove a file that is configured
+     * to not be deleted upon removal of the entity.
+     */
+    public function testRemoveSkipsConfiguredNotToDeleteOnRemove()
+    {
+        $obj = new DummyEntity();
+
+        $mapping = $this->getMock('Vich\UploaderBundle\Mapping\PropertyMapping');
+
+        $mapping
+                ->expects($this->once())
+                ->method('getDeleteOnRemove')
+                ->will($this->returnValue(false));
+
+        $mapping
+                ->expects($this->never())
+                ->method('getFileNameProperty');
+
+        $this->factory
+                ->expects($this->once())
+                ->method('fromObject')
+                ->with($obj)
+                ->will($this->returnValue(array($mapping)));
+
+        $storage = new GaufretteStorage($this->factory, $this->filesystemMap);
+        $storage->remove($obj);
+    }
+
+    /**
+     * Test the remove method skips trying to remove a file whose file name
+     * property value returns null.
+     */
+    public function testRemoveSkipsNullFileNameProperty()
+    {
+        $obj = new DummyEntity();
+
+        $prop = $this->getMockBuilder('\ReflectionProperty')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $prop
+                ->expects($this->once())
+                ->method('getValue')
+                ->with($obj)
+                ->will($this->returnValue(null));
+
+        $mapping = $this->getMock('Vich\UploaderBundle\Mapping\PropertyMapping');
+        $mapping
+                ->expects($this->once())
+                ->method('getDeleteOnRemove')
+                ->will($this->returnValue(true));
+
+        $mapping
+                ->expects($this->once())
+                ->method('getFileNameProperty')
+                ->will($this->returnValue($prop));
+
+        $mapping
+                ->expects($this->never())
+                ->method('getUploadDir');
+
+        $this->factory
+                ->expects($this->once())
+                ->method('fromObject')
+                ->with($obj)
+                ->will($this->returnValue(array($mapping)));
+
+        $storage = new GaufretteStorage($this->factory, $this->filesystemMap);
+        $storage->remove($obj);
+    }
+
+    /**
+     * Test the resolve path method.
+     */
+    public function testResolvePath()
+    {
+        $obj = new DummyEntity();
+
+        $mapping = $this->getMock('Vich\UploaderBundle\Mapping\PropertyMapping');
+
+        $prop = $this->getMockBuilder('\ReflectionProperty')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $prop
+                ->expects($this->once())
+                ->method('getValue')
+                ->with($obj)
+                ->will($this->returnValue('file.txt'));
+
+        $mapping
+                ->expects($this->once())
+                ->method('getUploadDir')
+                ->will($this->returnValue('filesystemKey'));
+
+        $mapping
+                ->expects($this->once())
+                ->method('getFileNameProperty')
+                ->will($this->returnValue($prop));
+
+        $this->factory
+                ->expects($this->once())
+                ->method('fromField')
+                ->with($obj, 'file')
+                ->will($this->returnValue($mapping));
+
+        $storage = new GaufretteStorage($this->factory, $this->filesystemMap);
+        $path = $storage->resolvePath($obj, 'file');
+
+        $this->assertEquals('gaufrette://filesystemKey/file.txt', $path);
+    }
+
+    /**
+     * Test the remove method does delete file from gaufrette filesystem
+     */
+    public function testThatRemoveMethodDoesDeleteFile()
+    {
+        $mapping = $this->getMock('Vich\UploaderBundle\Mapping\PropertyMapping');
+        $obj = new DummyEntity();
+
+        $prop = $this->getMockBuilder('\ReflectionProperty')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $prop
+            ->expects($this->any())
+            ->method('getValue')
+            ->with($obj)
+            ->will($this->returnValue('file.txt'));
+        $prop
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('nameProperty'));
+
+        $mapping
+            ->expects($this->once())
+            ->method('getDeleteOnRemove')
+            ->will($this->returnValue(true));
+        $mapping
+            ->expects($this->any())
+            ->method('getUploadDir')
+            ->will($this->returnValue('filesystemKey'));
+        $mapping
+            ->expects($this->once())
+            ->method('getFileNameProperty')
+            ->will($this->returnValue($prop));
+        $mapping
+            ->expects($this->once())
+            ->method('getProperty')
+            ->will($this->returnValue($prop));
+
+        $filesystem = $this->getFilesystemMock();
+        $filesystem
+            ->expects($this->once())
+            ->method('delete')
+            ->with('file.txt');
+
+        $this
+            ->filesystemMap
+            ->expects($this->once())
+            ->method('get')
+            ->with('filesystemKey')
+            ->will($this->returnValue($filesystem));
+
+        $this
+            ->factory
+            ->expects($this->once())
+            ->method('fromObject')
+            ->with($obj)
+            ->will($this->returnValue(array($mapping)));
+
+        $storage = new GaufretteStorage($this->factory, $this->filesystemMap);
+        $storage->remove($obj, 'file');
+    }
+
+    /**
+     * Test the resolve path method throws exception
+     * when an invaid field name is specified.
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testResolvePathThrowsExceptionOnInvalidFieldName()
+    {
+        $obj = new DummyEntity();
+
+        $this->factory
+                ->expects($this->once())
+                ->method('fromField')
+                ->with($obj, 'oops')
+                ->will($this->returnValue(null));
+
+        $storage = new GaufretteStorage($this->factory, $this->filesystemMap);
+        $storage->resolvePath($obj, 'oops');
+    }
+
+    /**
+     * Creates a mock factory.
+     *
+     * @return \Vich\UploaderBundle\Mapping\PropertyMappingFactory The factory.
+     */
+    protected function getFactoryMock()
+    {
+        return $this
+            ->getMockBuilder('Vich\UploaderBundle\Mapping\PropertyMappingFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Creates a mock of gaufrette filesystem map.
+     *
+     * @return \Knp\Bundle\GaufretteBundle\FilesystemMap The filesystem map.
+     */
+    protected function getFilesystemMapMock()
+    {
+        return $this
+            ->getMockBuilder('Knp\Bundle\GaufretteBundle\FilesystemMap')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Creates a mock of gaufrette filesystem.
+     *
+     * @return \Gaufrette\Filesystem The gaufrette filesystem object.
+     */
+    protected function getFilesystemMock()
+    {
+        return $this
+            ->getMockBuilder('\Gaufrette\Filesystem')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/dbal": "@stable",
         "doctrine/mongodb": "dev-master",
         "doctrine/mongodb-odm": "dev-master",
-        "knplabs/knp-gaufrette-bundle": "dev-master"
+        "knplabs/knp-gaufrette-bundle": "0.2.*"
     },
     "suggest": {
         "symfony/doctrine-bundle": "*",


### PR DESCRIPTION
Gaufrette\FileStream was changed to Gaufrette\Stream in Gaufrette lib. I fixed it here and added some basic unit test base on FileSystemStorageTest.

BTW to use this bundle with gaufrette we have to register stream wrapper: https://github.com/KnpLabs/KnpGaufretteBundle#stream-wrapper
