### PR TITLE
Avoid loading all metadata when there is no propel mapping

### DIFF
--- a/DependencyInjection/Compiler/RegisterPropelModelsPass.php
+++ b/DependencyInjection/Compiler/RegisterPropelModelsPass.php
@@ -23,12 +23,25 @@ class RegisterPropelModelsPass implements CompilerPassInterface
             return;
         }
 
+        $mappings = $container->getParameter('vich_uploader.mappings');
+        $hasPropelMapping = false;
+
+        foreach ($mappings as $mapping) {
+            if ($mapping['db_driver'] === 'propel') {
+                $hasPropelMapping = true;
+                break;
+            }
+        }
+
+        if (!$hasPropelMapping) {
+            return;
+        }
+
         $serviceTypes = array(
             'inject', 'clean', 'remove', 'upload',
         );
 
         $metadata = $container->get('vich_uploader.metadata_reader');
-        $mappings = $container->getParameter('vich_uploader.mappings');
 
         foreach ($metadata->getUploadableClasses() as $class) {
             foreach ($metadata->getUploadableFields($class) as $field) {


### PR DESCRIPTION
The Compiler pass registers listeners when the mapping used by the class is a Propel mapping.
But if there is no such mapping, there is no need to load the metadata at all.

The loading of metadata relies on an unsupported usage of Symfony (getting a service instance during the container building phase), and that it breaks in Symfony 3.2 (one of the dependencies of the ``vich_uploader.metadata_reader`` service depends on a cache pool on 3.2, which is not yet ready to be instantiated at the time your compiler pass runs).
Thanks to this change, the broken behavior only happens for people using the Propel integration (next plan is to look for a way to achieve the necessary behavior without instantiating the service here, to solve it for them). anyone not using the Propel 1 integration would have a working project again, as the compiler pass would return before reaching the broken case.