### PR TITLE
Add support for propel-events from GlorpenPropelBundle.

### DIFF
--- a/Adapter/Propel/PropelORMGeAdapter.php
+++ b/Adapter/Propel/PropelORMGeAdapter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Vich\UploaderBundle\Adapter\Propel;
+
+use Vich\UploaderBundle\Adapter\AdapterInterface;
+
+/**
+ * Propel adapter for GlorpenPropelBundle.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class PropelORMGeAdapter implements AdapterInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getObjectFromArgs($event)
+    {
+        return $event->getModel();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function recomputeChangeSet($event)
+    {
+    }
+}

--- a/DependencyInjection/Compiler/RegisterPropelModelsPass.php
+++ b/DependencyInjection/Compiler/RegisterPropelModelsPass.php
@@ -14,6 +14,16 @@ use Vich\UploaderBundle\Exception\MappingNotFoundException;
  */
 class RegisterPropelModelsPass implements CompilerPassInterface
 {
+    protected function isDriverUsed($driver, array $mappings)
+    {
+        foreach ($mappings as $mapping) {
+            if($mapping['db_driver'] === $driver){
+                return true;
+            }
+        }
+        return false;
+    }
+    
     /**
      * {@inheritdoc}
      */
@@ -23,12 +33,20 @@ class RegisterPropelModelsPass implements CompilerPassInterface
             return;
         }
 
+        $mappings = $container->getParameter('vich_uploader.mappings');
+
+        if ($this->isDriverUsed('propel', $mappings)) {
+            $this->registerBazingaEvents($mappings, $container);
+        }
+    }
+
+    protected function registerBazingaEvents(array $mappings, ContainerBuilder $container)
+    {
+        $metadata = $container->get('vich_uploader.metadata_reader');
+
         $serviceTypes = array(
             'inject', 'clean', 'remove', 'upload',
         );
-
-        $metadata = $container->get('vich_uploader.metadata_reader');
-        $mappings = $container->getParameter('vich_uploader.mappings');
 
         foreach ($metadata->getUploadableClasses() as $class) {
             foreach ($metadata->getUploadableFields($class) as $field) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    protected $supportedDbDrivers = array('orm', 'mongodb', 'propel', 'phpcr');
+    protected $supportedDbDrivers = array('orm', 'mongodb', 'propel', 'propel_ge', 'phpcr');
     protected $supportedStorages = array('gaufrette', 'flysystem', 'file_system');
 
     /**

--- a/DependencyInjection/VichUploaderExtension.php
+++ b/DependencyInjection/VichUploaderExtension.php
@@ -24,7 +24,8 @@ class VichUploaderExtension extends Extension
     protected $tagMap = array(
         'orm'       => 'doctrine.event_subscriber',
         'mongodb'   => 'doctrine_mongodb.odm.event_subscriber',
-        'phpcr'     => 'doctrine_phpcr.event_subscriber'
+        'phpcr'     => 'doctrine_phpcr.event_subscriber',
+        'propel_ge' => 'propel.event'
     );
 
     /**

--- a/EventListener/PropelGe/BaseListener.php
+++ b/EventListener/PropelGe/BaseListener.php
@@ -1,0 +1,23 @@
+<?php
+namespace Vich\UploaderBundle\EventListener\PropelGe;
+
+use Vich\UploaderBundle\EventListener\Propel\BaseListener as PropelBaseListener;
+use Vich\UploaderBundle\Util\ClassUtils;
+
+/**
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+abstract class BaseListener extends PropelBaseListener
+{
+    /**
+     * Checks if the given object is uploadable using the current mapping.
+     *
+     * @param mixed $object The object to test.
+     *
+     * @return bool
+     */
+    protected function isUploadable($object)
+    {
+        return $this->metadata->isUploadable(ClassUtils::getClass($object), $this->mapping);
+    }
+}

--- a/EventListener/PropelGe/CleanListener.php
+++ b/EventListener/PropelGe/CleanListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Vich\UploaderBundle\EventListener\PropelGe;
+
+use Glorpen\Propel\PropelBundle\Events\ModelEvent;
+
+/**
+ * CleanListener
+ *
+ * Listen to the update event to delete old files accordingly.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class CleanListener extends BaseListener
+{
+    /**
+     * The events the listener is subscribed to.
+     *
+     * @return array The array of events.
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'model.update.pre' => 'onUpload',
+        );
+    }
+
+    /**
+     * @param GenericEvent $event The event.
+     */
+    public function onUpload(ModelEvent $event)
+    {
+        $object = $this->adapter->getObjectFromArgs($event);
+
+        if (!$this->isUploadable($object)) {
+            return;
+        }
+
+        foreach ($this->getUploadableFields($object) as $field) {
+            $this->handler->clean($object, $field);
+        }
+    }
+}

