### PR TITLE
[WIP] Add PHPCR support via db_driver option, adapter and subscriber.

### DIFF
--- a/Adapter/PHPCR/PHPCRAdapter.php
+++ b/Adapter/PHPCR/PHPCRAdapter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Vich\UploaderBundle\Adapter\PHPCR;
+
+use Vich\UploaderBundle\Adapter\AdapterInterface;
+use Vich\UploaderBundle\Adapter\Doctrine\DoctrineAdapter;
+
+/**
+ * PHPCRAdapter.
+ *
+ * @author Ben Glassman <bglassman@gmail.com>
+ */
+class PHPCRAdapter extends DoctrineAdapter implements AdapterInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getObjectFromArgs($event)
+    {
+        return $event->getEntity();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function recomputeChangeSet($event)
+    {
+        $object = $this->getObjectFromArgs($event);
+
+        $dm = $event->getObjectManager();
+        $uow = $dm->getUnitOfWork();
+        $uow->computeSingleDocumentChangeSet($object);
+    }
+
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration implements ConfigurationInterface
 
     protected function addGeneralSection(ArrayNodeDefinition $node)
     {
-        $supportedDbDrivers = array('orm', 'mongodb', 'propel');
+        $supportedDbDrivers = array('orm', 'mongodb', 'propel', 'phpcr');
 
         $node
             ->children()

--- a/DependencyInjection/VichUploaderExtension.php
+++ b/DependencyInjection/VichUploaderExtension.php
@@ -20,7 +20,8 @@ class VichUploaderExtension extends Extension
      */
     protected $tagMap = array(
         'orm'       => 'doctrine.event_subscriber',
-        'mongodb'   => 'doctrine_mongodb.odm.event_subscriber'
+        'mongodb'   => 'doctrine_mongodb.odm.event_subscriber',
+        'phpcr'     => 'doctrine_phpcr.event_subscriber'
     );
 
     /**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ VichUploaderBundle
 [![Build Status](https://secure.travis-ci.org/dustin10/VichUploaderBundle.png?branch=master)](http://travis-ci.org/dustin10/VichUploaderBundle)	[![Total Downloads](https://poser.pugx.org/vich/uploader-bundle/downloads.png)](https://packagist.org/packages/vich/uploader-bundle) [![Latest Unstable Version](https://poser.pugx.org/vich/uploader-bundle/v/unstable.png)](https://packagist.org/packages/vich/uploader-bundle)
 
 The VichUploaderBundle is a Symfony2 bundle that attempts to ease file
-uploads that are attached to ORM entities, ODM documents or Propel models.
+uploads that are attached to ORM entities, ODM documents, PHPCR documents or Propel models.
 
 - Automatically name and save a file to a configured directory
 - Inject the file back into the entity or document when it is loaded from the datastore as an

--- a/Resources/config/adapter.xml
+++ b/Resources/config/adapter.xml
@@ -9,6 +9,7 @@
         <service id="vich_uploader.adapter.propel"  class="Vich\UploaderBundle\Adapter\Propel\PropelORMAdapter" public="false" />
         <service id="vich_uploader.adapter.mongodb" class="Vich\UploaderBundle\Adapter\ODM\MongoDB\MongoDBAdapter" public="false" />
         <service id="vich_uploader.adapter.orm"     class="Vich\UploaderBundle\Adapter\ORM\DoctrineORMAdapter" public="false" />
+        <service id="vich_uploader.adapter.phpcr"   class="Vich\UploaderBundle\Adapter\PHPCR\PHPCRAdapter" public="false" />
 
     </services>
 

--- a/Resources/config/listener.xml
+++ b/Resources/config/listener.xml
@@ -24,7 +24,10 @@
         </service>
 
         <service id="vich_uploader.listener.uploader.orm" parent="vich_uploader.listener.uploader.doctrine.base" class="Vich\UploaderBundle\EventListener\DoctrineUploaderListener" />
+
         <service id="vich_uploader.listener.uploader.mongodb" parent="vich_uploader.listener.uploader.orm" />
+
+        <service id="vich_uploader.listener.uploader.phpcr" parent="vich_uploader.listener.uploader.doctrine.base" class="Vich\UploaderBundle\EventListener\DoctrineUploaderListener" />
 
     </services>
 

--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -8,7 +8,7 @@ Below is the full default configuration for the bundle:
 ``` yaml
 # app/config/config.yml
 vich_uploader:
-    db_driver:  orm # or mongodb or propel
+    db_driver:  orm # or mongodb or propel or phpcr
     twig:       true
     gaufrette:  false # set to true to enable gaufrette support
     flysystem:  false # set to true to enable flysystem support

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -94,8 +94,8 @@ public function registerBundles()
 
 ## Doctrine
 
-Just make sure that `doctrine/orm` or `doctrine/mongodb-odm` are installed and
-properly registered in your application.
+Just make sure that `doctrine/orm` or `doctrine/mongodb-odm` or `doctrine/phpcr-odm` 
+are installed and properly registered in your application.
 
 
 ## Propel

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -35,13 +35,13 @@ go to [Configuration](#configuration) section
 
 ## Configuration
 
-First configure the `db_driver` option. You must specify either `orm` or
-`mongodb`.
+First configure the `db_driver` option. You must specify either `orm`,
+`mongodb` or `phpcr`.
 
 ``` yaml
 # app/config/config.yml
 vich_uploader:
-    db_driver: orm # or mongodb or propel
+    db_driver: orm # or mongodb or propel or phpcr
 ```
 
 And then add your mappings information. In order to map

--- a/Tests/Adapter/PHPCR/PHPCRAdapterTest.php
+++ b/Tests/Adapter/PHPCR/PHPCRAdapterTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Adapter\PHPCR;
+
+use Vich\UploaderBundle\Tests\DummyEntity;
+use Vich\UploaderBundle\Tests\DummyEntityProxyPHPCR;
+use Vich\UploaderBundle\Adapter\PHPCR\PHPCRAdapter;
+
+/**
+ * PHPCRAdapterTest.
+ *
+ * @author Ben Glassman <bglassman@gmail.com>
+ */
+class PHPCRAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists('Doctrine\Common\Persistence\Event\LifecycleEventArgs')) {
+            self::markTestSkipped('Doctrine\Common\Persistence\Event\LifecycleEventArgs does not exist.');
+        }
+    }
+
+    /**
+     * Test the getObjectFromArgs method.
+     */
+    public function testGetObjectFromArgs()
+    {
+        $entity = $this->getMock('Vich\UploaderBundle\Tests\DummyEntity');
+
+        $args = $this->getMockBuilder('Doctrine\Common\Persistence\Event\LifecycleEventArgs')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $args
+            ->expects($this->once())
+            ->method('getEntity')
+            ->will($this->returnValue($entity));
+
+        $adapter = new PHPCRAdapter();
+
+        $this->assertEquals($entity, $adapter->getObjectFromArgs($args));
+    }
+
+    /**
+     * @dataProvider entityProvider
+     */
+    public function testGetClassName($entity, $expectedClassName)
+    {
+        $adapter = new PHPCRAdapter();
+
+        $this->assertEquals($expectedClassName, $adapter->getClassName($entity));
+    }
+
+    public function entityProvider()
+    {
+        $classicEntity = new DummyEntity();
+        $proxiedEntity = new DummyEntityProxyPHPCR();
+
+        return array(
+            array($classicEntity, 'Vich\UploaderBundle\Tests\DummyEntity'),
+            array($proxiedEntity, 'Vich\UploaderBundle\Tests\DummyEntity'),
+        );
+    }
+}
+

