### PR TITLE
override getParent for vich form type classes to return file instead of form

### DIFF
--- a/Form/Type/VichFileType.php
+++ b/Form/Type/VichFileType.php
@@ -108,4 +108,12 @@ class VichFileType extends AbstractType
     {
         return 'vich_file';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'file';
+    }
 }

--- a/Form/Type/VichImageType.php
+++ b/Form/Type/VichImageType.php
@@ -27,4 +27,12 @@ class VichImageType extends VichFileType
     {
         return 'vich_image';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'file';
+    }
 }


### PR DESCRIPTION
We ran into a rather nasty bug that, as best as I can tell, seems to be caused by these forms not returning 'file' as their parent. Setup to reproduce:
OwningEntity has eg one-to-one cascade-persist relationship with ImageEntity
ImageEntity has ``@Vich\Uploadable and @Vich\UploadableField`` on it

ImageFormType has data_class of ImageEntity and service id of image_form_type (with a vich_image form type on the File field)
OwningFormType has the image_form_type as a subform on its relationship field

Submitting the owning form will only upload the file if parent of VichImage/FileType is set to file, as opposed to form.