### PR TITLE
Give access to the property mapping object to the namers

### DIFF
--- a/Mapping/PropertyMapping.php
+++ b/Mapping/PropertyMapping.php
@@ -222,16 +222,25 @@ class PropertyMapping
      * Gets the configured upload directory.
      *
      * @param object|null $obj
-     * @param string|null $field
      *
      * @return string The configured upload directory.
      */
-    public function getUploadDir($obj = null, $field = null)
+    public function getUploadDir($obj = null)
     {
         if ($this->hasDirectoryNamer()) {
-            return $this->getDirectoryNamer()->directoryName($obj, $field, $this->mapping['upload_destination']);
+            return $this->getDirectoryNamer()->directoryName($obj, $this);
         }
 
+        return $this->getUploadDestination();
+    }
+
+    /**
+     * Gets the base upload directory.
+     *
+     * @return string The configured upload directory.
+     */
+    public function getUploadDestination()
+    {
         return $this->mapping['upload_destination'];
     }
 

--- a/Naming/DirectoryNamerInterface.php
+++ b/Naming/DirectoryNamerInterface.php
@@ -2,6 +2,8 @@
 
 namespace Vich\UploaderBundle\Naming;
 
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
 /**
  * NamerInterface.
  *
@@ -12,10 +14,12 @@ interface DirectoryNamerInterface
     /**
      * Creates a directory name for the file being uploaded.
      *
-     * @param  object $obj       The object the upload is attached to.
-     * @param  string $field     The name of the uploadable field to generate a name for.
-     * @param  string $uploadDir The upload directory set in config
+     * @param object          $object  The object the upload is attached to.
+     * @param Propertymapping $mapping The mapping to use to manipulate the given object.
+     *
+     * @note The $object parameter can be null.
+     *
      * @return string The directory name.
      */
-    public function directoryName($obj, $field, $uploadDir);
+    public function directoryName($object, PropertyMapping $mapping);
 }

--- a/Naming/NamerInterface.php
+++ b/Naming/NamerInterface.php
@@ -2,6 +2,8 @@
 
 namespace Vich\UploaderBundle\Naming;
 
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
 /**
  * NamerInterface.
  *
@@ -12,9 +14,10 @@ interface NamerInterface
     /**
      * Creates a name for the file being uploaded.
      *
-     * @param  object $obj   The object the upload is attached to.
-     * @param  string $field The name of the uploadable field to generate a name for.
+     * @param object          $object  The object the upload is attached to.
+     * @param Propertymapping $mapping The mapping to use to manipulate the given object.
+     *
      * @return string The file name.
      */
-    public function name($obj, $field);
+    public function name($object, PropertyMapping $mapping);
 }

--- a/Naming/OrignameNamer.php
+++ b/Naming/OrignameNamer.php
@@ -5,6 +5,8 @@ namespace Vich\UploaderBundle\Naming;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
 /**
  * OrignameNamer
  *
@@ -15,14 +17,9 @@ class OrignameNamer implements NamerInterface
     /**
      * {@inheritDoc}
      */
-    public function name($obj, $field)
+    public function name($object, PropertyMapping $mapping)
     {
-        $refObj = new \ReflectionObject($obj);
-
-        $refProp = $refObj->getProperty($field);
-        $refProp->setAccessible(true);
-
-        $file = $refProp->getValue($obj);
+        $file = $mapping->getFile($object);
 
         /** @var $file UploadedFile */
 

--- a/Naming/UniqidNamer.php
+++ b/Naming/UniqidNamer.php
@@ -4,6 +4,8 @@ namespace Vich\UploaderBundle\Naming;
 
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
 /**
  * UniqidNamer
  *
@@ -14,14 +16,9 @@ class UniqidNamer implements NamerInterface
     /**
      * {@inheritDoc}
      */
-    public function name($obj, $field)
+    public function name($object, PropertyMapping $mapping)
     {
-        $refObj = new \ReflectionObject($obj);
-
-        $refProp = $refObj->getProperty($field);
-        $refProp->setAccessible(true);
-
-        $file = $refProp->getValue($obj);
+        $file = $mapping->getFile($object);
         $name = uniqid();
 
         if ($extension = $this->getExtension($file)) {

--- a/Storage/AbstractStorage.php
+++ b/Storage/AbstractStorage.php
@@ -53,18 +53,18 @@ abstract class AbstractStorage implements StorageInterface
             }
 
             if ($mapping->getDeleteOnUpdate() && ($name = $mapping->getFileName($obj))) {
-                $dir = $mapping->getUploadDir($obj, $mapping->getFilePropertyName());
+                $dir = $mapping->getUploadDir($obj);
 
                 $this->doRemove($dir, $name);
             }
 
             if ($mapping->hasNamer()) {
-                $name = $mapping->getNamer()->name($obj, $mapping->getFilePropertyName());
+                $name = $mapping->getNamer()->name($obj, $mapping);
             } else {
                 $name = $file->getClientOriginalName();
             }
 
-            $dir = $mapping->getUploadDir($obj, $mapping->getFilePropertyName());
+            $dir = $mapping->getUploadDir($obj);
 
             $this->doUpload($file, $dir, $name);
 
@@ -101,7 +101,7 @@ abstract class AbstractStorage implements StorageInterface
                 continue;
             }
 
-            $dir = $mapping->getUploadDir($obj, $mapping->getFilePropertyName());
+            $dir = $mapping->getUploadDir($obj);
 
             $this->doRemove($dir, $name);
         }
@@ -123,7 +123,7 @@ abstract class AbstractStorage implements StorageInterface
     public function resolvePath($obj, $field, $className = null)
     {
         list($mapping, $filename) = $this->getFilename($obj, $field, $className);
-        $dir = $mapping->getUploadDir($obj, $field);
+        $dir = $mapping->getUploadDir($obj);
 
         return $this->doResolvePath($dir, $filename);
     }

