### PR TITLE
Avoid some warning with Transliterator

### DIFF
--- a/Util/Transliterator.php
+++ b/Util/Transliterator.php
@@ -8,7 +8,7 @@ class Transliterator
     {
         // needs intl extension
         $transId = "Any-Latin; Latin-ASCII; [\u0100-\u7fff] remove";
-        if (function_exists('transliterator_transliterate') && $transliterator = \Transliterator::create($transId)) {
+        if (class_exists('\\Transliterator') && $transliterator = \Transliterator::create($transId)) {
             $string = $transliterator->transliterate($string);
             $string = preg_replace('/[^\\pL\d._]+/u', '-', $string);
             $string = preg_replace('/[-\s]+/', '-', $string);

--- a/Util/Transliterator.php
+++ b/Util/Transliterator.php
@@ -7,8 +7,9 @@ class Transliterator
     public static function transliterate($string)
     {
         // needs intl extension
-        if (function_exists('transliterator_transliterate')) {
-            $string = transliterator_transliterate("Any-Latin; Latin-ASCII; [\u0100-\u7fff] remove" , $string);
+        $transId = "Any-Latin; Latin-ASCII; [\u0100-\u7fff] remove";
+        if (function_exists('transliterator_transliterate') && $transliterator = \Transliterator::create($transId)) {
+            $string = $transliterator->transliterate($string);
             $string = preg_replace('/[^\\pL\d._]+/u', '-', $string);
             $string = preg_replace('/[-\s]+/', '-', $string);
         } else {


### PR DESCRIPTION
Here is safer way to check if we can use ICU related function.

In some case and some environnement I get a warning like this one: 
```
Warning: transliterator_transliterate(): Could not create transliterator with
ID "Any-Latin; Latin-ASCII; [\u0100-\u7fff] remove"
(transliterator_create: unable to open ICU transliterator
with id "Any-Latin; Latin-ASCII; [\u0100-\u7fff] remove": U_INVALID_ID)
```

By the way, this should fix #554
