### PR TITLE
Fix setting metadata content type in gaufrette storage

### DIFF
--- a/Storage/GaufretteStorage.php
+++ b/Storage/GaufretteStorage.php
@@ -54,7 +54,7 @@ class GaufretteStorage extends AbstractStorage
         $filesystem = $this->getFilesystem($mapping);
 
         if ($filesystem->getAdapter() instanceof MetadataSupporter) {
-            $filesystem->getAdapter()->setMetadata($name, array('contentType' => $file->getMimeType()));
+            $filesystem->getAdapter()->setMetadata($dir . $name, array('contentType' => $file->getMimeType()));
         }
 
         $src = new LocalStream($file->getPathname());


### PR DESCRIPTION
When I use a custom directory namer with Gaufrette AwS3 adapter, the metadata content-type key  was set with the filename only.
In order to work, the metadata key must contain the directory.
