### PR TITLE
Improve Travis build speed by reducing amount of jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,36 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
+    - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
 
 sudo: false
 
-env:
-    - SYMFONY_VERSION="~2.3.0"
-    - SYMFONY_VERSION="~2.5.0"
-    - SYMFONY_VERSION="~2.6.0"
-    - SYMFONY_VERSION="~2.7.0"
-    - SYMFONY_VERSION="2.8.x-dev symfony/security-acl:2.8.x-dev"
+cache:
+    directories:
+      - $HOME/.composer/cache
 
-before_script:
+env:
+    - SYMFONY_VERSION="~2.7.0"
+
+matrix:
+    include:
+        - php: 5.6
+          env: SYMFONY_VERSION="~2.3.0"
+        - php: 5.6
+          env: SYMFONY_VERSION="~2.7.0"
+        - php: 5.6
+          env: SYMFONY_VERSION="~2.8.0@dev"
+        - php: 5.6
+          env: SYMFONY_VERSION="~3.0.0@dev"
+
+before_install:
     - composer self-update
     - phpenv config-rm xdebug.ini || true
     - composer require --no-update symfony/symfony:${SYMFONY_VERSION}
-    - composer install --prefer-source --ignore-platform-reqs
+    
+install: composer update --prefer-dist
 
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
 before_install:
     - composer self-update
     - phpenv config-rm xdebug.ini || true
+    - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - composer require --no-update symfony/symfony:${SYMFONY_VERSION}
     
 install: composer update --prefer-dist


### PR DESCRIPTION
This also tests the claim that this bundle supports Symfony 3.

You don't need to test every version of Symfony against every PHP version. This PR changes the logic so only 2.7 is tested against every PHP version and all other versions are tested against the latest stable PHP version (5.6). This means instead of `supported_php_versions * supported_symfony_versions`, you now have `supported_php_versions + supported_symfony_versions` jobs.