--- a/EventListener/PropelGe/InjectListener.php
+++ b/EventListener/PropelGe/InjectListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Vich\UploaderBundle\EventListener\PropelGe;
+
+use Glorpen\Propel\PropelBundle\Events\ModelEvent;
+
+/**
+ * InjectListener
+ *
+ * Listen to the load event in order to inject File objects.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class InjectListener extends BaseListener
+{
+    /**
+     * The events the listener is subscribed to.
+     *
+     * @return array The array of events.
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'model.hydrate.post' => 'onHydrate',
+        );
+    }
+
+    /**
+     * @param GenericEvent $event The event.
+     */
+    public function onHydrate(ModelEvent $event)
+    {
+        $object = $this->adapter->getObjectFromArgs($event);
+
+        if (!$this->isUploadable($object)) {
+            return;
+        }
+
+        foreach ($this->getUploadableFields($object) as $field) {
+            $this->handler->inject($object, $field);
+        }
+    }
+}

--- a/EventListener/PropelGe/RemoveListener.php
+++ b/EventListener/PropelGe/RemoveListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Vich\UploaderBundle\EventListener\PropelGe;
+
+use Glorpen\Propel\PropelBundle\Events\ModelEvent;
+
+/**
+ * RemoveListener
+ *
+ * Listen to the remove event to delete files accordingly.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class RemoveListener extends BaseListener
+{
+    /**
+     * The events the listener is subscribed to.
+     *
+     * @return array The array of events.
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'model.delete.post' => 'onDelete',
+        );
+    }
+
+    /**
+     * @param GenericEvent $event The event.
+     */
+    public function onDelete(ModelEvent $event)
+    {
+        $object = $this->adapter->getObjectFromArgs($event);
+
+        if (!$this->isUploadable($object)) {
+            return;
+        }
+
+        foreach ($this->getUploadableFields($object) as $field) {
+            $this->handler->remove($object, $field);
+        }
+    }
+}

--- a/EventListener/PropelGe/UploadListener.php
+++ b/EventListener/PropelGe/UploadListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Vich\UploaderBundle\EventListener\PropelGe;
+
+use Glorpen\Propel\PropelBundle\Events\ModelEvent;
+
+/**
+ * UploadListener
+ *
+ * Handles file uploads.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class UploadListener extends BaseListener
+{
+    /**
+     * The events the listener is subscribed to.
+     *
+     * @return array The array of events.
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'model.save.pre' => 'onUpload',
+        );
+    }
+
+    /**
+     * @param GenericEvent $event The event.
+     */
+    public function onUpload(ModelEvent $event)
+    {
+        $object = $this->adapter->getObjectFromArgs($event);
+
+        if (!$this->isUploadable($object)) {
+            return;
+        }
+
+        foreach ($this->getUploadableFields($object) as $field) {
+            $this->handler->upload($object, $field);
+        }
+    }
+}

--- a/Resources/config/adapter.xml
+++ b/Resources/config/adapter.xml
@@ -7,6 +7,7 @@
     <services>
 
         <service id="vich_uploader.adapter.propel"  class="Vich\UploaderBundle\Adapter\Propel\PropelORMAdapter" public="false" />
+        <service id="vich_uploader.adapter.propel_ge"  class="Vich\UploaderBundle\Adapter\Propel\PropelORMGeAdapter" public="false" />
         <service id="vich_uploader.adapter.mongodb" class="Vich\UploaderBundle\Adapter\ODM\MongoDB\MongoDBAdapter" public="false" />
         <service id="vich_uploader.adapter.orm"     class="Vich\UploaderBundle\Adapter\ORM\DoctrineORMAdapter" public="false" />
         <service id="vich_uploader.adapter.phpcr"   class="Vich\UploaderBundle\Adapter\PHPCR\PHPCRAdapter" public="false" />

