### PR TITLE
Remove element names in @var annotation and use namespace

### DIFF
--- a/Resources/doc/known_issues.md
+++ b/Resources/doc/known_issues.md
@@ -20,7 +20,7 @@ class Product
     /**
      * @ORM\Column(type="datetime")
      *
-     * @var \DateTime $updatedAt
+     * @var \DateTime
      */
     protected $updatedAt;
 
@@ -83,6 +83,13 @@ Consider the following class:
 
 ``` php
 <?php
+
+namespace Acme\DemoBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\HttpFoundation\File\File;
+use Vich\UploaderBundle\Mapping\Annotation as Vich;
+
 /**
  * @ORM\Entity
  * @Vich\Uploadable
@@ -92,7 +99,7 @@ class Product
     /**
      * @Vich\UploadableField(mapping="product_image", fileNameProperty="imageName")
      *
-     * @var \Symfony\Component\HttpFoundation\File\File $image
+     * @var File
      */
     protected $image;
 
@@ -103,7 +110,7 @@ class Product
      * must be able to accept an instance of 'File' as the bundle will inject one here
      * during Doctrine hydration.
      *
-     * @param \Symfony\Component\HttpFoundation\File\File $image
+     * @param File $image
      */
     public function setImage(File $image = null)
     {

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -102,21 +102,21 @@ class Product
      * 
      * @Vich\UploadableField(mapping="product_image", fileNameProperty="imageName")
      * 
-     * @var File $imageFile
+     * @var File
      */
     protected $imageFile;
 
     /**
      * @ORM\Column(type="string", length=255, name="image_name")
      *
-     * @var string $imageName
+     * @var string
      */
     protected $imageName;
 
     /**
      * @ORM\Column(type="datetime")
      *
-     * @var \DateTime $updatedAt
+     * @var \DateTime
      */
     protected $updatedAt;
 


### PR DESCRIPTION
I think for simlicity we could avoid element names. The element name in `@var` is optional and not required. If anybody copy/paste this code from examples he most probably change the names so he should change it in few places (in code and annotation).