### PR TITLE
Gaufrette circular reference

### DIFF
--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="vich_uploader.storage.gaufrette" class="Vich\UploaderBundle\Storage\GaufretteStorage" public="false">
+        <service id="vich_uploader.storage.gaufrette" class="Vich\UploaderBundle\Storage\GaufretteStorage" public="false" lazy="true">
             <argument type="service" id="vich_uploader.property_mapping_factory" />
             <argument type="service" id="knp_gaufrette.filesystem_map" />
             <argument>%knp_gaufrette.stream_wrapper.protocol%</argument>


### PR DESCRIPTION
Fixed `ServiceCircularReferenceException` for service `vich_uploader.storage`
