### PR TITLE
Created helpful bash script for running tests locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Tests/autoload.php
 nbproject
 catalog.xml
 .idea
+composer.phar
 composer.lock
 vendor/*
 !vendor/vendors.php

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ PHPUnit should be installed by composer. Run the tests with the
 Alternatively you can use the `runTests.sh` bash script present at the project root.
 Default usage example:
 
-```~$ ./runTest.sh``` (This runs all tests with your current PHP version against all the support Symfony versions.)
+```~$ ./runTest.sh``` (This runs all tests with your current PHP version against all supported Symfony versions.)
 
 You can also set a specific Symfony version to test against and/or pass the arguments for PHPUnit
  as arguments to the script. Usage example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,19 @@ Thank you!
 ## Running the test suite
 
 Ensure that the required vendors are installed by running `composer install`.
-The test suite requires the `php5-mongo` extension to be installed.
+The test suite requires the `php5-mongo` and `php5-sqlite` extensions to be installed.
 
 PHPUnit should be installed by composer. Run the tests with the
 `./vendor/bin/phpunit` command.
+
+Alternatively you can use the `runTests.sh` bash script present at the project root.
+Default usage example:
+
+```~$ ./runTest.sh``` (This runs all tests with your current PHP version against all the support Symfony versions.)
+
+You can also set a specific Symfony version to test against and/or pass the arguments for PHPUnit
+ as arguments to the script. Usage example:
+
+```~$ SYMFONY_VERSION=2.7.1 ./runTests.sh --filter testCustomFileNameProperty```
+
+**Note:** The script was prepared to run under Ubuntu and using Bash so it might need further validation for other OS.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "ocramius/proxy-manager": "~0.5"
     },
     "require-dev": {
-        "ext-mongo" : "*",
         "ext-sqlite3" : "*",
 
         "doctrine/mongodb-odm": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "ocramius/proxy-manager": "~0.5"
     },
     "require-dev": {
+        "ext-mongo" : "*",
+        "ext-sqlite3" : "*",
+
         "doctrine/mongodb-odm": "@dev",
         "knplabs/knp-gaufrette-bundle": "*",
         "oneup/flysystem-bundle": "dev-master",

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+
+#export SYMFONY_VERSION="~2.7.0"
+SUPPORTED_SYMFONY_VERSIONS=('~2.3.0' '~2.5.0' '~2.6.0' '~2.7.0' '2.8.x-dev')
+export DOCTRINE_VERSION=">=2.2.3,<2.5-dev"
+
+sudo apt-get -qq update
+sudo apt-get install -y php5 php5-mongo php5-sqlite
+php --version
+
+# Install/upgrade composer.phar
+curl -sS https://getcomposer.org/installer | php
+php composer.phar --version
+
+# Save a copy of the current composer.json file so we can restore it later
+cp composer.json composer.json.bck
+
+# Clear temp folder before the tests run
+sudo rm -rf /tmp/VichUploaderBundle/
+
+# If SYMFONY_VERSION is set run the tests only for that version
+if [ "${SYMFONY_VERSION}" != "" ]; then
+  SUPPORTED_SYMFONY_VERSIONS=(${SYMFONY_VERSION})
+fi
+
+# Run the tests for each supported symfony version
+for sf_version in ${SUPPORTED_SYMFONY_VERSIONS[@]}; do
+  php composer.phar require --no-update "symfony/symfony":"${sf_version}"
+  php composer.phar require --no-update "doctrine/orm":"${DOCTRINE_VERSION}"
+
+  php composer.phar update symfony/symfony
+  php composer.phar install --prefer-source
+
+  vendor/bin/phpunit $@
+done
+
+# Restore the composer.json file
+rm composer.json && mv composer.json.bck composer.json

--- a/runTests.sh
+++ b/runTests.sh
@@ -2,7 +2,7 @@
 #
 
 SUPPORTED_SYMFONY_VERSIONS=('~2.3.0' '~2.5.0' '~2.6.0' '~2.7.0' '2.8.x-dev')
-export DOCTRINE_VERSION=">=2.2.3,<2.5-dev"
+DOCTRINE_VERSION=">=2.2.3,<2.5-dev"
 
 restore_composer (){
   # Restore the composer.json file
@@ -26,12 +26,14 @@ fi
 
 # Run the tests for each supported symfony version
 for sf_version in ${SUPPORTED_SYMFONY_VERSIONS[@]}; do
+  echo -e "\n\nSetting requirements version constraints: Symfony (${sf_version}) and Doctrine (${DOCTRINE_VERSION})"
   php composer.phar require --no-update "symfony/symfony":"${sf_version}"
   php composer.phar require --no-update "doctrine/orm":"${DOCTRINE_VERSION}"
 
-  php composer.phar update symfony/symfony || { restore_composer && exit 1; }
-  php composer.phar install --prefer-source || { restore_composer && exit 1; }
+  echo -e "\nInstalling dependencies"
+  php composer.phar update --prefer-source || { restore_composer && exit 1; }
 
+  echo -e "\nLaunching tests"
   vendor/bin/phpunit $@
 done
 

--- a/runTests.sh
+++ b/runTests.sh
@@ -17,7 +17,7 @@ php composer.phar --version
 cp composer.json composer.json.bck
 
 # Clear temp folder before the tests run
-sudo rm -rf /tmp/VichUploaderBundle/
+rm -rf /tmp/VichUploaderBundle/
 
 # If SYMFONY_VERSION is set run the tests only for that version
 if [ "${SYMFONY_VERSION}" != "" ]; then

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 #
 
-#export SYMFONY_VERSION="~2.7.0"
 SUPPORTED_SYMFONY_VERSIONS=('~2.3.0' '~2.5.0' '~2.6.0' '~2.7.0' '2.8.x-dev')
 export DOCTRINE_VERSION=">=2.2.3,<2.5-dev"
 
-sudo apt-get -qq update
-sudo apt-get install -y php5 php5-mongo php5-sqlite
-php --version
+restore_composer (){
+  # Restore the composer.json file
+  rm composer.json && mv composer.json.bck composer.json
+}
 
 # Install/upgrade composer.phar
 curl -sS https://getcomposer.org/installer | php
@@ -29,11 +29,10 @@ for sf_version in ${SUPPORTED_SYMFONY_VERSIONS[@]}; do
   php composer.phar require --no-update "symfony/symfony":"${sf_version}"
   php composer.phar require --no-update "doctrine/orm":"${DOCTRINE_VERSION}"
 
-  php composer.phar update symfony/symfony
-  php composer.phar install --prefer-source
+  php composer.phar update symfony/symfony || { restore_composer && exit 1; }
+  php composer.phar install --prefer-source || { restore_composer && exit 1; }
 
   vendor/bin/phpunit $@
 done
 
-# Restore the composer.json file
-rm composer.json && mv composer.json.bck composer.json
+restore_composer


### PR DESCRIPTION
I've created this small bash script when I was developing the unit test for #405 to help me run the tests against all the Symfony versions supported by the bundle.

I've made a few adjustments today and decided to add it to my fork.
I'm creating this PR in case you're interested in adding it to the bundle.

It supports passing a single SF2 version and/or the arguments for phpunit. Example:
```
~$ SYMFONY_VERSION=2.7.1 ./runTests.sh --filter testCustomFileNameProperty
```

PS- I've only tested this in Ubuntu 14.04 with the packaged PHP version (5.5.9).