--- a/Resources/config/listener.xml
+++ b/Resources/config/listener.xml
@@ -41,6 +41,11 @@
         <service id="vich_uploader.listener.upload.propel" class="Vich\UploaderBundle\EventListener\Propel\UploadListener" parent="vich_uploader.listener.propel.base" />
         <service id="vich_uploader.listener.clean.propel" class="Vich\UploaderBundle\EventListener\Propel\CleanListener" parent="vich_uploader.listener.propel.base" />
         <service id="vich_uploader.listener.remove.propel" class="Vich\UploaderBundle\EventListener\Propel\RemoveListener" parent="vich_uploader.listener.propel.base" />
+        
+        <service id="vich_uploader.listener.inject.propel_ge" class="Vich\UploaderBundle\EventListener\PropelGe\InjectListener" parent="vich_uploader.listener.propel.base" />
+        <service id="vich_uploader.listener.upload.propel_ge" class="Vich\UploaderBundle\EventListener\PropelGe\UploadListener" parent="vich_uploader.listener.propel.base" />
+        <service id="vich_uploader.listener.clean.propel_ge" class="Vich\UploaderBundle\EventListener\PropelGe\CleanListener" parent="vich_uploader.listener.propel.base" />
+        <service id="vich_uploader.listener.remove.propel_ge" class="Vich\UploaderBundle\EventListener\PropelGe\RemoveListener" parent="vich_uploader.listener.propel.base" />
 
     </services>
 

--- a/Tests/Adapter/Propel/PropelORMGeAdapterTest.php
+++ b/Tests/Adapter/Propel/PropelORMGeAdapterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Adapter\Propel;
+
+use Vich\UploaderBundle\Adapter\Propel\PropelORMGaAdapter;
+
+/**
+ * PropelORMGeAdapterTest
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class PropelORMGeAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    protected $adapter;
+
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists('Glorpen\PropelBundle\Events\ModelEvent')) {
+            self::markTestSkipped('Glorpen\PropelBundle\Events\ModelEvent does not exist.');
+        }
+    }
+
+    public function setUp()
+    {
+        $this->adapter = new PropelORMGaAdapter();
+    }
+
+    public function testGetObjectFromArgs()
+    {
+        $event = $this->getMock('\Glorpen\PropelBundle\Events\ModelEvent');
+        $event
+            ->expects($this->once())
+            ->method('getModel')
+            ->will($this->returnValue(42));
+
+        $this->assertSame(42, $this->adapter->getObjectFromArgs($event));
+    }
+
+    public function testRecomputeChangeset()
+    {
+        $event = $this->getMock('\Glorpen\PropelBundle\Events\ModelEvent');
+
+        // does nothing but should be callable
+        $this->adapter->recomputeChangeSet($event);
+    }
+}

--- a/Tests/EventListener/PropelGe/CleanListenerTest.php
+++ b/Tests/EventListener/PropelGe/CleanListenerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\EventListener\PropelGe;
+
+use Vich\UploaderBundle\EventListener\PropelGe\CleanListener;
+
+/**
+ * Propel clean listener test case.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class CleanListenerTest extends ListenerTestCase
+{
+    /**
+     * Sets up the test
+     */
+    public function setUp()
+    {
+        parent::setUp();
+    
+        $this->listener = new CleanListener(self::MAPPING_NAME, $this->adapter, $this->metadata, $this->handler);
+    }
+    
+    /**
+     * Test the getSubscribedEvents method.
+     */
+    public function testGetSubscribedEvents()
+    {
+        $events = $this->listener->getSubscribedEvents();
+
+        $this->assertArrayHasKey('model.update.pre', $events);
+    }
+    
+
+    /**
+     * Test the onUpload method.
+     */
+    public function testOnUpload()
+    {
+        $this->metadata
+        ->expects($this->once())
+        ->method('isUploadable')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity')
+        ->will($this->returnValue(true));
+    
+        $this->metadata
+        ->expects($this->once())
+        ->method('getUploadableFields')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+        ->will($this->returnValue(array(
+            array('propertyName' => self::FIELD_NAME)
+        )));
+    
+        $this->handler
+        ->expects($this->once())
+        ->method('clean')
+        ->with($this->object, self::FIELD_NAME);
+    
+        $this->adapter
+        ->expects($this->never())
+        ->method('recomputeChangeSet')
+        ->with($this->event);
+    
+        $this->listener->onUpload($this->event);
+    }
+    
+    /**
+     * Test that onUpload skips non uploadable entity.
+     */
+    public function testOnUploadSkipsNonUploadable()
+    {
+        $this->metadata
+        ->expects($this->once())
+        ->method('isUploadable')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity')
+        ->will($this->returnValue(false));
+    
+        $this->handler
+        ->expects($this->never())
+        ->method('clean');
+    
+        $this->adapter
+        ->expects($this->never())
+        ->method('recomputeChangeSet');
+    
+        $this->listener->onUpload($this->event);
+    }
+}

