### PR TITLE
Add support for uploadable properties inherited from parent class.

### DIFF
--- a/Driver/AnnotationDriver.php
+++ b/Driver/AnnotationDriver.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Driver;
 
 use Doctrine\Common\Annotations\Reader;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 
 /**
  * AnnotationDriver.
@@ -47,7 +48,7 @@ class AnnotationDriver
     {
         $fields = array();
 
-        foreach ($class->getProperties() as $prop) {
+        foreach (PropertyMappingFactory::getProperties($class) as $prop) {
             $field = $this->reader->getPropertyAnnotation($prop, 'Vich\UploaderBundle\Mapping\Annotation\UploadableField');
             if (null !== $field) {
                 $field->setPropertyName($prop->getName());
@@ -69,7 +70,7 @@ class AnnotationDriver
     public function readUploadableField(\ReflectionClass $class, $field)
     {
         try {
-            $prop = $class->getProperty($field);
+            $prop = PropertyMappingFactory::getProperty($class, $field);
 
             $field = $this->reader->getPropertyAnnotation($prop, 'Vich\UploaderBundle\Mapping\Annotation\UploadableField');
             if (null === $field) {

--- a/Mapping/PropertyMappingFactory.php
+++ b/Mapping/PropertyMappingFactory.php
@@ -129,8 +129,8 @@ class PropertyMappingFactory
         $config = $this->mappings[$field->getMapping()];
 
         $mapping = new PropertyMapping();
-        $mapping->setProperty($class->getProperty($field->getPropertyName()));
-        $mapping->setFileNameProperty($class->getProperty($field->getFileNameProperty()));
+        $mapping->setProperty(self::getProperty($class, $field->getPropertyName()));
+        $mapping->setFileNameProperty(self::getProperty($class, $field->getFileNameProperty()));
         $mapping->setMappingName($field->getMapping());
         $mapping->setMapping($config);
 
@@ -143,5 +143,26 @@ class PropertyMappingFactory
         }
 
         return $mapping;
+    }
+
+    public static function getProperties(\ReflectionClass $class)
+    {
+        $properties = $class->getProperties();
+        if ($parentClass = $class->getParentClass()) {
+            $properties = array_merge(self::getProperties($parentClass), $properties);
+        }
+        return $properties;
+    }
+
+    public static function getProperty(\ReflectionClass $class, $property)
+    {
+        try {
+            return $class->getProperty($property);
+        } catch (\ReflectionException $e) {
+            if ($parentClass = $class->getParentClass()) {
+                return self::getProperty($parentClass, $property);
+            }
+            throw $e;
+        }
     }
 }


### PR DESCRIPTION
Vich uploader was not able to read uploadable fields defined in the parent class. You will have to redefine all the properties inside the child class again.

With this the upload is able to support fields defined in the parent class. The child class still need to be annotated as uploadable.
