### PR TITLE
Additional ocramius/proxy-manager version (1.0 and 2.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,11 @@ matrix:
           env: SYMFONY_VERSION="~3.0.0"
 
 before_install:
+    - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - composer self-update
     - phpenv config-rm xdebug.ini || true
     - composer require --no-update symfony/symfony:${SYMFONY_VERSION}
 
-install: composer update --prefer-dist --ignore-platform-reqs
+install: composer update --prefer-dist
 
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "require-dev": {
         "ext-sqlite3" : "*",
 
+        "alcaeus/mongo-php-adapter": "^1.0.0@beta",
         "doctrine/mongodb-odm": "@dev",
         "knplabs/knp-gaufrette-bundle": "dev-master",
         "oneup/flysystem-bundle": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "jms/metadata": "~1.5",
         "symfony/finder": "~2.0|~3.0",
         "symfony/property-access": "~2.4|~3.0",
-        "ocramius/proxy-manager": "~1.0"
+        "ocramius/proxy-manager": "~1.0|~2.0"
     },
     "require-dev": {
         "ext-sqlite3" : "*",


### PR DESCRIPTION
There are some problems with using older version of "ocramius/proxy-manager" in PHP 7.

Argument parameter types such as string, float, int, bool are not converted in the proper way during the caching process. Declarations of cached/proxy methods are not compatible with their's parent equivalent.

On the other hand 2nd version of "ocramius/proxy-manager" is just stable.