### PR TITLE
fixed mimetype

### DIFF
--- a/Storage/FlysystemStorage.php
+++ b/Storage/FlysystemStorage.php
@@ -41,7 +41,7 @@ class FlysystemStorage extends AbstractStorage
 
         $stream = fopen($file->getRealPath(), 'r+');
         $fs->writeStream($dir . $name, $stream, array(
-            'content-type' => $file->getMimeType()
+            'mimetype' => $file->getMimeType()
         ));
     }
 


### PR DESCRIPTION
Hi,

Looks like the correct option is `mimetype` instead of `content-type`, at least on the AwsS3 adapter, but I'm not sure if it's used anywhere else.

Thanks for your work :)
