### PR TITLE
Compute change set after updating all fields

### DIFF
--- a/EventListener/Doctrine/UploadListener.php
+++ b/EventListener/Doctrine/UploadListener.php
@@ -55,7 +55,8 @@ class UploadListener extends BaseListener
 
         foreach ($this->getUploadableFields($object) as $field) {
             $this->handler->upload($object, $field);
-            $this->adapter->recomputeChangeSet($event);
         }
+
+	$this->adapter->recomputeChangeSet($event);
     }
 }


### PR DESCRIPTION
In an entity with multiple uploadable fields, is there a reason to compute the change set before all fields have been updated?