### PR TITLE
Fix name when guessed extension is empty

### DIFF
--- a/Naming/UniqidNamer.php
+++ b/Naming/UniqidNamer.php
@@ -21,6 +21,12 @@ class UniqidNamer implements NamerInterface
 
         $file = $refProp->getValue($obj);
 
-        return sprintf('%s.%s', uniqid(), $file->guessExtension());
+        $name = uniqid();
+
+        if ($extension = $file->guessExtension()) {
+            $name = sprintf('%s.%s', $name, $file->guessExtension());
+        }
+
+        return $name;
     }
 }

--- a/Tests/Naming/UniqidNamerTest.php
+++ b/Tests/Naming/UniqidNamerTest.php
@@ -13,7 +13,18 @@ use Vich\UploaderBundle\Naming\UniqidNamer;
  */
 class UniqidNamerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testNameReturnsAnUniqueName()
+    public static function fileDataProvider()
+    {
+        return array(
+            array('jpeg', '/[a-z0-9]{13}.jpeg/'),
+            array(null, '/[a-z0-9]{13}/'),
+        );
+    }
+
+    /**
+     * @dataProvider fileDataProvider
+     */
+    public function testNameReturnsAnUniqueName($extension, $pattern)
     {
         $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
             ->disableOriginalConstructor()
@@ -22,13 +33,13 @@ class UniqidNamerTest extends \PHPUnit_Framework_TestCase
         $file
             ->expects($this->any())
             ->method('guessExtension')
-            ->will($this->returnValue('jpeg'));
+            ->will($this->returnValue($extension));
 
         $entity = new DummyEntity;
         $entity->setFile($file);
 
         $namer = new UniqidNamer();
 
-        $this->assertRegExp('/[a-z0-9]{13}.jpeg/', $namer->name($entity, 'file'));
+        $this->assertRegExp($pattern, $namer->name($entity, 'file'));
     }
 }


### PR DESCRIPTION
When extension cannot be guessed, file name ended with a dot without the extension (for example `5113d9d14306a.`)
