### PR TITLE
Make properties as private in docs examples

### DIFF
--- a/Resources/doc/known_issues.md
+++ b/Resources/doc/known_issues.md
@@ -22,7 +22,7 @@ class Product
      *
      * @var \DateTime
      */
-    protected $updatedAt;
+    private $updatedAt;
 
     // ...
 
@@ -101,7 +101,7 @@ class Product
      *
      * @var File
      */
-    protected $image;
+    private $image;
 
     /**
      * If manually uploading a file (i.e. not using Symfony Form) ensure an instance

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -93,7 +93,7 @@ class Product
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
      */
-    protected $id;
+    private $id;
 
     // ..... other fields
 
@@ -104,21 +104,21 @@ class Product
      * 
      * @var File
      */
-    protected $imageFile;
+    private $imageFile;
 
     /**
      * @ORM\Column(type="string", length=255)
      *
      * @var string
      */
-    protected $imageName;
+    private $imageName;
 
     /**
      * @ORM\Column(type="datetime")
      *
      * @var \DateTime
      */
-    protected $updatedAt;
+    private $updatedAt;
 
     /**
      * If manually uploading a file (i.e. not using Symfony Form) ensure an instance


### PR DESCRIPTION
I think better to make properties `private` and use other modifiers only if you need.
Another one improvement for convenient copy/paste.