### PR TITLE
Fixes [Doctrine\Common\Annotations\AnnotationException]  @note.

### DIFF
--- a/Storage/AbstractStorage.php
+++ b/Storage/AbstractStorage.php
@@ -130,7 +130,7 @@ abstract class AbstractStorage implements StorageInterface
     }
 
     /**
-     * @note extension point.
+     *  note: extension point.
      */
     protected function getFilename($obj, $mappingName, $className = null)
     {


### PR DESCRIPTION
Fixes:

[Doctrine\Common\Annotations\AnnotationException]
  [Semantical Error] The annotation "@note" in method Vich\UploaderBundle\Storage\AbstractStorage::getFilename() was never imported. Did you maybe forget to add a "use" stat
  ement for this annotation?
