### PR TITLE
Removed test target for symfony 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ sudo: false
 
 env:
     - SYMFONY_VERSION="~2.3.0" DOCTRINE_VERSION=">=2.2.3,<2.5-dev"
-    - SYMFONY_VERSION="~2.4.0" DOCTRINE_VERSION=">=2.2.3,<2.5-dev"
     - SYMFONY_VERSION="~2.5.0" DOCTRINE_VERSION=">=2.2.3,<2.5-dev"
     - SYMFONY_VERSION="~2.6.0" DOCTRINE_VERSION=">=2.2.3,<2.5-dev"
     - SYMFONY_VERSION="2.7.x-dev" DOCTRINE_VERSION=">=2.2.3,<2.5-dev"


### PR DESCRIPTION
The symfony 2.4 version which is no longer supported.

[Symfony Version Checker](http://symfony.com/roadmap?version=2.4#checker)

PS- BTW, version 2.5 support ends by July 2015 (next month).