### PR TITLE
`inject_on_load` default false

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -60,7 +60,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('directory_namer')->defaultNull()->end()
                             ->scalarNode('delete_on_remove')->defaultTrue()->end()
                             ->scalarNode('delete_on_update')->defaultTrue()->end()
-                            ->scalarNode('inject_on_load')->defaultTrue()->end()
+                            ->scalarNode('inject_on_load')->defaultFalse()->end()
                         ->end()
                     ->end()
                 ->end()

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -452,7 +452,7 @@ vich_uploader:
             namer: ~ # specify a file namer service id for this entity, null default
             directory_namer: ~ # specify a directory namer service id for this entity, null default
             delete_on_remove: true # determines whether to delete file upon removal of entity
-            inject_on_load: true # determines whether to inject a File instance upon load
+            inject_on_load: false # determines whether to inject a File instance upon load
         # ... more mappings
 ```
 


### PR DESCRIPTION
I think it's a good idea to change default value of configuration parameter `inject_on_load` to  `false`. In most cases developers don't need file to entity injection but if turned on it takes a lot of time and memory. Especially when you use Gaufrette to upload files to S3.

I've spend much time profiling to find what makes my app so slow. This pull request is to save time of other devs.
