### PR TITLE
Fix Gaufrette storage : metadata key with path + force overwrite

### DIFF
--- a/Storage/GaufretteStorage.php
+++ b/Storage/GaufretteStorage.php
@@ -51,10 +51,10 @@ class GaufretteStorage extends AbstractStorage
         $path = !empty($dir) ? $dir . '/' .$name : $name;
 
         if ($filesystem->getAdapter() instanceof MetadataSupporter) {
-            $filesystem->getAdapter()->setMetadata($dir . $name, array('contentType' => $file->getMimeType()));
+            $filesystem->getAdapter()->setMetadata($path, array('contentType' => $file->getMimeType()));
         }
 
-        $filesystem->write($path, file_get_contents($file->getPathname()));
+        $filesystem->write($path, file_get_contents($file->getPathname()), true);
     }
 
     /**


### PR DESCRIPTION
I've change the key argument in setMetadata to reflect your refactorization in order to get the same behaviour as #338 

And I've added the third argument as true in filesystem->write() to tell to overwrite if a file with a same name is already present.
Don't know if you want this to be a configuration choice, it seems to me that it should always overwrite as a classic upload operation.
