### PR TITLE
Remove duplicated label for vich_file FormType

### DIFF
--- a/Form/Type/VichFileType.php
+++ b/Form/Type/VichFileType.php
@@ -43,7 +43,7 @@ class VichFileType extends AbstractType
     {
         $builder->add('file', 'file', array(
             'required' => $options['required'],
-            'label'    => $options['label'],
+            'label'    => false,
             'attr'     => $options['attr'],
         ));
 


### PR DESCRIPTION
When adding 'vich_file' in form builder it creates double label for file (child form in parent form). To avoid this add 'label' => false to child form.