### PR TITLE
Improved documentation

### DIFF
--- a/Resources/doc/known_issues.md
+++ b/Resources/doc/known_issues.md
@@ -35,6 +35,13 @@ class Product
 ```
 See issue [GH-123](https://github.com/dustin10/VichUploaderBundle/issues/123)
 
+## Catchable Fatal Error
+
+When you get the following error:`Catchable Fatal Error: ... must be an instance of Symfony\Component\HttpFoundation\File\UploadedFile, string given, ...` 
+you have to define   
+`{{ form_enctype(upload_form) }}` in your form. 
+
+This is needed for Symfony versions older than 2.3.
 
 ## Annotations don't work with Propel
 


### PR DESCRIPTION
In older Symfony versions you have to define {{ form_enctype(upload_form) }}
