### PR TITLE
Override the default text 'File' in the label

### DIFF
--- a/Form/Type/VichFileType.php
+++ b/Form/Type/VichFileType.php
@@ -44,6 +44,7 @@ class VichFileType extends AbstractType
     {
         $builder->add('file', 'file', array(
             'required' => $options['required'],
+            'label' => $options['label'],
         ));
 
         $builder->addModelTransformer(new FileTransformer());


### PR DESCRIPTION
On the all form rendered, the label are the same text 'File', get the parent attribute
