### PR TITLE
Use double slashes in twig example

### DIFF
--- a/Resources/doc/generating_urls.md
+++ b/Resources/doc/generating_urls.md
@@ -35,7 +35,7 @@ In a Twig template you can use the `vich_uploader_asset` function:
 > will need to manually specify the class name:
 
 ```html+jinja
-{{ vich_uploader_asset(product, 'image', 'FooBundle\Entity\Product') }}
+{{ vich_uploader_asset(product, 'image', 'FooBundle\\Entity\\Product') }}
 ```
 
 


### PR DESCRIPTION
Otherwise, twig just crunches it all together, eg `FooBundleEntityProduct`, and throws a `Class not found` Reflection Exception.