--- a/Tests/DummyEntityProxyPHPCR.php
+++ b/Tests/DummyEntityProxyPHPCR.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests;
+
+use Doctrine\Common\Persistence\Proxy;
+
+/**
+ * DummyEntityProxyPHPCR.
+ *
+ * @author Ben Glassman <bglassman@gmail.com>
+ */
+class DummyEntityProxyPHPCR extends DummyEntity implements Proxy
+{
+    public function __load() { }
+
+    public function __isInitialized() { }
+}
+

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "suggest": {
         "doctrine/orm": "*",
         "doctrine/doctrine-bundle": "*",
+        "doctrine/phpcr-odm": "~1.0",
         "doctrine/mongodb-odm-bundle": "*",
         "knplabs/knp-gaufrette-bundle": "*",
         "willdurand/propel-eventdispatcher-bundle": ">=1.2",


### PR DESCRIPTION
The basics. This works in terms of add the Vich Uploader annotation to a PHPCR document and having the adapter correctly persist the mapped name to the database and move the file to the right location.

TODO
- [x] Tests
- [x] Update docs
- [x] Add doctrine phpcr odm to suggest in composer.json
- [x] Ensure that the inject on load is working
- [x] Ensure that delete on update is working
- [x] Ensure delete on replace is working

I would really love for this bundle to support multiple db drivers because we have PHPCR documents which are part of the CMS (based on symfony cmf) while many of our other tools use doctrine orm so right now using only one db driver makes it so this bundle is only a partial solution. Honestly i dont really see why it would be problematic to enable multiple drivers, seems like it might just be a config change. If you see any other issues I might not be thinking of let me know. I can try to work up a PR for this feature as well after this adapter is complete.
