### PR TITLE
UniqidNamer: Change visibility to protected

### DIFF
--- a/Naming/Polyfill/FileExtensionTrait.php
+++ b/Naming/Polyfill/FileExtensionTrait.php
@@ -13,7 +13,7 @@ trait FileExtensionTrait
      *
      * @return string|null
      */
-    private function getExtension(UploadedFile $file)
+    protected function getExtension(UploadedFile $file)
     {
         $originalName = $file->getClientOriginalName();
 


### PR DESCRIPTION
When using a custom file namer that extends UniqidNamer, getExtension() can only be overridden when visibility is not private. I think it's good practice to allow extending classes when publishing bundles for common use.