### PR TITLE
Replace uploaded file with stored one on save entity.

### DIFF
--- a/EventListener/UploaderListener.php
+++ b/EventListener/UploaderListener.php
@@ -77,6 +77,8 @@ class UploaderListener implements EventSubscriber
         $obj = $this->adapter->getObjectFromArgs($args);
         if ($this->isUploadable($obj)) {
             $this->storage->upload($obj);
+            
+            $this->injector->injectFiles($obj);
         }
     }
 
@@ -90,6 +92,8 @@ class UploaderListener implements EventSubscriber
         $obj = $this->adapter->getObjectFromArgs($args);
         if ($this->isUploadable($obj)) {
             $this->storage->upload($obj);
+            
+            $this->injector->injectFiles($obj);
 
             $this->adapter->recomputeChangeSet($args);
         }

--- a/Tests/EventListener/UploaderListenerTest.php
+++ b/Tests/EventListener/UploaderListenerTest.php
@@ -94,6 +94,11 @@ class UploaderListenerTest extends \PHPUnit_Framework_TestCase
             ->method('upload')
             ->with($obj);
 
+        $this->injector
+            ->expects($this->once())
+            ->method('injectFiles')
+            ->with($obj);
+
         $listener = new UploaderListener($this->adapter, $this->driver, $this->storage, $this->injector);
         $listener->prePersist($args);
     }
@@ -129,6 +134,10 @@ class UploaderListenerTest extends \PHPUnit_Framework_TestCase
         $this->storage
             ->expects($this->never())
             ->method('upload');
+
+        $this->injector
+            ->expects($this->never())
+            ->method('injectFiles');
 
         $listener = new UploaderListener($this->adapter, $this->driver, $this->storage, $this->injector);
         $listener->prePersist($args);
@@ -176,6 +185,11 @@ class UploaderListenerTest extends \PHPUnit_Framework_TestCase
             ->method('upload')
             ->with($obj);
 
+        $this->injector
+            ->expects($this->once())
+            ->method('injectFiles')
+            ->with($obj);
+
         $listener = new UploaderListener($this->adapter, $this->driver, $this->storage, $this->injector);
         $listener->preUpdate($args);
     }
@@ -215,6 +229,10 @@ class UploaderListenerTest extends \PHPUnit_Framework_TestCase
         $this->adapter
             ->expects($this->never())
             ->method('recomputeChangeSet');
+
+        $this->injector
+            ->expects($this->never())
+            ->method('injectFiles');git
 
         $listener = new UploaderListener($this->adapter, $this->driver, $this->storage, $this->injector);
         $listener->preUpdate($args);


### PR DESCRIPTION
It fixes #34

Without this change it is not possible to use `exercise/elastica-bundle` with `mapper-attachment` plugin. The uploaded file is removed on flush but the elastica bundle tries to index the file content at same time. Is there a change to get this merged?
