### PR TITLE
FIX Directory Separator management on Gaufrette

### DIFF
--- a/Mapping/PropertyMapping.php
+++ b/Mapping/PropertyMapping.php
@@ -237,7 +237,7 @@ class PropertyMapping
 
         // append the trailing directory separator if needed
         if (!empty($dir)) {
-            $dir .= substr($dir, -1) !== DIRECTORY_SEPARATOR ? DIRECTORY_SEPARATOR : '';
+            $dir .= substr($dir, -1) !== '/' ? '/' : '';
         }
 
         return $dir;

--- a/Storage/AbstractStorage.php
+++ b/Storage/AbstractStorage.php
@@ -131,7 +131,7 @@ abstract class AbstractStorage implements StorageInterface
             return null;
         }
 
-        return $mapping->getUriPrefix() . '/' . $mapping->getUploadDir($obj) . $filename;
+        return $mapping->getUriPrefix() . '/' . str_replace('\\', '/', $mapping->getUploadDir($obj)) . $filename;
     }
 
     /**

--- a/Storage/GaufretteStorage.php
+++ b/Storage/GaufretteStorage.php
@@ -93,7 +93,7 @@ class GaufretteStorage extends AbstractStorage
     {
         $fsIdentifier = $mapping->getUploadDestination();
 
-        return $this->protocol.'://' . $fsIdentifier . DIRECTORY_SEPARATOR . $dir . $name;
+        return $this->protocol.'://' . $fsIdentifier . '/' . $dir . $name;
     }
 
     /**


### PR DESCRIPTION
When using Gaufrette (or actually any other File System manager) we could not handle Directory Separator with the constant Directory Separator because target directory separator could be different from system directory separator.

Example: application running on windows storing data on Azure or Amazon
- Windows : DIRECTORY_SEPARATOR = \
- Amazon : DIRECTORY_SEPARATOR = /
- Azure : DIRECTORY_SEPARATOR = /

Directory separator should be manage by Gaufrette Adapter.
- FIX on `resolveUri` method (which, before that commit, didn't convert `\` by `/`
