### PR TITLE
Defer RegisterPropelModelsPass

### DIFF
--- a/VichUploaderBundle.php
+++ b/VichUploaderBundle.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle;
 
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Vich\UploaderBundle\DependencyInjection\Compiler\RegisterPropelModelsPass;
@@ -20,6 +21,6 @@ class VichUploaderBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new RegisterPropelModelsPass());
+        $container->addCompilerPass(new RegisterPropelModelsPass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 }


### PR DESCRIPTION
The changeset was necessary after a change in symfony master.

The service 'cache.annotations', which is resolved when the metadata
reader is received from the container in the Pass, is not available
at that point in the container compilation process.

This changeset defers the PropelModelsPass until a point in time, where the
container is fully accessible.

Ref: symfony/symfony#19205
