### PR TITLE
Fix DownloadHandler

### DIFF
--- a/Handler/DownloadHandler.php
+++ b/Handler/DownloadHandler.php
@@ -42,7 +42,7 @@ class DownloadHandler extends AbstractHandler
     private function createDownloadResponse($stream, $filename)
     {
         $response = new StreamedResponse(function () use ($stream) {
-            echo stream_copy_to_stream($stream, fopen('php://output', 'w'));
+            stream_copy_to_stream($stream, fopen('php://output', 'w'));
         });
 
         $disposition = $response->headers->makeDisposition(


### PR DESCRIPTION
The result of stream_copy_to_stream is the number of byte copied and shouldn't be echoed.