### PR TITLE
[Code style] Import all FQCNs when possible

### DIFF
--- a/Event/Event.php
+++ b/Event/Event.php
@@ -35,7 +35,7 @@ class Event extends BaseEvent
     /**
      * Accessor to the mapping used to manipulate the object.
      *
-     * @return \Vich\UploaderBundle\Mapping\PropertyMapping
+     * @return PropertyMapping
      */
     public function getMapping()
     {

--- a/Handler/AbstractHandler.php
+++ b/Handler/AbstractHandler.php
@@ -12,18 +12,18 @@ use Vich\UploaderBundle\Storage\StorageInterface;
 abstract class AbstractHandler
 {
     /**
-     * @var \Vich\UploaderBundle\Mapping\PropertyMappingFactory
+     * @var PropertyMappingFactory
      */
     protected $factory;
 
     /**
-     * @var \Vich\UploaderBundle\Storage\StorageInterface $storage
+     * @var StorageInterface $storage
      */
     protected $storage;
 
     /**
-     * @param \Vich\UploaderBundle\Mapping\PropertyMappingFactory $factory The mapping factory.
-     * @param \Vich\UploaderBundle\Storage\StorageInterface       $storage The storage.
+     * @param PropertyMappingFactory $factory The mapping factory.
+     * @param StorageInterface       $storage The storage.
      */
     public function __construct(PropertyMappingFactory $factory, StorageInterface $storage)
     {

--- a/Handler/UploadHandler.php
+++ b/Handler/UploadHandler.php
@@ -19,22 +19,22 @@ use Vich\UploaderBundle\Storage\StorageInterface;
 class UploadHandler extends AbstractHandler
 {
     /**
-     * @var \Vich\UploaderBundle\Injector\FileInjectorInterface $injector
+     * @var FileInjectorInterface $injector
      */
     protected $injector;
 
     /**
-     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
+     * @var EventDispatcherInterface $dispatcher
      */
     protected $dispatcher;
 
     /**
      * Constructs a new instance of UploaderListener.
      *
-     * @param \Vich\UploaderBundle\Mapping\PropertyMappingFactory         $factory    The mapping factory.
-     * @param \Vich\UploaderBundle\Storage\StorageInterface               $storage    The storage.
-     * @param \Vich\UploaderBundle\Injector\FileInjectorInterface         $injector   The injector.
-     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher The event dispatcher.
+     * @param PropertyMappingFactory   $factory    The mapping factory.
+     * @param StorageInterface         $storage    The storage.
+     * @param FileInjectorInterface    $injector   The injector.
+     * @param EventDispatcherInterface $dispatcher The event dispatcher.
      */
     public function __construct(PropertyMappingFactory $factory, StorageInterface $storage, FileInjectorInterface $injector, EventDispatcherInterface $dispatcher)
     {

--- a/Injector/FileInjector.php
+++ b/Injector/FileInjector.php
@@ -15,14 +15,14 @@ use Vich\UploaderBundle\Storage\StorageInterface;
 class FileInjector implements FileInjectorInterface
 {
     /**
-     * @var \Vich\UploaderBundle\Storage\StorageInterface
+     * @var StorageInterface
      */
     protected $storage;
 
     /**
      * Constructs a new instance of FileInjector.
      *
-     * @param \Vich\UploaderBundle\Storage\StorageInterface $storage Storage.
+     * @param StorageInterface $storage Storage.
      */
     public function __construct(StorageInterface $storage)
     {

--- a/Mapping/PropertyMapping.php
+++ b/Mapping/PropertyMapping.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Mapping;
 
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
@@ -62,8 +63,8 @@ class PropertyMapping
     /**
      * Gets the file property value for the given object.
      *
-     * @param  object                                             $obj The object.
-     * @return \Symfony\Component\HttpFoundation\File\UploadedFile The file.
+     * @param  object       $obj The object.
+     * @return UploadedFile The file.
      */
     public function getFile($obj)
     {
@@ -75,8 +76,8 @@ class PropertyMapping
     /**
      * Modifies the file property value for the given object.
      *
-     * @param object                                             $obj  The object.
-     * @param \Symfony\Component\HttpFoundation\File\UploadedFile $file The new file.
+     * @param object       $obj  The object.
+     * @param UploadedFile $file The new file.
      */
     public function setFile($obj, $file)
     {
@@ -133,7 +134,7 @@ class PropertyMapping
     /**
      * Gets the configured namer.
      *
-     * @return null|\Vich\UploaderBundle\Naming\NamerInterface The namer.
+     * @return null|NamerInterface The namer.
      */
     public function getNamer()
     {
@@ -143,7 +144,7 @@ class PropertyMapping
     /**
      * Sets the namer.
      *
-     * @param \Vich\UploaderBundle\Naming\NamerInterface $namer The namer.
+     * @param NamerInterface $namer The namer.
      */
     public function setNamer(NamerInterface $namer)
     {

--- a/Mapping/PropertyMappingFactory.php
+++ b/Mapping/PropertyMappingFactory.php
@@ -41,10 +41,10 @@ class PropertyMappingFactory
     /**
      * Constructs a new instance of PropertyMappingFactory.
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container                      The container.
-     * @param \Vich\UploaderBundle\Metadata\MetadataReader              $metadata                       The mapping mapping.
-     * @param array                                                     $mappings                       The configured mappings.
-     * @param string                                                    $defaultFilenameAttributeSuffix The default suffix to be used if the fileNamePropertyPath isn't given for a mapping.
+     * @param ContainerInterface $container                      The container.
+     * @param MetadataReader     $metadata                       The mapping mapping.
+     * @param array              $mappings                       The configured mappings.
+     * @param string             $defaultFilenameAttributeSuffix The default suffix to be used if the fileNamePropertyPath isn't given for a mapping.
      */
     public function __construct(ContainerInterface $container, MetadataReader $metadata, array $mappings, $defaultFilenameAttributeSuffix = '_name')
     {

--- a/Resources/doc/mapping/xml.md
+++ b/Resources/doc/mapping/xml.md
@@ -5,7 +5,7 @@ You can choose to describe your entities in XML. This bundle supports this
 format and comes with the following syntax to declare your uploadable fields:
 
 ```xml
-# src/Acme/DemoBundle/Resources/config/vich_uploader/Product.xml
+<!-- src/Acme/DemoBundle/Resources/config/vich_uploader/Product.xml -->
 <vich_uploader class="Acme\DemoBundle\Entity\Product">
   <field mapping="product_image" name="image" filename_property="image_name" />
 </vich_uploader>

--- a/Storage/AbstractStorage.php
+++ b/Storage/AbstractStorage.php
@@ -15,14 +15,14 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 abstract class AbstractStorage implements StorageInterface
 {
     /**
-     * @var \Vich\UploaderBundle\Mapping\PropertyMappingFactory $factory
+     * @var PropertyMappingFactory $factory
      */
     protected $factory;
 
     /**
      * Constructs a new instance of FileSystemStorage.
      *
-     * @param \Vich\UploaderBundle\Mapping\PropertyMappingFactory $factory The factory.
+     * @param PropertyMappingFactory $factory The factory.
      */
     public function __construct(PropertyMappingFactory $factory)
     {

--- a/Storage/FlysystemStorage.php
+++ b/Storage/FlysystemStorage.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Storage;
 
+use League\Flysystem\FilesystemInterface;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\MountManager;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -21,8 +22,8 @@ class FlysystemStorage extends AbstractStorage
     /**
      * Constructs a new instance of FlysystemStorage.
      *
-     * @param \Vich\UploaderBundle\Mapping\PropertyMappingFactory $factory      The factory.
-     * @param League\Flysystem\MountManager                       $mountManager Gaufrete filesystem factory.
+     * @param PropertyMappingFactory $factory      The factory.
+     * @param MountManager           $mountManager Gaufrete filesystem factory.
      */
     public function __construct(PropertyMappingFactory $factory, MountManager $mountManager)
     {
@@ -97,7 +98,7 @@ class FlysystemStorage extends AbstractStorage
      *
      * @param string $key
      *
-     * @return \League\Flysystem\FilesystemInterface
+     * @return FilesystemInterface
      */
     protected function getFilesystem(PropertyMapping $mapping)
     {

--- a/Storage/GaufretteStorage.php
+++ b/Storage/GaufretteStorage.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Storage;
 
+use Gaufrette\Filesystem;
 use Gaufrette\Adapter\MetadataSupporter;
 use Gaufrette\Exception\FileNotFound;
 use Knp\Bundle\GaufretteBundle\FilesystemMap;
@@ -29,9 +30,9 @@ class GaufretteStorage extends AbstractStorage
     /**
      * Constructs a new instance of FileSystemStorage.
      *
-     * @param \Vich\UploaderBundle\Mapping\PropertyMappingFactory $factory       The factory.
-     * @param \Knp\Bundle\GaufretteBundle\FilesystemMap           $filesystemMap Gaufrete filesystem factory.
-     * @param string                                              $protocol      Gaufrette stream wrapper protocol.
+     * @param PropertyMappingFactory $factory       The factory.
+     * @param FilesystemMap          $filesystemMap Gaufrete filesystem factory.
+     * @param string                 $protocol      Gaufrette stream wrapper protocol.
      */
     public function __construct(PropertyMappingFactory $factory, FilesystemMap $filesystemMap, $protocol = 'gaufrette')
     {
@@ -90,7 +91,7 @@ class GaufretteStorage extends AbstractStorage
      *
      * @param PropertyMapping $mapping
      *
-     * @return \Gaufrette\Filesystem
+     * @return Filesystem
      */
     protected function getFilesystem(PropertyMapping $mapping)
     {

--- a/Templating/Helper/UploaderHelper.php
+++ b/Templating/Helper/UploaderHelper.php
@@ -13,14 +13,14 @@ use Vich\UploaderBundle\Storage\StorageInterface;
 class UploaderHelper extends Helper
 {
     /**
-     * @var \Vich\UploaderBundle\Storage\StorageInterface $storage
+     * @var StorageInterface $storage
      */
     protected $storage;
 
     /**
      * Constructs a new instance of UploaderHelper.
      *
-     * @param \Vich\UploaderBundle\Storage\StorageInterface $storage The storage.
+     * @param StorageInterface $storage The storage.
      */
     public function __construct(StorageInterface $storage)
     {

--- a/Tests/EventListener/Doctrine/ListenerTestCase.php
+++ b/Tests/EventListener/Doctrine/ListenerTestCase.php
@@ -2,6 +2,10 @@
 
 namespace Vich\UploaderBundle\Tests\EventListener\Doctrine;
 
+use Doctrine\Common\EventArgs;
+use Vich\UploaderBundle\Adapter\AdapterInterface;
+use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Metadata\MetadataReader;
 use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
@@ -14,17 +18,17 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     const MAPPING_NAME = 'dummy_mapping';
 
     /**
-     * @var \Vich\UploaderBundle\Adapter\AdapterInterface $adapter
+     * @var AdapterInterface $adapter
      */
     protected $adapter;
 
     /**
-     * @var \Vich\UploaderBundle\Metadata\MetadataReader $metadata
+     * @var MetadataReader $metadata
      */
     protected $metadata;
 
     /**
-     * @var \Vich\UploaderBundle\Handler\UploadHandler $handler
+     * @var UploadHandler $handler
      */
     protected $handler;
 
@@ -66,7 +70,7 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock adapter.
      *
-     * @return \Vich\UploaderBundle\Adapter\AdapterInterface The mock adapter.
+     * @return AdapterInterface The mock adapter.
      */
     protected function getAdapterMock()
     {
@@ -76,7 +80,7 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock metadata reader.
      *
-     * @return \Vich\UploaderBundle\Metadata\MetadataReader The mock metadata reader.
+     * @return MetadataReader The mock metadata reader.
      */
     protected function getMetadataReaderMock()
     {
@@ -88,7 +92,7 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock handler.
      *
-     * @return \Vich\UploaderBundle\Handler\UploadHandler The handler mock.
+     * @return UploadHandler The handler mock.
      */
     protected function getHandlerMock()
     {
@@ -100,7 +104,7 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock doctrine event
      *
-     * @return \Doctrine\Common\EventArgs
+     * @return EventArgs
      */
     protected function getEventMock()
     {

--- a/Tests/EventListener/Doctrine/RemoveListenerTest.php
+++ b/Tests/EventListener/Doctrine/RemoveListenerTest.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\EventListener\Doctrine;
 
+use Doctrine\Common\Persistence\Proxy;
 use Vich\UploaderBundle\EventListener\Doctrine\RemoveListener;
 
 /**
@@ -111,7 +112,7 @@ class RemoveListenerTest extends ListenerTestCase
     /**
      * Creates a mock doctrine entity proxy.
      *
-     * @return \Doctrine\Common\Persistence\Proxy
+     * @return Proxy
      */
     protected function getEntityProxyMock()
     {

--- a/Tests/EventListener/Propel/ListenerTestCase.php
+++ b/Tests/EventListener/Propel/ListenerTestCase.php
@@ -2,6 +2,10 @@
 
 namespace Vich\UploaderBundle\Tests\EventListener\Propel;
 
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Vich\UploaderBundle\Adapter\AdapterInterface;
+use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Metadata\MetadataReader;
 use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
@@ -15,12 +19,12 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     const MAPPING_NAME = 'mapping_name';
 
     /**
-     * @var \Vich\UploaderBundle\Adapter\AdapterInterface $adapter
+     * @var AdapterInterface $adapter
      */
     protected $adapter;
 
     /**
-     * @var \Vich\UploaderBundle\Handler\UploadHandler $handler
+     * @var UploadHandler $handler
      */
     protected $handler;
 
@@ -74,7 +78,7 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock adapter.
      *
-     * @return \Vich\UploaderBundle\Adapter\AdapterInterface The mock adapter.
+     * @return AdapterInterface The mock adapter.
      */
     protected function getAdapterMock()
     {
@@ -84,7 +88,7 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock handler.
      *
-     * @return \Vich\UploaderBundle\Handler\UploadHandler The handler mock.
+     * @return UploadHandler The handler mock.
      */
     protected function getHandlerMock()
     {
@@ -96,7 +100,7 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock event.
      *
-     * @return \Symfony\Component\EventDispatcher\GenericEvent The mock event.
+     * @return GenericEvent The mock event.
      */
     protected function getEventMock()
     {
@@ -108,7 +112,7 @@ class ListenerTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock metadata reader.
      *
-     * @return \Vich\UploaderBundle\Metadata\MetadataReader The mock metadata reader.
+     * @return MetadataReader The mock metadata reader.
      */
     protected function getMetadataReaderMock()
     {

--- a/Tests/Handler/DownloadHandlerTest.php
+++ b/Tests/Handler/DownloadHandlerTest.php
@@ -3,6 +3,8 @@
 namespace Vich\UploaderBundle\Tests\Handler;
 
 use Vich\UploaderBundle\Handler\DownloadHandler;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
@@ -105,7 +107,7 @@ class DownloadHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock property mapping factory
      *
-     * @return \Vich\UploaderBundle\Mapping\PropertyMappingFactory
+     * @return PropertyMappingFactory
      */
     protected function getPropertyMappingFactoryMock()
     {
@@ -117,7 +119,7 @@ class DownloadHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * Gets a mock property mapping.
      *
-     * @return \Vich\UploaderBundle\Mapping\PropertyMapping
+     * @return PropertyMapping
      */
     protected function getPropertyMappingMock()
     {

--- a/Tests/Handler/UploadHandlerTest.php
+++ b/Tests/Handler/UploadHandlerTest.php
@@ -5,6 +5,8 @@ namespace Vich\UploaderBundle\Tests\Handler;
 use Vich\UploaderBundle\Event\Event;
 use Vich\UploaderBundle\Event\Events;
 use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 use Vich\UploaderBundle\Tests\DummyEntity;
 use Vich\UploaderBundle\Tests\TestCase;
 
@@ -206,7 +208,7 @@ class UploadHandlerTest extends TestCase
     /**
      * Creates a mock property mapping factory
      *
-     * @return \Vich\UploaderBundle\Mapping\PropertyMappingFactory
+     * @return PropertyMappingFactory
      */
     protected function getPropertyMappingFactoryMock()
     {
@@ -218,7 +220,7 @@ class UploadHandlerTest extends TestCase
     /**
      * Gets a mock property mapping.
      *
-     * @return \Vich\UploaderBundle\Mapping\PropertyMapping
+     * @return PropertyMapping
      */
     protected function getPropertyMappingMock()
     {

--- a/Tests/Mapping/PropertyMappingFactoryTest.php
+++ b/Tests/Mapping/PropertyMappingFactoryTest.php
@@ -2,7 +2,9 @@
 
 namespace Vich\UploaderBundle\Tests\Mapping;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Metadata\MetadataReader;
 use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
@@ -13,12 +15,12 @@ use Vich\UploaderBundle\Tests\DummyEntity;
 class PropertyMappingFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface $container
+     * @var ContainerInterface $container
      */
     protected $container;
 
     /**
-     * @var \Vich\UploaderBundle\Metadata\MetadataReader $metadata
+     * @var MetadataReader $metadata
      */
     protected $metadata;
 
@@ -411,7 +413,7 @@ class PropertyMappingFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Creates a mock metadata reader.
      *
-     * @return \Vich\UploaderBundle\Metadata\MetadataReader The metadata reader.
+     * @return MetadataReader The metadata reader.
      */
     protected function getMetadataReaderMock()
     {

--- a/Tests/Metadata/Driver/FileLocatorTest.php
+++ b/Tests/Metadata/Driver/FileLocatorTest.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Tests\Metadata\Driver;
 
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 
 use Vich\UploaderBundle\Metadata\Driver\FileLocator;
 
@@ -14,7 +15,7 @@ use Vich\UploaderBundle\Metadata\Driver\FileLocator;
 class FileLocatorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \org\bovigo\vfs\vfsStreamDirectory
+     * @var vfsStreamDirectory
      */
     protected $root;
 

--- a/Tests/Naming/PropertyNamerTest.php
+++ b/Tests/Naming/PropertyNamerTest.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Naming;
 
+use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Naming\PropertyNamer;
 use Vich\UploaderBundle\Tests\DummyEntity;
 use Vich\UploaderBundle\Tests\TestCase;
@@ -103,7 +104,7 @@ class PropertyNamerTest extends TestCase
     }
 
     /**
-     * @return \Vich\UploaderBundle\Mapping\PropertyMapping
+     * @return PropertyMapping
      */
     private function getPropertyMappingMock()
     {

--- a/Tests/Storage/FlysystemStorageTest.php
+++ b/Tests/Storage/FlysystemStorageTest.php
@@ -3,6 +3,9 @@
 namespace Vich\UploaderBundle\Tests\Storage;
 
 use League\Flysystem\File;
+use League\Flysystem\FileNotFoundException;
+use League\Flysystem\FilesystemInterface;
+use League\Flysystem\MountManager;
 use Vich\UploaderBundle\Storage\FlysystemStorage;
 
 /**
@@ -13,12 +16,12 @@ class FlysystemStorageTest extends StorageTestCase
     const FS_KEY = 'filesystemKey';
 
     /**
-     * @var \League\Flysystem\MountManager $mountManager
+     * @var MountManager $mountManager
      */
     protected $mountManager;
 
     /**
-     * @var \League\Flysystem\FilesystemInterface
+     * @var FilesystemInterface
      */
     protected $filesystem;
 
@@ -111,7 +114,7 @@ class FlysystemStorageTest extends StorageTestCase
             ->expects($this->once())
             ->method('delete')
             ->with('not_found.txt')
-            ->will($this->throwException(new \League\Flysystem\FileNotFoundException('dummy path')));
+            ->will($this->throwException(new FileNotFoundException('dummy path')));
 
         $this->mapping
             ->expects($this->once())
@@ -171,7 +174,7 @@ class FlysystemStorageTest extends StorageTestCase
     /**
      * Creates a filesystem map mock.
      *
-     * @return \League\Flysystem\MountManager The mount manager.
+     * @return MountManager The mount manager.
      */
     protected function getMountManagerMock()
     {

--- a/Tests/Storage/GaufretteStorageTest.php
+++ b/Tests/Storage/GaufretteStorageTest.php
@@ -2,7 +2,9 @@
 
 namespace Vich\UploaderBundle\Tests\Storage;
 
+use Gaufrette\Filesystem;
 use Gaufrette\Exception\FileNotFound;
+use Knp\Bundle\GaufretteBundle\FilesystemMap;
 
 use Vich\UploaderBundle\Storage\GaufretteStorage;
 
@@ -14,7 +16,7 @@ use Vich\UploaderBundle\Storage\GaufretteStorage;
 class GaufretteStorageTest extends StorageTestCase
 {
     /**
-     * @var \Knp\Bundle\GaufretteBundle\FilesystemMap $factory
+     * @var FilesystemMap $factory
      */
     protected $filesystemMap;
 
@@ -291,7 +293,7 @@ class GaufretteStorageTest extends StorageTestCase
     /**
      * Creates a mock of gaufrette filesystem map.
      *
-     * @return \Knp\Bundle\GaufretteBundle\FilesystemMap The filesystem map.
+     * @return FilesystemMap The filesystem map.
      */
     protected function getFilesystemMapMock()
     {
@@ -304,7 +306,7 @@ class GaufretteStorageTest extends StorageTestCase
     /**
      * Creates a mock of gaufrette filesystem.
      *
-     * @return \Gaufrette\Filesystem The gaufrette filesystem object.
+     * @return Filesystem The gaufrette filesystem object.
      */
     protected function getFilesystemMock()
     {

--- a/Tests/Storage/StorageTestCase.php
+++ b/Tests/Storage/StorageTestCase.php
@@ -3,8 +3,11 @@
 namespace Vich\UploaderBundle\Tests\Storage;
 
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use Symfony\Component\HttpFoundation\File\File;
 
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 use Vich\UploaderBundle\Tests\DummyEntity;
 use Vich\UploaderBundle\Tests\TestCase;
 
@@ -16,17 +19,17 @@ use Vich\UploaderBundle\Tests\TestCase;
 abstract class StorageTestCase extends TestCase
 {
     /**
-     * @var \Vich\UploaderBundle\Mapping\PropertyMappingFactory $factory
+     * @var PropertyMappingFactory $factory
      */
     protected $factory;
 
     /**
-     * @var \Vich\UploaderBundle\Mapping\PropertyMapping
+     * @var PropertyMapping
      */
     protected $mapping;
 
     /**
-     * @var \Vich\UploaderBundle\Tests\DummyEntity
+     * @var DummyEntity
      */
     protected $object;
 
@@ -36,7 +39,7 @@ abstract class StorageTestCase extends TestCase
     protected $storage;
 
     /**
-     * @var \org\bovigo\vfs\vfsStreamDirectory
+     * @var vfsStreamDirectory
      */
     protected $root;
 
@@ -134,7 +137,7 @@ abstract class StorageTestCase extends TestCase
     /**
      * Creates a mock factory.
      *
-     * @return \Vich\UploaderBundle\Mapping\PropertyMappingFactory The factory.
+     * @return PropertyMappingFactory The factory.
      */
     protected function getFactoryMock()
     {
@@ -146,7 +149,7 @@ abstract class StorageTestCase extends TestCase
     /**
      * Creates a mapping mock.
      *
-     * @return \Vich\UploaderBundle\Mapping\PropertyMapping The property mapping.
+     * @return PropertyMapping The property mapping.
      */
     protected function getMappingMock()
     {

--- a/Util/ClassUtils.php
+++ b/Util/ClassUtils.php
@@ -2,6 +2,8 @@
 
 namespace Vich\UploaderBundle\Util;
 
+use Doctrine\Common\Util\ClassUtils as DoctrineClassUtils;
+
 class ClassUtils
 {
     /**
@@ -14,7 +16,7 @@ class ClassUtils
     public static function getClass($object)
     {
         if (class_exists('\Doctrine\Common\Util\ClassUtils')) {
-            return \Doctrine\Common\Util\ClassUtils::getClass($object);
+            return DoctrineClassUtils::getClass($object);
         }
 
         return get_class($object);


### PR DESCRIPTION
It might be cool to simplify all class imports.

I noticed there was a bug in some phpdoc in v0.14.0 because my IDE wasn't auto-completing correctly.
