### PR TITLE
use write mode instead of append mode when uploading a file

### DIFF
--- a/Storage/GaufretteStorage.php
+++ b/Storage/GaufretteStorage.php
@@ -62,7 +62,7 @@ class GaufretteStorage extends AbstractStorage
         $dst = $filesystem->createStream($name);
 
         $src->open(new StreamMode('rb+'));
-        $dst->open(new StreamMode('ab+'));
+        $dst->open(new StreamMode('wb+'));
 
         while (!$src->eof()) {
             $data = $src->read(100000);


### PR DESCRIPTION
When performing an upload one probably expects the new file to replace the old file instead of appending to it.
