### PR TITLE
set signature of directoryName method in DirectoryNamerInterface

### DIFF
--- a/Naming/DirectoryNamerInterface.php
+++ b/Naming/DirectoryNamerInterface.php
@@ -14,12 +14,11 @@ interface DirectoryNamerInterface
     /**
      * Creates a directory name for the file being uploaded.
      *
-     * @param object          $object  The object the upload is attached to.
-     * @param Propertymapping $mapping The mapping to use to manipulate the given object.
-     *
-     * @note The $object parameter can be null.
+     * @param object $obj       The object the upload is attached to.
+     * @param string $field     The name of the uploadable field to generate a name for.
+     * @param string $uploadDir The upload directory set in config
      *
      * @return string The directory name.
      */
-    public function directoryName($object, PropertyMapping $mapping);
+    public function directoryName($obj, $field, $uploadDir);
 }


### PR DESCRIPTION
I believe the method signature in the DirectoryNamerInterface was incorrect as our existing code would no longer work with the new version and the method did not match what was in the documentation. By reverting the method signature to how it was, our code works and the method seems to match the documentation.

Thanks.