--- a/Storage/FileSystemStorage.php
+++ b/Storage/FileSystemStorage.php
@@ -53,7 +53,7 @@ class FileSystemStorage extends AbstractStorage
     {
         list($mapping, $name) = $this->getFilename($obj, $field, $className);
         $uriPrefix = $mapping->getUriPrefix();
-        $parts = explode($uriPrefix, $this->convertWindowsDirectorySeparator($mapping->getUploadDir($obj, $field)));
+        $parts = explode($uriPrefix, $this->convertWindowsDirectorySeparator($mapping->getUploadDir($obj)));
 
         return sprintf('%s/%s', $uriPrefix . array_pop($parts), $name);
     }

--- a/Tests/Mapping/ProperyMappingTest.php
+++ b/Tests/Mapping/ProperyMappingTest.php
@@ -75,4 +75,24 @@ class PropertyMappingTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($date, $object->getFile());
         $this->assertSame('joe.png', $object->getFileName());
     }
+
+    public function testDirectoryNamerIsCalled()
+    {
+        $prop = new PropertyMapping('file', 'fileName');
+        $prop->setMapping(array(
+            'upload_destination' => '/tmp',
+        ));
+
+        $namer = $this->getMock('Vich\UploaderBundle\Naming\DirectoryNamerInterface');
+        $namer
+            ->expects($this->once())
+            ->method('directoryName')
+            ->with(null, $prop)
+            ->will($this->returnValue('/other-dir'));
+
+        $prop->setDirectoryNamer($namer);
+
+        $this->assertEquals('/other-dir', $prop->getUploadDir());
+        $this->assertEquals('/tmp', $prop->getUploadDestination());
+    }
 }

--- a/Tests/Naming/OrignameNamerTest.php
+++ b/Tests/Naming/OrignameNamerTest.php
@@ -3,7 +3,6 @@
 namespace Vich\UploaderBundle\Tests\Naming;
 
 use Vich\UploaderBundle\Naming\OrignameNamer;
-use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
  * OrignameNamerTest.
@@ -28,17 +27,23 @@ class OrignameNamerTest extends \PHPUnit_Framework_TestCase
         $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')
             ->disableOriginalConstructor()
             ->getMock();
-
         $file
             ->expects($this->any())
             ->method('getClientOriginalName')
             ->will($this->returnValue($name));
 
-        $entity = new DummyEntity;
-        $entity->setFile($file);
+        $entity = new \DateTime();
+
+        $mapping = $this->getMockBuilder('Vich\UploaderBundle\Mapping\PropertyMapping')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mapping->expects($this->once())
+            ->method('getFile')
+            ->with($entity)
+            ->will($this->returnValue($file));
 
         $namer = new OrignameNamer();
 
-        $this->assertRegExp($pattern, $namer->name($entity, 'file'));
+        $this->assertRegExp($pattern, $namer->name($entity, $mapping));
     }
 }

--- a/Tests/Naming/UniqidNamerTest.php
+++ b/Tests/Naming/UniqidNamerTest.php
@@ -3,7 +3,6 @@
 namespace Vich\UploaderBundle\Tests\Naming;
 
 use Vich\UploaderBundle\Naming\UniqidNamer;
-use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
  * UniqidNamerTest.
@@ -31,22 +30,27 @@ class UniqidNamerTest extends \PHPUnit_Framework_TestCase
         $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')
             ->disableOriginalConstructor()
             ->getMock();
-
         $file
             ->expects($this->any())
             ->method('getClientOriginalName')
             ->will($this->returnValue($originalName));
-
         $file
             ->expects($this->any())
             ->method('guessExtension')
             ->will($this->returnValue($guessedExtension));
 
-        $entity = new DummyEntity;
-        $entity->setFile($file);
+        $entity = new \DateTime();
+
+        $mapping = $this->getMockBuilder('Vich\UploaderBundle\Mapping\PropertyMapping')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mapping->expects($this->once())
+            ->method('getFile')
+            ->with($entity)
+            ->will($this->returnValue($file));
 
         $namer = new UniqidNamer();
 
-        $this->assertRegExp($pattern, $namer->name($entity, 'file'));
+        $this->assertRegExp($pattern, $namer->name($entity, $mapping));
     }
 }

--- a/Tests/Storage/FileSystemStorageTest.php
+++ b/Tests/Storage/FileSystemStorageTest.php
@@ -338,7 +338,7 @@ class FileSystemStorageTest extends \PHPUnit_Framework_TestCase
         $namer
             ->expects($this->once())
             ->method('name')
-            ->with($this->object, 'file')
+            ->with($this->object, $this->mapping)
             ->will($this->returnValue($filename));
 
         $this->mapping
@@ -365,7 +365,7 @@ class FileSystemStorageTest extends \PHPUnit_Framework_TestCase
         $this->mapping
             ->expects($this->once())
             ->method('getUploadDir')
-            ->with($this->object, 'file')
+            ->with($this->object)
             ->will($this->returnValue($dir));
 
         $file

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,8 @@ Upgrading from v0.9.0 to master
 - `inject_on_load` config param defaults to false. Set it to
 true if you want to keep your old behavior.
 
+- the `NamerInterface` and `DirectoryNamerInterface` were modified.
+
 Upgrading from v0.5.0 to 0.6.0
 ===============================
 


### PR DESCRIPTION
Namers used to heavily rely on reflection to access object properties. PropertyMapping objects are here to avoid that, we should use them.

**Note:** as the `DirectoryNamerInterface` and the `NamerInterface` were changed, this PR causes a BC break for all the user defining their own namers.
