### PR TITLE
Enforce strict naming conventions for mapping files

### DIFF
--- a/Metadata/Driver/FileLocator.php
+++ b/Metadata/Driver/FileLocator.php
@@ -34,7 +34,7 @@ class FileLocator implements AdvancedFileLocatorInterface
                 continue;
             }
 
-            $files = $finder->files()->in($dir)->name(sprintf('*%s*.%s', $class->getShortName(), $extension));
+            $files = $finder->files()->in($dir)->name(sprintf('%s.%s', $class->getShortName(), $extension));
 
             if (count($files) !== 1) {
                 continue;
@@ -42,7 +42,7 @@ class FileLocator implements AdvancedFileLocatorInterface
 
             $file = current(iterator_to_array($files));
 
-            return $file->getRealpath();
+            return $file->getPathname();
         }
 
         return null;

--- a/Tests/Metadata/Driver/FileLocatorTest.php
+++ b/Tests/Metadata/Driver/FileLocatorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Metadata\Driver;
+
+use org\bovigo\vfs\vfsStream;
+
+use Vich\UploaderBundle\Metadata\Driver\FileLocator;
+
+/**
+ * FileLocatorTest
+ *
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ */
+class FileLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \org\bovigo\vfs\vfsStreamDirectory
+     */
+    protected $root;
+
+    /**
+     * @var FileLocator
+     */
+    protected $locator;
+
+    /**
+     * Sets up the test.
+     */
+    public function setUp()
+    {
+        // initialize the virtual filesystem
+        $this->root = vfsStream::setup('vich_uploader_bundle', null, array(
+            'vich_uploader' => array(
+                'Foo.yml'       => 'some content',
+                'FooBaz.yml'    => 'some content',
+                'Bar.yml'       => 'some content',
+                'Baz.xml'       => 'some content',
+            ),
+        ));
+
+        $this->locator = new FileLocator(array(
+            '\DummyNamespace' => $this->root->url() . DIRECTORY_SEPARATOR . 'vich_uploader',
+        ));
+    }
+
+    /**
+     * @dataProvider fileProvider
+     */
+    public function testFindFileForClass($namespace, $name, $extension, $path)
+    {
+        $rClass = $this->getMockBuilder('\ReflectionClass')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $rClass
+            ->expects($this->any())
+            ->method('getNamespaceName')
+            ->will($this->returnValue($namespace));
+        $rClass
+            ->expects($this->any())
+            ->method('getShortName')
+            ->will($this->returnValue($name));
+
+        $file = $this->locator->findFileForClass($rClass, $extension);
+
+        $this->assertEquals($path, $file);
+    }
+
+    public function fileProvider()
+    {
+        return array(
+            array( '\DummyNamespace', 'Foo', 'yml', 'vfs://vich_uploader_bundle/vich_uploader/Foo.yml' ),
+            array( '\DummyNamespace', 'FooBaz', 'yml', 'vfs://vich_uploader_bundle/vich_uploader/FooBaz.yml' ),
+            array( '\DummyNamespace', 'Baz', 'xml', 'vfs://vich_uploader_bundle/vich_uploader/Baz.xml' ),
+            array( '\DummyNamespace', 'Dummy', 'xml', null ),
+        );
+    }
+
+    /**
+     * @dataProvider classesProvider
+     */
+    public function testFindAllClasses($extension, array $expectedClasses)
+    {
+        $classes = $this->locator->findAllClasses($extension);
+        $classNames = array_values(array_map(function($item) {
+            return $item->getFileName();
+        }, $classes));
+
+        $this->assertEquals($expectedClasses, $classNames);
+    }
+
+    public function classesProvider()
+    {
+        return array(
+            array( 'yml', array('Foo.yml', 'FooBaz.yml', 'Bar.yml') ),
+            array( 'xml', array('Baz.xml') ),
+            array( 'php', array() ),
+        );
+    }
+}


### PR DESCRIPTION
Fixes issue #214.

Mapping files must be named exactly after the entity they are describing (`Foo.xml` for the `Foo` class. `Foo.orm.xml` won't work anymore)
