### PR TITLE
Fix file injector

### DIFF
--- a/Injector/FileInjector.php
+++ b/Injector/FileInjector.php
@@ -40,6 +40,8 @@ class FileInjector implements FileInjectorInterface
             return;
         }
 
-        $mapping->setFile($obj, new File($path, false));
+        if($path){
+            $mapping->setFile($obj, new File($path, false));
+        }
     }
 }

--- a/Tests/Injector/FileInjectorTest.php
+++ b/Tests/Injector/FileInjectorTest.php
@@ -83,7 +83,7 @@ class FileInjectorTest extends \PHPUnit_Framework_TestCase
         $this->storage
             ->expects($this->once())
             ->method('resolvePath')
-            ->will($this->throwException(new \InvalidArgumentException));
+            ->will($this->returnValue(null));
 
         $inject = new FileInjector($this->storage);
         $inject->injectFile($obj, $fileMapping);


### PR DESCRIPTION
I've spotted some issue with file injector. 

First of all the test was wrong, the mock defined a method which does not exists in the concrete class (if I'm not wrong) and more important, the behaviour seems not correct to me. 

If $path is null the file should not be injected, as I wrote in 9479e0e 
I'm also not getting why we're catching for InvalidArgumentException. The try...catch has been introduced by 61ae3376 but it make no sense to me. Why the injector should catch an InvalidArgumentException and silently fail to inject to file into the object? 

If we want to use an exception to control that flow, it can't  be InvalidArgumentException, it has to be something more meaningful, and it has to be documented in \Vich\UploaderBundle\Storage\StorageInterface

As for me a null $path make perfect sense for a non existing file and I think we could simply:
- Do no inject the file if path is null
- Remove the try...catch block.

I kept it because I'm not sure if some other StorageInterface implementations actually throws it when the file is not present (if so we should fix them).

I'd like some :+1: before merging this, what do you think @K-Phoen ?
