### PR TITLE
Allow generate directory name basing on the generated file name

### DIFF
--- a/Storage/AbstractStorage.php
+++ b/Storage/AbstractStorage.php
@@ -51,9 +51,6 @@ abstract class AbstractStorage implements StorageInterface
             throw new \LogicException('No uploadable file found');
         }
 
-        // determine the file's directory
-        $dir = $mapping->getUploadDir($obj);
-
         // determine the file's name
         if ($mapping->hasNamer()) {
             $name = $mapping->getNamer()->name($obj, $mapping);
@@ -62,6 +59,9 @@ abstract class AbstractStorage implements StorageInterface
         }
 
         $mapping->setFileName($obj, $name);
+        
+        // determine the file's directory
+        $dir = $mapping->getUploadDir($obj);
 
         $this->doUpload($mapping, $file, $dir, $name);
     }


### PR DESCRIPTION
For example, the filename generated by the $mapping->getNamer() service used uniqid() and it is "49f3c69b3b96fdcad5542875679a7806.jpg" 
I want to use a directory_namer, which will propose directory structure for this file like "49/f3". In this case, the directory namer should be called later, after filename was generated by the namer
