### PR TITLE
Add custom storage support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -58,8 +58,10 @@ class Configuration implements ConfigurationInterface
                         ->then(function ($v) { return strtolower($v); })
                     ->end()
                     ->validate()
-                        ->ifNotInArray($this->supportedStorages)
-                        ->thenInvalid('The storage %s is not supported. Please choose one of ' . implode(', ', $this->supportedStorages))
+                        ->ifTrue(function ($storage) {
+                            return strpos($storage, '@') !== 0 && !in_array($storage, $this->supportedStorages, true);
+                        })
+                        ->thenInvalid('The storage %s is not supported. Please choose one of ' . implode(', ', $this->supportedStorages) . ' or provide a service name prefixed with "@".')
                     ->end()
                 ->end()
                 ->scalarNode('twig')->defaultTrue()->end()

--- a/DependencyInjection/VichUploaderExtension.php
+++ b/DependencyInjection/VichUploaderExtension.php
@@ -44,7 +44,12 @@ class VichUploaderExtension extends Extension
         // define a few parameters
         $container->setParameter('vich_uploader.default_filename_attribute_suffix', $config['default_filename_attribute_suffix']);
         $container->setParameter('vich_uploader.mappings', $config['mappings']);
-        $container->setAlias('vich_uploader.storage', 'vich_uploader.storage.' . $config['storage']);
+
+        if (strpos($config['storage'], '@') === 0) {
+            $container->setAlias('vich_uploader.storage', substr($config['storage'], 1));
+        } else {
+            $container->setAlias('vich_uploader.storage', 'vich_uploader.storage.' . $config['storage']);
+        }
 
         $this->loadServicesFiles($container, $config);
         $this->registerMetadataDirectories($container, $config);

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -33,6 +33,7 @@ Don't worry, it will be quick and easy (I promise!):
 
   * [Using Gaufrette as storage abstraction](storage/gaufrette.md)
   * [Using Flysystem as storage abstraction](storage/flysystem.md)
+  * [Using a custom storage](storage/custom.md)
 
 ### Mapping-related
 

--- a/Resources/doc/storage/custom.md
+++ b/Resources/doc/storage/custom.md
@@ -1,0 +1,21 @@
+Custom Storage
+==============
+
+The bundle supports some built-in storage but you can also create your own 
+by implementing the `Vich\UploaderBundle\Storage\StorageInterface` or by
+extending the `Vich\UploaderBundle\Storage\AbstractStorage`.
+
+Once you have implementing it, you need to register it in the Symfony 
+container and provide its service name in the configuration by 
+prefixing it with `@`:
+
+``` yaml
+vich_uploader:
+    db_driver: orm
+    storage:   "@acme.custom.storage"
+```
+
+## That was it!
+
+Check out the docs for information on how to use the bundle! [Return to the
+index.](../index.md)

--- a/Tests/DependencyInjection/VichUploaderExtensionTest.php
+++ b/Tests/DependencyInjection/VichUploaderExtensionTest.php
@@ -39,6 +39,15 @@ class VichUploaderExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasAlias('vich_uploader.storage', 'vich_uploader.storage.gaufrette');
     }
 
+    public function testStorageServiceCustom()
+    {
+        $this->load(array(
+            'storage' => '@acme.storage',
+        ));
+
+        $this->assertContainerBuilderHasAlias('vich_uploader.storage', 'acme.storage');
+    }
+
     public function testExtraServiceFilesAreLoaded()
     {
         $this->load(array(


### PR DESCRIPTION
This PR fixes #573 by allowing to define a custom storage service name in the configuration. 

To to not break the BC, I have chosen to prefix the service name with an `@` in order to inform the DI extension we are using a custom storage service. I think the `@` char is the best option since it is also used in yaml service definition :)

WDYT?