### PR TITLE
Remove name parameter from field mapping

### DIFF
--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -107,7 +107,7 @@ class Product
     protected $imageFile;
 
     /**
-     * @ORM\Column(type="string", length=255, name="image_name")
+     * @ORM\Column(type="string", length=255)
      *
      * @var string $imageName
      */


### PR DESCRIPTION
The `name` could override `doctrine.orm.naming_strategy`.
Other developers could use different naming strategy so would be better to avoid it in example in favor to easy copy/paste.