### PR TITLE
downloadhandler fix for non-ascii file name

### DIFF
--- a/Handler/DownloadHandler.php
+++ b/Handler/DownloadHandler.php
@@ -45,9 +45,17 @@ class DownloadHandler extends AbstractHandler
             stream_copy_to_stream($stream, fopen('php://output', 'w'));
         });
 
+        $filenameFallback = '';
+        if (function_exists('iconv')) {
+            $filenameFallback = iconv('UTF-8', 'ASCII//TRANSLIT', $filename);
+        } else if (function_exists('mb_convert_encoding')) {
+            $filenameFallback = mb_convert_encoding($filename, 'ASCII');
+        }
+
         $disposition = $response->headers->makeDisposition(
             ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-            $filename
+            $filename,
+            $filenameFallback
         );
         $response->headers->set('Content-Disposition', $disposition);
         $response->headers->set('Content-Type', 'application/octet-stream');

--- a/Tests/Handler/DownloadHandlerTest.php
+++ b/Tests/Handler/DownloadHandlerTest.php
@@ -50,6 +50,19 @@ class DownloadHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceof('\Symfony\Component\HttpFoundation\StreamedResponse', $response);
     }
 
+    public function testDownloadNonAsciiFileName()
+    {
+        $this->storage
+            ->expects($this->once())
+            ->method('resolveStream')
+            ->with($this->object, 'file_field')
+            ->will($this->returnValue('something not null'));
+
+        $response = $this->handler->downloadObject($this->object, 'file_field', null, 'ÉÁŰÚŐPÓÜÉŰÍÍÍÍ$$$$$$$++4334');
+
+        $this->assertInstanceof('\Symfony\Component\HttpFoundation\StreamedResponse', $response);
+    }
+
     /**
      * @expectedException Vich\UploaderBundle\Exception\MappingNotFoundException
      */
@@ -74,6 +87,7 @@ class DownloadHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->handler->downloadObject($this->object, 'file_field');
     }
+
 
     /**
      * Creates a mock property mapping factory


### PR DESCRIPTION
Response dispositions must have ASCII file names