### PR TITLE
Documentation fix

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -308,7 +308,7 @@ vich_uploader:
     # ...
     mappings:
         product_image:
-            upload_destination: product_image
+            upload_destination: product_image_fs
             namer: vich_uploader.namer_uniqid
 ```
 


### PR DESCRIPTION
The docs appear to be missing _fs to indicate the product_image filesystem rather
than the product_image alias
