### PR TITLE
Force 'has-error' when invalid

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -1,3 +1,8 @@
+{% block vich_file_row -%}
+    {% set force_error = true %}
+    {{- block('form_row') }}
+{%- endblock %}
+
 {% block vich_file_widget %}
 {% spaceless %}
     <div class="vich-file">
@@ -12,6 +17,11 @@
     </div>
 {% endspaceless %}
 {% endblock %}
+
+{% block vich_image_row -%}
+    {% set force_error = true %}
+    {{- block('form_row') }}
+{%- endblock %}
 
 {% block vich_image_widget %}
 {% spaceless %}


### PR DESCRIPTION
Before this change, an invalid image/file field was missing the `has-error` class, resulting in missing red coloring of label and error

before:
![before](https://cloud.githubusercontent.com/assets/179866/14496344/317968e8-0193-11e6-8aa3-e8bb54c2c6fd.png)

after:
![after](https://cloud.githubusercontent.com/assets/179866/14496345/33eaf3bc-0193-11e6-88bd-ccd89eea898f.png)
