### PR TITLE
Remove PHP requirement from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         }
     },
     "require": {
-        "php": "~5.5|~7.0",
         "symfony/framework-bundle": "~2.3|~3.0",
         "jms/metadata": "~1.5",
         "symfony/finder": "~2.0|~3.0",


### PR DESCRIPTION
We should allow PHP 5.3 and PHP 5.4. The PHP requirement check is already done by the Symfony ``symfony/framework-bundle``.