--- a/Tests/EventListener/PropelGe/InjectListenerTest.php
+++ b/Tests/EventListener/PropelGe/InjectListenerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\EventListener\PropelGe;
+
+use Vich\UploaderBundle\EventListener\PropelGe\InjectListener;
+
+/**
+ * Propel remove listener test case.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class InjectListenerTest extends ListenerTestCase
+{
+    /**
+     * Sets up the test
+     */
+    public function setUp()
+    {
+        parent::setUp();
+    
+        $this->listener = new InjectListener(self::MAPPING_NAME, $this->adapter, $this->metadata, $this->handler);
+    }
+    
+    /**
+     * Test the getSubscribedEvents method.
+     */
+    public function testGetSubscribedEvents()
+    {
+        $events = $this->listener->getSubscribedEvents();
+
+        $this->assertArrayHasKey('model.hydrate.post', $events);
+    }
+    
+
+    /**
+     * Test the onHydrate method.
+     */
+    public function testOnHydrate()
+    {
+        $this->metadata
+        ->expects($this->once())
+        ->method('isUploadable')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity')
+        ->will($this->returnValue(true));
+    
+        $this->metadata
+        ->expects($this->once())
+        ->method('getUploadableFields')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+        ->will($this->returnValue(array(
+            array('propertyName' => self::FIELD_NAME)
+        )));
+    
+        $this->handler
+        ->expects($this->once())
+        ->method('inject')
+        ->with($this->object, self::FIELD_NAME);
+    
+        $this->listener->onHydrate($this->event);
+    }
+    
+    /**
+     * Test that onHydrate skips non uploadable entity.
+     */
+    public function testOnHydrateSkipsNonUploadable()
+    {
+        $this->metadata
+        ->expects($this->once())
+        ->method('isUploadable')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity')
+        ->will($this->returnValue(false));
+    
+        $this->handler
+        ->expects($this->never())
+        ->method('inject', self::MAPPING_NAME);
+    
+        $this->listener->onHydrate($this->event);
+    }
+}

