### PR TITLE
[Composer] Refine dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,33 +18,45 @@
     },
     "require": {
         "php": "~5.5|~7.0",
+        "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "jms/metadata": "~1.5",
-        "symfony/finder": "~2.0|~3.0",
-        "symfony/property-access": "~2.4|~3.0",
-        "ocramius/proxy-manager": "~1.0|~2.0"
+        "symfony/finder": "~2.2|~3.0",
+        "symfony/property-access": "~2.5|~3.0",
+        "ocramius/proxy-manager": "~1.0|~2.0",
+        "jms/metadata": "~1.5"
     },
     "require-dev": {
         "ext-sqlite3" : "*",
 
+        "doctrine/doctrine-bundle": "~1.6",
+        "doctrine/orm": "^2.2.3",
         "doctrine/mongodb-odm": "~1.0",
+
         "knplabs/knp-gaufrette-bundle": "~0.3",
         "oneup/flysystem-bundle": "~1.0",
-        "doctrine/orm": "~2.2,>=2.2.3",
-        "doctrine/doctrine-bundle": "~1.6",
+
+        "symfony/browser-kit": "~2.3|~3.0",
+        "symfony/css-selector": "~2.3|~3.0",
+        "symfony/dom-crawler": "~2.3|~3.0",
+        "symfony/form": "~2.3|~3.0",
+        "symfony/proxy-manager-bridge": "~2.3|~3.0",
+        "symfony/twig-bridge": "~2.3.10|~3.0",
+        "symfony/twig-bundle": "~2.3|~3.0",
+        "symfony/validator": "~2.3|~3.0",
+        "symfony/yaml": "^2.0.5|~3.0",
 
         "phpunit/phpunit": "~4.0",
-        "mikey179/vfsStream": "~1.0",
+        "mikey179/vfsStream": "~1.2",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7"
     },
     "suggest": {
-        "doctrine/orm": ">=2.2.3",
-        "doctrine/doctrine-bundle": "*",
+        "doctrine/orm": "^2.2.3",
+        "doctrine/doctrine-bundle": "~1.6",
         "doctrine/phpcr-odm": "~1.0",
         "doctrine/mongodb-odm-bundle": "*",
-        "knplabs/knp-gaufrette-bundle": "*",
-        "willdurand/propel-eventdispatcher-bundle": ">=1.2",
-        "symfony/yaml": "@stable"
+        "knplabs/knp-gaufrette-bundle": "~0.3",
+        "willdurand/propel-eventdispatcher-bundle": "~1.2",
+        "symfony/yaml": "^2.0.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hey!

This PR refines the composer dependencies in order to be able to run phpunit tests locally just after running a `composer install` (a bunch of dependencies were missing if we use Symfony 3).

It also refines dependencies in order to make tests green even if we install with the lowest deps: `composer install --prefer-lowest --prefer-stable`.

Since travis is ran with the full `symfony/symfony`, this has not been detected previously.