### PR TITLE
Fix Windows bug when using DirectoryNamerInterface

### DIFF
--- a/Storage/FileSystemStorage.php
+++ b/Storage/FileSystemStorage.php
@@ -64,7 +64,7 @@ class FileSystemStorage extends AbstractStorage
         }
 
         $uriPrefix = $mapping->getUriPrefix();
-        $parts = explode($uriPrefix, $mapping->getUploadDir($obj, $field));
+        $parts = explode($uriPrefix, str_replace('\\', '/', $mapping->getUploadDir($obj, $field)));
         return sprintf('%s/%s', $uriPrefix . array_pop($parts), $name);
     }
 }


### PR DESCRIPTION
Vich\UploaderBundle\Storage\FileSystemStorage::resolveUri does not replace Windows directory separators when using a DirectoryNamer.