--- a/Tests/EventListener/PropelGe/ListenerTestCase.php
+++ b/Tests/EventListener/PropelGe/ListenerTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\EventListener\PropelGe;
+
+use Vich\UploaderBundle\Tests\EventListener\Propel\ListenerTestCase as PropelListenerTestCase;
+
+/**
+ * Propel listener test case.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class ListenerTestCase extends PropelListenerTestCase
+{
+    /**
+     * Creates a mock event.
+     *
+     * @return \Symfony\Component\EventDispatcher\GenericEvent The mock event.
+     */
+    protected function getEventMock()
+    {
+        return $this->getMockBuilder('\Glorpen\Propel\PropelBundle\Events\ModelEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/Tests/EventListener/PropelGe/RemoveListenerTest.php
+++ b/Tests/EventListener/PropelGe/RemoveListenerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\EventListener\PropelGe;
+
+use Vich\UploaderBundle\EventListener\PropelGe\RemoveListener;
+
+/**
+ * Propel remove listener test case.
+ * 
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class RemoveListenerTest extends ListenerTestCase
+{
+    /**
+     * Sets up the test
+     */
+    public function setUp()
+    {
+        parent::setUp();
+    
+        $this->listener = new RemoveListener(self::MAPPING_NAME, $this->adapter, $this->metadata, $this->handler);
+    }
+    
+    /**
+     * Test the getSubscribedEvents method.
+     */
+    public function testGetSubscribedEvents()
+    {
+        $events = $this->listener->getSubscribedEvents();
+
+        $this->assertArrayHasKey('model.delete.post', $events);
+    }
+    
+    /**
+     * Test the onDelete method.
+     */
+    public function testOnDelete()
+    {
+        $this->metadata
+        ->expects($this->once())
+        ->method('isUploadable')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity')
+        ->will($this->returnValue(true));
+    
+        $this->metadata
+        ->expects($this->once())
+        ->method('getUploadableFields')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+        ->will($this->returnValue(array(
+            array('propertyName' => self::FIELD_NAME)
+        )));
+    
+        $this->handler
+        ->expects($this->once())
+        ->method('remove')
+        ->with($this->object, self::FIELD_NAME);
+    
+        $this->listener->onDelete($this->event);
+    }
+    
+    /**
+     * Test that onDelete skips non uploadable entity.
+     */
+    public function testOnDeleteSkipsNonUploadable()
+    {
+        $this->metadata
+        ->expects($this->once())
+        ->method('isUploadable')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity')
+        ->will($this->returnValue(false));
+    
+        $this->handler
+        ->expects($this->never())
+        ->method('remove');
+    
+        $this->listener->onDelete($this->event);
+    }
+}

--- a/Tests/EventListener/PropelGe/UploadListenerTest.php
+++ b/Tests/EventListener/PropelGe/UploadListenerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\EventListener\PropelGe;
+
+use Vich\UploaderBundle\EventListener\PropelGe\UploadListener;
+
+/**
+ * Propel remove listener test case.
+ *
+ * @author Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>
+ */
+class UploadListenerTest extends ListenerTestCase
+{
+    /**
+     * Sets up the test
+     */
+    public function setUp()
+    {
+        parent::setUp();
+    
+        $this->listener = new UploadListener(self::MAPPING_NAME, $this->adapter, $this->metadata, $this->handler);
+    }
+    
+    /**
+     * Test the getSubscribedEvents method.
+     */
+    public function testGetSubscribedEvents()
+    {
+        $events = $this->listener->getSubscribedEvents();
+
+        $this->assertArrayHasKey('model.save.pre', $events);
+    }
+    
+    /**
+     * Test the onUpload method.
+     */
+    public function testOnUpload()
+    {
+        $this->adapter
+        ->expects($this->never())
+        ->method('recomputeChangeSet')
+        ->with($this->event);
+    
+        $this->metadata
+        ->expects($this->once())
+        ->method('isUploadable')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity')
+        ->will($this->returnValue(true));
+    
+        $this->metadata
+        ->expects($this->once())
+        ->method('getUploadableFields')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+        ->will($this->returnValue(array(
+            array('propertyName' => self::FIELD_NAME)
+        )));
+    
+        $this->handler
+        ->expects($this->once())
+        ->method('upload')
+        ->with($this->object, self::FIELD_NAME);
+    
+        $this->listener->onUpload($this->event);
+    }
+    
+    /**
+     * Test that onUpload skips non uploadable entity.
+     */
+    public function testOnUploadSkipsNonUploadable()
+    {
+        $this->metadata
+        ->expects($this->once())
+        ->method('isUploadable')
+        ->with('Vich\UploaderBundle\Tests\DummyEntity')
+        ->will($this->returnValue(false));
+    
+        $this->adapter
+        ->expects($this->never())
+        ->method('recomputeChangeSet');
+    
+        $this->handler
+        ->expects($this->never())
+        ->method('upload');
+    
+        $this->listener->onUpload($this->event);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "doctrine/phpcr-odm": "~1.0",
         "doctrine/mongodb-odm-bundle": "*",
         "knplabs/knp-gaufrette-bundle": "~0.3",
+        "glorpen/propel-bundle": ">=1.3.2",
         "willdurand/propel-eventdispatcher-bundle": "~1.2",
         "symfony/yaml": "^2.0.5"
     },


### PR DESCRIPTION
I've bumped into problem when creating custom driver - when using `propel` orm option,
`getUploadableClasses` and `getUploadableFields` are called when Container is not yet built,
and because of it some base services are unavailable - eg. `kernel`.

This PR adds support for GlorpenPropelBundle as another "orm": `propel_ge`, when used allows to skip
reading data from not-yet-built Container in `RegisterPropelModelsPass`.
Going further, event handling looks more like in Doctrine part of this bundle and thus enables a way
to write custom drivers when using Propel.
