### PR TITLE
Fix metadata changes detection

### DIFF
--- a/Resources/config/mapping.xml
+++ b/Resources/config/mapping.xml
@@ -42,6 +42,8 @@
 
         <service id="vich_uploader.metadata_factory" class="Metadata\MetadataFactory" public="false">
             <argument type="service" id="vich_uploader.metadata_driver" />
+            <argument>Metadata\ClassHierarchyMetadata</argument>
+            <argument>%kernel.debug%</argument>
             <call method="setCache">
                 <argument type="service" id="vich_uploader.metadata.cache" on-invalid="ignore" />
             </call>


### PR DESCRIPTION
Hey!

Since I'm currently playing with this bundle, I submit a bugfix about metadata changes detection. Basically, the JMS metadata factory was always in no debug mode meaning once the metadata were loaded, no more checks were done on them.

This PR fixes it by propagating the `kernel.debug` flag into the metadata factory and then, bring back the metadata changes detection :)