### PR TITLE
Fix error with annotation using Doctrine ORM

### DIFF
--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -98,10 +98,10 @@ class Product
     // ..... other fields
 
     /**
+     * NOTE: This is not a mapped field of entity metadata, just a simple property.
+     * 
      * @Vich\UploadableField(mapping="product_image", fileNameProperty="imageName")
-     *
-     * @note This is not a mapped field of entity metadata, just a simple property.
-     *
+     * 
      * @var File $imageFile
      */
     protected $imageFile;


### PR DESCRIPTION
The `@note` annotation thrown exception `Doctrine\Common\Annotations\AnnotationException`:

```
[Semantical Error] The annotation "@note" in property Acme\DemoBundle\Entity\Image::$imageFile was never imported. Did you maybe forget to add a "use" statement for this annotation?
```