### PR TITLE
remove test namespace from autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Vich\\UploaderBundle\\": "",
+            "Vich\\UploaderBundle\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Vich\\TestBundle\\": "Tests/Fixtures/App/src/TestBundle/"
         }
     }


### PR DESCRIPTION
It removes 3 files from autoloading, not much, but a good start to clean up the optimized autoloader maps.

A lot of test files remains in the loader path because the root directory is the autoloading psr-4 root directory too. It should be separated to another dir.