### PR TITLE
Fix MetadataReader::getUploadableField with a PropertyPath argument

### DIFF
--- a/Metadata/MetadataReader.php
+++ b/Metadata/MetadataReader.php
@@ -96,6 +96,9 @@ class MetadataReader
     {
         $fieldsMetadata = $this->getUploadableFields($class);
 
+        // Prevents error if $field is an instance of Symfony\Component\PropertyAccess\PropertyPath
+        $field = (string) $field;
+
         return isset($fieldsMetadata[$field]) ? $fieldsMetadata[$field] : null;
     }
 }


### PR DESCRIPTION
Sometime with an image upload, `$field` is not a string but a `PropertyPath` object and this produce this error:

![selection_645](https://cloud.githubusercontent.com/assets/1698357/12954428/d2d1ed1a-d01e-11e5-8d4c-d23bd7940f89.png)

This PR fix it by casting it onto a real string.