### PR TITLE
Rework form options, download handler options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,15 @@ env:
 matrix:
     include:
         - php: 7.0
-          env: SYMFONY_VERSION="~2.8.0"
+          env: VALIDATE_DOCS=true
+        - php: 7.0
+          env: SYMFONY_VERSION="~3.2.0"
         - php: 7.1
           env: SYMFONY_VERSION="~3.2.0"
+        - php: 7.1
+          env: SYMFONY_VERSION="~2.8.0" WITH_LIIP_IMAGINE=true
+        - php: 7.1
+          env: SYMFONY_VERSION="~3.2.0" WITH_LIIP_IMAGINE=true
     allow_failures:
         - php: nightly
 
@@ -27,11 +33,12 @@ before_install:
     - composer self-update
     - phpenv config-rm xdebug.ini || true
     - composer config platform.ext-mongo 1.6.14
-    - composer require --no-update symfony/symfony:${SYMFONY_VERSION}
-    - if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then composer require --dev --no-update kphoen/rusty dev-master; fi
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
+    - if [ "$WITH_LIIP_IMAGINE" = true ] ; then composer require --no-update liip/imagine-bundle:^1.7; fi;
+    - if [ "$VALIDATE_DOCS" = true ]; then composer require --dev --no-update kphoen/rusty dev-master; fi
 
-install: php -d memory_limit=-1 $(phpenv which composer) update --prefer-dist
+install: php -d memory_limit=-1 $(phpenv which composer) install --no-suggest --prefer-dist
 
 script:
-    - ./vendor/bin/phpunit
-    - if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then php ./vendor/bin/rusty check --no-execute ./Resources/doc; fi
+    - if [ "$VALIDATE_DOCS" != true ]; then ./vendor/bin/phpunit; fi
+    - if [ "$VALIDATE_DOCS" = true ]; then php ./vendor/bin/rusty check --no-execute ./Resources/doc; fi

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,9 +17,7 @@ class Configuration implements ConfigurationInterface
     protected $supportedStorages = ['gaufrette', 'flysystem', 'file_system'];
 
     /**
-     * Gets the configuration tree builder for the extension.
-     *
-     * @return Tree The configuration tree builder
+     * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {

--- a/DependencyInjection/VichUploaderExtension.php
+++ b/DependencyInjection/VichUploaderExtension.php
@@ -11,8 +11,6 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * VichUploaderExtension.
- *
  * @author Dustin Dobervich <ddobervich@gmail.com>
  */
 class VichUploaderExtension extends Extension
@@ -55,6 +53,8 @@ class VichUploaderExtension extends Extension
         $this->registerCacheStrategy($container, $config);
 
         $this->registerListeners($container, $config);
+
+        $this->registerFormTheme($container);
     }
 
     protected function loadServicesFiles(ContainerBuilder $container, array $config)
@@ -161,7 +161,7 @@ class VichUploaderExtension extends Extension
         foreach ($config['mappings'] as $name => $mapping) {
             $driver = $mapping['db_driver'];
 
-            // create optionnal listeners
+            // create optional listeners
             foreach ($servicesMap as $configOption => $service) {
                 if (!$mapping[$configOption]) {
                     continue;
@@ -209,5 +209,14 @@ class VichUploaderExtension extends Extension
         if (isset($this->tagMap[$driver])) {
             $definition->addTag($this->tagMap[$driver], ['priority' => $priority]);
         }
+    }
+
+    private function registerFormTheme(ContainerBuilder $container)
+    {
+        $resources = $container->hasParameter('twig.form.resources') ?
+            $container->getParameter('twig.form.resources') : [];
+
+        $resources[] = '@VichUploader/Form/fields.html.twig';
+        $container->setParameter('twig.form.resources', $resources);
     }
 }

--- a/Form/Type/VichFileType.php
+++ b/Form/Type/VichFileType.php
@@ -9,11 +9,21 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Vich\UploaderBundle\Form\DataTransformer\FileTransformer;
 use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 use Vich\UploaderBundle\Storage\StorageInterface;
 
+/**
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ * @author Konstantin Myakshin <koc-dp@yandex.ru>
+ * @author Massimiliano Arione <max.arione@gmail.com>
+ */
 class VichFileType extends AbstractType
 {
     /**
@@ -27,13 +37,21 @@ class VichFileType extends AbstractType
     protected $handler;
 
     /**
-     * @param StorageInterface $storage
-     * @param UploadHandler    $handler
+     * @var PropertyMappingFactory
      */
-    public function __construct(StorageInterface $storage, UploadHandler $handler)
+    protected $factory;
+
+    /**
+     * @var PropertyAccessorInterface
+     */
+    protected $propertyAccessor;
+
+    public function __construct(StorageInterface $storage, UploadHandler $handler, PropertyMappingFactory $factory, PropertyAccessorInterface $propertyAccessor = null)
     {
         $this->storage = $storage;
         $this->handler = $handler;
+        $this->factory = $factory;
+        $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
     }
 
     /**
@@ -43,14 +61,32 @@ class VichFileType extends AbstractType
     {
         $resolver->setDefaults([
             'allow_delete' => true,
-            'download_link' => true,
+            'download_link' => null,
+            'download_uri' => true,
+            //TODO: use 'form.label.download'
+            'download_label' => 'download',
+            'delete_label' => 'form.label.delete',
             'error_bubbling' => false,
-            'download_uri' => null,
+            'translation_domain' => 'VichUploaderBundle',
         ]);
 
         $resolver->setAllowedTypes('allow_delete', 'bool');
-        $resolver->setAllowedTypes('download_link', 'bool');
+        $resolver->setAllowedTypes('download_link', ['null', 'bool']);
+        $resolver->setAllowedTypes('download_uri', ['bool', 'string', 'callable']);
+        $resolver->setAllowedTypes('download_label', ['bool', 'string', 'callable', PropertyPath::class]);
         $resolver->setAllowedTypes('error_bubbling', 'bool');
+
+        $downloadUriNormalizer = function (Options $options, $downloadUri) {
+            if (null !== $options['download_link']) {
+                @trigger_error('The "download_link" option is deprecated since version 1.6 and will be removed in 2.0. You should use "download_uri" instead.', E_USER_DEPRECATED);
+
+                return $options['download_link'];
+            }
+
+            return $downloadUri;
+        };
+
+        $resolver->setNormalizer('download_uri', $downloadUriNormalizer);
     }
 
     /**
@@ -62,6 +98,7 @@ class VichFileType extends AbstractType
             'required' => $options['required'],
             'label' => $options['label'],
             'attr' => $options['attr'],
+            'translation_domain' => $options['translation_domain'],
         ]);
 
         $builder->addModelTransformer(new FileTransformer());
@@ -88,18 +125,18 @@ class VichFileType extends AbstractType
             }
 
             $form->add('delete', Type\CheckboxType::class, [
-                'label' => 'form.label.delete',
-                'translation_domain' => 'VichUploaderBundle',
-                'required' => false,
+                'label' => $options['delete_label'],
                 'mapped' => false,
+                'translation_domain' => $options['translation_domain'],
+                'required' => false,
             ]);
         });
 
         // delete file if needed
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
-            $delete = $form->has('delete') ? $form->get('delete')->getData() : false;
             $object = $form->getParent()->getData();
+            $delete = $form->has('delete') ? $form->get('delete')->getData() : false;
 
             if (!$delete) {
                 return;
@@ -117,9 +154,13 @@ class VichFileType extends AbstractType
         $object = $form->getParent()->getData();
         $view->vars['object'] = $object;
 
-        if ($options['download_link'] && $object) {
-            $view->vars['download_uri'] = $options['download_uri']
-                ?: $this->storage->resolveUri($object, $form->getName());
+        $view->vars['download_uri'] = null;
+        if ($options['download_uri'] && $object) {
+            $view->vars['download_uri'] = $this->resolveUriOption($options['download_uri'], $object, $form);
+            $view->vars = array_replace(
+                $view->vars,
+                $this->resolveDownloadLabel($options['download_label'], $object, $form)
+            );
         }
     }
 
@@ -129,5 +170,45 @@ class VichFileType extends AbstractType
     public function getBlockPrefix()
     {
         return 'vich_file';
+    }
+
+    protected function resolveUriOption($uriOption, $object, FormInterface $form)
+    {
+        if (true === $uriOption) {
+            return $this->storage->resolveUri($object, $form->getName());
+        }
+
+        if (is_callable($uriOption)) {
+            return $uriOption($object, $this->storage->resolveUri($object, $form->getName()));
+        }
+
+        return $uriOption;
+    }
+
+    protected function resolveDownloadLabel($downloadLabel, $object, FormInterface $form)
+    {
+        if (true === $downloadLabel) {
+            $mapping = $this->factory->fromField($object, $form->getName());
+
+            return ['download_label' => $mapping->readProperty($object, 'originalName'), 'translation_domain' => false];
+        }
+
+        if (is_callable($downloadLabel)) {
+            $result = $downloadLabel($object);
+
+            return [
+                'download_label' => isset($result['download_label']) ? $result['download_label'] : $result,
+                'translation_domain' => isset($result['translation_domain']) ? $result['translation_domain'] : false,
+            ];
+        }
+
+        if ($downloadLabel instanceof PropertyPath) {
+            return [
+                'download_label' => $this->propertyAccessor->getValue($object, $downloadLabel),
+                'translation_domain' => false,
+            ];
+        }
+
+        return ['download_label' => $downloadLabel];
     }
 }

--- a/Form/Type/VichImageType.php
+++ b/Form/Type/VichImageType.php
@@ -2,24 +2,84 @@
 
 namespace Vich\UploaderBundle\Form\Type;
 
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Storage\StorageInterface;
 
+/**
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ * @author Konstantin Myakshin <koc-dp@yandex.ru>
+ * @author Massimiliano Arione <max.arione@gmail.com>
+ */
 class VichImageType extends VichFileType
 {
+    /**
+     * @var CacheManager
+     */
+    private $cacheManager;
+
+    public function __construct(StorageInterface $storage, UploadHandler $handler, PropertyMappingFactory $factory, PropertyAccessorInterface $propertyAccessor = null, CacheManager $cacheManager = null)
+    {
+        parent::__construct($storage, $handler, $factory, $propertyAccessor);
+        $this->cacheManager = $cacheManager;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults([
+            'image_uri' => true,
+            'imagine_pattern' => null,
+        ]);
+
+        $resolver->setAllowedTypes('image_uri', ['bool', 'string', 'callable']);
+
+        $imageUriNormalizer = function (Options $options, $imageUri) {
+            return null !== $imageUri ? $imageUri : $options['download_uri'];
+        };
+
+        $resolver->setNormalizer('image_uri', $imageUriNormalizer);
+    }
+
     /**
      * {@inheritdoc}
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $object = $form->getParent()->getData();
-
         $view->vars['object'] = $object;
-        $view->vars['show_download_link'] = $options['download_link'];
+        $view->vars['image_uri'] = null;
 
         if ($object) {
-            $view->vars['download_uri'] = $options['download_uri']
-                ?: $this->storage->resolveUri($object, $form->getName());
+            if ($options['imagine_pattern']) {
+                if (!$this->cacheManager) {
+                    throw new \RuntimeException('LiipImagineBundle must be installed and configured for using "imagine_pattern" option.');
+                }
+
+                $uri = $this->storage->resolveUri($object, $form->getName());
+                if ($uri) {
+                    $view->vars['image_uri'] = $this->cacheManager->getBrowserPath($uri, $options['imagine_pattern']);
+                }
+            } else {
+                $view->vars['image_uri'] = $this->resolveUriOption($options['image_uri'], $object, $form);
+            }
+
+            $view->vars = array_replace(
+                $view->vars,
+                $this->resolveDownloadLabel($options['download_label'], $object, $form)
+            );
+
+            $view->vars['download_uri'] = $this->resolveUriOption($options['download_uri'], $object, $form);
+            // required for BC
+            //TODO: remove for 2.0
+            $view->vars['show_download_link'] = !empty($view->vars['download_uri']);
         }
     }
 

--- a/Mapping/PropertyMapping.php
+++ b/Mapping/PropertyMapping.php
@@ -361,6 +361,7 @@ class PropertyMapping
 
     protected function getAccessor()
     {
+        //TODO: reuse original property accessor from forms
         if ($this->accessor !== null) {
             return $this->accessor;
         }

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -7,14 +7,17 @@
         <service id="vich_uploader.form.type.file" class="Vich\UploaderBundle\Form\Type\VichFileType">
             <argument type="service" id="vich_uploader.storage" />
             <argument type="service" id="vich_uploader.upload_handler" />
-
+            <argument type="service" id="vich_uploader.property_mapping_factory" />
+            <argument type="service" id="form.property_accessor" />
             <tag name="form.type" alias="vich_file" />
         </service>
 
         <service id="vich_uploader.form.type.image" class="Vich\UploaderBundle\Form\Type\VichImageType">
             <argument type="service" id="vich_uploader.storage" />
             <argument type="service" id="vich_uploader.upload_handler" />
-
+            <argument type="service" id="vich_uploader.property_mapping_factory" />
+            <argument type="service" id="form.property_accessor" />
+            <argument type="service" id="liip_imagine.cache.manager" on-invalid="null" />
             <tag name="form.type" alias="vich_image" />
         </service>
     </services>

--- a/Resources/doc/downloads/serving_files_with_a_controller.md
+++ b/Resources/doc/downloads/serving_files_with_a_controller.md
@@ -39,15 +39,17 @@ class AcmeController extends Controller
     public function downloadImageAction(Image $image)
     {
         $downloadHandler = $this->get('vich_uploader.download_handler');
-        $imageFileName   = 'foo.png';
+        $fileName   = 'foo.png';
 
-        return $downloadHandler->downloadObject($image, $fileField = 'imageFile', $objectClass = null, $imageFileName);
+        return $downloadHandler->downloadObject($image, $fileField = 'imageFile', $objectClass = null, $fileName);
     }
 }
 ```
 
-By setting the `$imageFileName` variable to *foo.png*, I ensure that no matter
+By setting the `$fileName` variable to *foo.png*, I ensure that no matter
 the original filename of the file, it will be downloaded as *foo.png*.
+
+You can pass `true` as `$fileName` and in this case file will be served with original file name.
 
 Using this feature, using a *unique id namer* to store the file and restore
 their original name only when they are downloaded is possible (as long as you

--- a/Resources/doc/form/vich_file_type.md
+++ b/Resources/doc/form/vich_file_type.md
@@ -1,5 +1,5 @@
-VichFileType
-============
+VichFileType Field
+==================
 
 The bundle provides a custom form type in order to ease the upload, deletion and
 download of files.
@@ -19,27 +19,87 @@ class Form extends AbstractType
 
         $builder->add('genericFile', VichFileType::class, [
             'required' => false,
-            'allow_delete' => true, // optional, default is true
-            'download_link' => true, // optional, default is true
-            'download_uri' => '...', // optional, if not provided - will automatically resolved using storage
+            'allow_delete' => true, 
+            'download_uri' => '...',
+            'download_label' => '...',
         ]);
     }
 }
 ```
 
-For the form type to fully work, you'll also have to use the form theme bundled
-with VichUploaderBundle.
+allow_delete
+------------
+**type**: `bool` **default**: `true`
 
-```yaml
-# app/config/config.yml
-twig:
-    form_themes:
-        # other form themes
-        - 'VichUploaderBundle:Form:fields.html.twig'
+download_uri
+------------
+**type**: `bool`, `string`, `callable` **default**: `true`
+
+If set to `true`, download uri will automatically resolved using storage.
+
+Can be string
+
+```php
+use Vich\UploaderBundle\Form\Type\VichFileType;
+
+$builder->add('genericFile', VichFileType::class, [
+    'download_uri' => $router->generateUrl('acme_download_image', $product->getId()),
+]);
+
 ```
 
-See [Symfony's documentation on form themes](https://symfony.com/doc/current/form/form_customization.html#form-theming)
-for more information.
+Can be callable
+
+```php
+use Vich\UploaderBundle\Form\Type\VichFileType;
+
+$builder->add('genericFile', VichFileType::class, [
+    'download_uri' => function (Product $product) use ($router) {
+        return $router->generateUrl('acme_download_image', $product->getId());
+    },
+]);
+
+```
+
+download_label
+--------------
+**type**: `bool`, `string`, `callable`, `Symfony\Component\PropertyAccess\PropertyPath` **default**: `'download'`
+
+If set to `true`, download label will use original file name.
+
+Can be string 
+```php
+use Vich\UploaderBundle\Form\Type\VichFileType;
+
+$builder->add('genericFile', VichFileType::class, [
+    'download_label' => 'download_file',
+]);
+
+```
+
+Can be callable
+
+```php
+use Vich\UploaderBundle\Form\Type\VichFileType;
+
+$builder->add('genericFile', VichFileType::class, [
+    'download_label' => function (Product $product) {
+        return $product->getTitle();
+    },
+]);
+
+```
+
+Can be property path 
+```php
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Vich\UploaderBundle\Form\Type\VichFileType;
+
+$builder->add('genericFile', VichFileType::class, [
+    'download_label' => new PropertyPath('title'),
+]);
+
+```
 
 ## That was it!
 

--- a/Resources/doc/form/vich_image_type.md
+++ b/Resources/doc/form/vich_image_type.md
@@ -1,5 +1,5 @@
-VichImageType
-=============
+VichImageType Field
+===================
 
 The bundle provides a custom form type in order to ease the upload, deletion and
 download of images.
@@ -19,27 +19,141 @@ class Form extends AbstractType
 
         $builder->add('imageFile', VichImageType::class, [
             'required' => false,
-            'allow_delete' => true, // optional, default is true
-            'download_link' => true, // optional, default is true
-            'download_uri' => '...', // optional, if not provided - will automatically resolved using storage
+            'allow_delete' => true,
+            'download_label' => '...',
+            'download_uri' => true,
+            'image_uri' => true,
+            'imagine_pattern' => '...',
         ]);
     }
 }
 ```
 
-For the form type to fully work, you'll also have to use the form theme bundled
-with VichUploaderBundle.
+allow_delete
+------------
+**type**: `bool` **default**: `true`
 
-```yaml
-# app/config/config.yml
-twig:
-    form_themes:
-        # other form themes
-        - 'VichUploaderBundle:Form:fields.html.twig'
+download_uri
+------------
+**type**: `bool`, `string`, `callable` **default**: `true`
+
+If set to `true`, download uri will automatically resolved using storage.
+
+Can be string
+
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'download_uri' => $router->generateUrl('acme_download_image', $product->getId()),
+]);
+
 ```
 
-See [Symfony's documentation on form themes](https://symfony.com/doc/current/form/form_customization.html#form-theming)
-for more information.
+Can be callable
+
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'download_uri' => function (Product $product) use ($router) {
+        return $router->generateUrl('acme_download_image', $product->getId());
+    },
+]);
+
+```
+
+download_label
+--------------
+**type**: `bool`, `string`, `callable`, `Symfony\Component\PropertyAccess\PropertyPath` **default**: `'download'`
+
+If set to `true`, download label will use original file name.
+
+Can be string 
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'download_label' => 'download_file',
+]);
+
+```
+
+Can be callable
+
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'download_label' => function (Product $product) {
+        return $product->getTitle();
+    },
+]);
+
+```
+
+Can be property path 
+```php
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'download_label' => new PropertyPath('title'),
+]);
+
+```
+
+image_uri
+---------
+**type**: `bool`, `string`, `callable` **default**: `true`
+
+If set to `true`, download uri will automatically resolved using storage.
+
+Can be string
+
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'image_uri' => 'full uri for image',
+]);
+
+```
+
+Can be callable
+
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'image_uri' => function (Photo $photo, $resolvedUri) use ($cacheManager) {
+        // $cacheManager is LiipImagine cache manager
+        return $cacheManager->getBrowserPath(
+            $resolvedUri,
+            'photo_thumb',
+            ['thumbnail' => ['size' => [$photo->getWidth(), $photo->getHeigth()]]]
+        );
+    },
+]);
+
+```
+
+imagine_pattern
+------------
+**type**: `string` **default**: `null`
+
+If set, image will automatically transformed using [LiipImagineBundle](https://github.com/liip/LiipImagineBundle/).
+
+Example
+
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('photo', VichImageType::class, [
+    'imagine_pattern' => 'product_photo_320x240',
+]);
+
+```
 
 ## That was it!
 

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -4,18 +4,18 @@
 {%- endblock %}
 
 {% block vich_file_widget %}
-{% spaceless %}
-    <div class="vich-file">
-        {{ form_widget(form.file) }}
-        {% if form.delete is defined %}
-        {{ form_row(form.delete) }}
-        {% endif %}
+    {% spaceless %}
+        <div class="vich-file">
+            {{ form_widget(form.file) }}
+            {% if form.delete is defined %}
+                {{ form_row(form.delete) }}
+            {% endif %}
 
-        {% if download_uri is defined and download_uri %}
-        <a href="{{ download_uri }}">{{ 'download'|trans({}, 'VichUploaderBundle') }}</a>
-        {% endif %}
-    </div>
-{% endspaceless %}
+            {% if download_uri %}
+                <a href="{{ download_uri }}">{{ translation_domain is same as(false) ? download_label : download_label|trans({}, translation_domain) }}</a>
+            {% endif %}
+        </div>
+    {% endspaceless %}
 {% endblock %}
 
 {% block vich_image_row -%}
@@ -24,19 +24,19 @@
 {%- endblock %}
 
 {% block vich_image_widget %}
-{% spaceless %}
-    <div class="vich-image">
-        {{ form_widget(form.file) }}
-        {% if form.delete is defined %}
-        {{ form_row(form.delete) }}
-        {% endif %}
+    {% spaceless %}
+        <div class="vich-image">
+            {{ form_widget(form.file) }}
+            {% if form.delete is defined %}
+                {{ form_row(form.delete) }}
+            {% endif %}
 
-        {% if download_uri is defined and download_uri %}
-         <a href="{{ download_uri }}"><img src="{{ download_uri }}" alt="" /></a>
-        {% endif %}
-        {% if show_download_link and download_uri is defined and download_uri%}
-        <a href="{{ download_uri }}">{{ 'download'|trans({}, 'VichUploaderBundle') }}</a>
-        {% endif %}
-    </div>
-{% endspaceless %}
+            {% if image_uri %}
+                <a href="{{ image_uri }}"><img src="{{ image_uri }}" alt="" /></a>
+            {% endif %}
+            {% if download_uri %}
+                <a href="{{ download_uri }}">{{ translation_domain is same as(false) ? download_label : download_label|trans({}, translation_domain) }}</a>
+            {% endif %}
+        </div>
+    {% endspaceless %}
 {% endblock %}

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -5,8 +5,6 @@ namespace Vich\UploaderBundle\Storage;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 
 /**
- * StorageInterface.
- *
  * @author Dustin Dobervich <ddobervich@gmail.com>
  */
 interface StorageInterface
@@ -32,23 +30,25 @@ interface StorageInterface
      * Resolves the path for a file based on the specified object
      * and mapping name.
      *
-     * @param object $obj       The object
-     * @param string $fieldName The field to use
-     * @param string $className The object's class. Mandatory if $obj can't be used to determine it
-     * @param bool   $relative  Whether the path should be relative or absolute
+     * @param object|array $obj       The object
+     * @param string       $fieldName The field to use
+     * @param string       $className The object's class. Mandatory if $obj can't be used to determine it
+     * @param bool         $relative  Whether the path should be relative or absolute
      *
      * @return string The path
      */
     public function resolvePath($obj, $fieldName, $className = null, $relative = false);
 
+    //TODO: inconsistency - use PropertyMapping instead of fieldName+className
+
     /**
      * Resolves the uri based on the specified object and mapping name.
      *
-     * @param object $obj       The object
-     * @param string $fieldName The field to use
-     * @param string $className The object's class. Mandatory if $obj can't be used to determine it
+     * @param object|array $obj       The object
+     * @param string       $fieldName The field to use
+     * @param string       $className The object's class. Mandatory if $obj can't be used to determine it
      *
-     * @return string The uri
+     * @return string|null The uri or null if file not stored
      */
     public function resolveUri($obj, $fieldName, $className = null);
 
@@ -56,11 +56,11 @@ interface StorageInterface
      * Returns a read-only stream based on the specified object and mapping
      * name.
      *
-     * @param object $obj       The object
-     * @param string $fieldName The field to use
-     * @param string $className The object's class. Mandatory if $obj can't be used to determine it
+     * @param object|array $obj       The object
+     * @param string       $fieldName The field to use
+     * @param string       $className The object's class. Mandatory if $obj can't be used to determine it
      *
-     * @return string The uri
+     * @return resource|null The resolved resource or null if file not stored
      */
     public function resolveStream($obj, $fieldName, $className = null);
 }

--- a/Templating/Helper/UploaderHelper.php
+++ b/Templating/Helper/UploaderHelper.php
@@ -41,11 +41,11 @@ class UploaderHelper extends Helper
      * Gets the public path for the file associated with the
      * object.
      *
-     * @param object $obj       The object
-     * @param string $fieldName The field name
-     * @param string $className The object's class. Mandatory if $obj can't be used to determine it
+     * @param object|array $obj       The object
+     * @param string       $fieldName The field name
+     * @param string       $className The object's class. Mandatory if $obj can't be used to determine it
      *
-     * @return string The public asset path
+     * @return string|null The public asset path or null if file not stored
      */
     public function asset($obj, $fieldName, $className = null)
     {

--- a/Tests/Fixtures/App/src/TestBundle/Entity/Product.php
+++ b/Tests/Fixtures/App/src/TestBundle/Entity/Product.php
@@ -19,6 +19,8 @@ class Product
 
     private $imageOriginalName;
 
+    private $title;
+
     /**
      * @return File
      */
@@ -73,5 +75,15 @@ class Product
     public function setImageOriginalName($imageOriginalName)
     {
         $this->imageOriginalName = $imageOriginalName;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
     }
 }

--- a/Tests/Handler/DownloadHandlerTest.php
+++ b/Tests/Handler/DownloadHandlerTest.php
@@ -2,8 +2,10 @@
 
 namespace Vich\UploaderBundle\Tests\Handler;
 
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Vich\TestBundle\Entity\Product;
 use Vich\UploaderBundle\Handler\DownloadHandler;
-use Vich\UploaderBundle\Tests\DummyEntity;
+use Vich\UploaderBundle\Storage\StorageInterface;
 use Vich\UploaderBundle\Tests\TestCase;
 
 /**
@@ -13,16 +15,22 @@ class DownloadHandlerTest extends TestCase
 {
     protected $factory;
     protected $storage;
+    /**
+     * @var Product
+     */
     protected $object;
+    /**
+     * @var DownloadHandler
+     */
     protected $handler;
     protected $mapping;
 
     protected function setUp()
     {
         $this->factory = $this->getPropertyMappingFactoryMock();
-        $this->storage = $this->createMock('Vich\UploaderBundle\Storage\StorageInterface');
+        $this->storage = $this->createMock(StorageInterface::class);
         $this->mapping = $this->getPropertyMappingMock();
-        $this->object = new DummyEntity();
+        $this->object = new Product();
 
         $this->handler = new DownloadHandler($this->factory, $this->storage);
         $this->factory
@@ -47,8 +55,7 @@ class DownloadHandlerTest extends TestCase
      */
     public function testDownloadObject($fileName, $expectedFileName)
     {
-        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')
-            ->disableOriginalConstructor()->getMock();
+        $file = $this->getUploadedFileMock();
 
         $this->mapping
             ->expects($this->once())
@@ -75,7 +82,7 @@ class DownloadHandlerTest extends TestCase
 
         $response = $this->handler->downloadObject($this->object, 'file_field');
 
-        $this->assertInstanceof('\Symfony\Component\HttpFoundation\StreamedResponse', $response);
+        $this->assertInstanceOf(StreamedResponse::class, $response);
         $this->assertSame(sprintf('attachment; filename="%s"', $expectedFileName), $response->headers->get('Content-Disposition'));
     }
 
@@ -104,14 +111,51 @@ class DownloadHandlerTest extends TestCase
 
         $response = $this->handler->downloadObject($this->object, 'file_field');
 
-        $this->assertInstanceof('\Symfony\Component\HttpFoundation\StreamedResponse', $response);
+        $this->assertInstanceOf(StreamedResponse::class, $response);
         $this->assertSame(sprintf('attachment; filename="%s"', $expectedFileName), $response->headers->get('Content-Disposition'));
+    }
+
+    public function testDownloadObjectCallOriginalName()
+    {
+        $this->object->setImageOriginalName('original-name.jpeg');
+
+        $this->mapping
+            ->expects($this->once())
+            ->method('readProperty')
+            ->with($this->object, 'originalName')
+            ->will($this->returnValue($this->object->getImageOriginalName()));
+
+        $file = $this->getUploadedFileMock();
+
+        $this->mapping
+            ->expects($this->once())
+            ->method('getFile')
+            ->with($this->object)
+            ->will($this->returnValue($file));
+
+        $file
+            ->expects($this->once())
+            ->method('getMimeType')
+            ->will($this->returnValue(null));
+
+        $this->storage
+            ->expects($this->once())
+            ->method('resolveStream')
+            ->with($this->object, 'file_field')
+            ->will($this->returnValue('something not null'));
+
+        $response = $this->handler->downloadObject($this->object, 'file_field', null, true);
+
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertSame(
+            sprintf('attachment; filename="%s"', $this->object->getImageOriginalName()),
+            $response->headers->get('Content-Disposition')
+        );
     }
 
     public function testNonAsciiFilenameIsTransliterated()
     {
-        $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')
-            ->disableOriginalConstructor()->getMock();
+        $file = $this->getUploadedFileMock();
 
         $this->mapping
             ->expects($this->once())
@@ -132,13 +176,13 @@ class DownloadHandlerTest extends TestCase
 
         $response = $this->handler->downloadObject($this->object, 'file_field', null, 'ÉÁŰÚŐPÓÜÉŰÍÍÍÍ$$$$$$$++4334º');
 
-        $this->assertInstanceof('\Symfony\Component\HttpFoundation\StreamedResponse', $response);
+        $this->assertInstanceOf(StreamedResponse::class, $response);
     }
 
     /**
      * @expectedException \Vich\UploaderBundle\Exception\MappingNotFoundException
      */
-    public function testAnExceptionIsThrownIfMappingIsntFound()
+    public function testAnExceptionIsThrownIfMappingIsNotFound()
     {
         $this->factory = $this->getPropertyMappingFactoryMock();
         $this->handler = new DownloadHandler($this->factory, $this->storage);
@@ -149,7 +193,7 @@ class DownloadHandlerTest extends TestCase
     /**
      * @expectedException \Vich\UploaderBundle\Exception\NoFileFoundException
      */
-    public function testAnExceptionIsThrownIfNoFileIsFould()
+    public function testAnExceptionIsThrownIfNoFileIsFound()
     {
         $this->storage
             ->expects($this->once())

--- a/Tests/Vich/UploaderBundle/Tests/Form/Type/VichFileTypeTest.php
+++ b/Tests/Vich/UploaderBundle/Tests/Form/Type/VichFileTypeTest.php
@@ -5,9 +5,14 @@ namespace Vich\UploaderBundle\Tests\Form\Type;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Vich\TestBundle\Entity\Product;
 use Vich\UploaderBundle\Form\Type\VichFileType;
 use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 use Vich\UploaderBundle\Storage\StorageInterface;
 
 class VichFileTypeTest extends TestCase
@@ -15,9 +20,60 @@ class VichFileTypeTest extends TestCase
     const TESTED_TYPE = VichFileType::class;
 
     /**
+     * @dataProvider configureOptionsBCDataProvider
+     * @group legacy
+     * @expectedDeprecation The "download_link" option is deprecated since version 1.6 and will be removed in 2.0. You should use "download_uri" instead.
+     */
+    public function testConfigureOptionsBC($options, $resolvedOptions)
+    {
+        $optionsResolver = new OptionsResolver();
+
+        $storage = $this->createMock(StorageInterface::class);
+        $uploadHandler = $this->createMock(UploadHandler::class);
+        $propertyMappingFactory = $this->createMock(PropertyMappingFactory::class);
+        $propertyAccessor = $this->createMock(PropertyAccessor::class);
+
+        $testedType = static::TESTED_TYPE;
+
+        $type = new $testedType($storage, $uploadHandler, $propertyMappingFactory, $propertyAccessor);
+
+        $type->configureOptions($optionsResolver);
+
+        $resolved = $optionsResolver->resolve($options);
+        $this->assertArraySubset($resolvedOptions, $resolved);
+    }
+
+    public function configureOptionsBCDataProvider()
+    {
+        return [
+            [['download_link' => true], ['download_uri' => true]],
+            [['download_link' => false], ['download_uri' => false]],
+        ];
+    }
+
+    public function testEmptyDownloadLinkDoNotThrowsDeprecation()
+    {
+        $optionsResolver = new OptionsResolver();
+
+        $storage = $this->createMock(StorageInterface::class);
+        $uploadHandler = $this->createMock(UploadHandler::class);
+        $propertyMappingFactory = $this->createMock(PropertyMappingFactory::class);
+        $propertyAccessor = $this->createMock(PropertyAccessor::class);
+
+        $testedType = static::TESTED_TYPE;
+
+        $type = new $testedType($storage, $uploadHandler, $propertyMappingFactory, $propertyAccessor);
+
+        $type->configureOptions($optionsResolver);
+
+        $resolved = $optionsResolver->resolve([]);
+        $this->assertArraySubset(['download_uri' => true, 'download_link' => null], $resolved);
+    }
+
+    /**
      * @dataProvider buildViewDataProvider
      */
-    public function testBuildView($object, array $options, array $vars)
+    public function testBuildView(Product $object, array $options, array $vars)
     {
         $field = 'image';
 
@@ -44,10 +100,40 @@ class VichFileTypeTest extends TestCase
             ->method('getName')
             ->will($this->returnValue($field));
 
+        $uploadHandler = $this->createMock(UploadHandler::class);
+        $propertyMappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        $propertyAccessor = $this->createMock(PropertyAccessor::class);
+
+        if (isset($options['download_label'])) {
+            if (true === $options['download_label']) {
+                $mapping = $this->createMock(PropertyMapping::class);
+                $mapping
+                    ->expects($this->once())
+                    ->method('readProperty')
+                    ->with($object, 'originalName')
+                    ->will($this->returnValue($object->getImageOriginalName()));
+
+                $propertyMappingFactory
+                    ->expects($this->once())
+                    ->method('fromField')
+                    ->with($object, $field)
+                    ->will($this->returnValue($mapping));
+            }
+
+            if ($options['download_label'] instanceof PropertyPath) {
+                $propertyAccessor
+                    ->expects($this->once())
+                    ->method('getValue')
+                    ->with($object, $options['download_label'])
+                    ->will($this->returnValue($object->getTitle()));
+            }
+        }
+
         $testedType = static::TESTED_TYPE;
 
         $view = new FormView();
-        $type = new $testedType($storage, $this->createMock(UploadHandler::class));
+        $type = new $testedType($storage, $uploadHandler, $propertyMappingFactory, $propertyAccessor);
         $type->buildView($view, $form, $options);
         $this->assertEquals($vars, $view->vars);
     }
@@ -55,22 +141,121 @@ class VichFileTypeTest extends TestCase
     public function buildViewDataProvider()
     {
         $object = new Product();
+        $object->setImageOriginalName('image.jpeg');
+        $object->setTitle('Product1');
 
         return [
             [
                 $object,
-                ['download_link' => true, 'download_uri' => null],
-                ['object' => $object, 'download_uri' => 'resolved-uri', 'value' => null, 'attr' => []],
+                ['download_label' => 'custom label', 'download_uri' => true],
+                [
+                    'object' => $object,
+                    'download_label' => 'custom label',
+                    'download_uri' => 'resolved-uri',
+                    'value' => null,
+                    'attr' => [],
+                ],
             ],
             [
                 $object,
-                ['download_link' => false, 'download_uri' => null],
-                ['object' => $object, 'value' => null, 'attr' => []],
+                ['download_label' => 'download', 'download_uri' => false],
+                [
+                    'object' => $object,
+                    'download_uri' => null,
+                    'value' => null,
+                    'attr' => [],
+                ],
             ],
             [
                 $object,
-                ['download_link' => true, 'download_uri' => 'custom-uri'],
-                ['object' => $object, 'download_uri' => 'custom-uri', 'value' => null, 'attr' => []],
+                [
+                    'download_label' => 'download',
+                    'download_uri' => function (Product $product) {
+                        return '/download/'.$product->getImageOriginalName();
+                    },
+                ],
+                [
+                    'object' => $object,
+                    'download_label' => 'download',
+                    'download_uri' => '/download/image.jpeg',
+                    'value' => null,
+                    'attr' => [],
+                ],
+            ],
+            [
+                $object,
+                ['download_label' => 'download', 'download_uri' => 'custom-uri'],
+                [
+                    'object' => $object,
+                    'download_label' => 'download',
+                    'download_uri' => 'custom-uri',
+                    'value' => null,
+                    'attr' => [],
+                ],
+            ],
+            [
+                $object,
+                ['download_label' => true, 'download_uri' => true],
+                [
+                    'object' => $object,
+                    'download_label' => 'image.jpeg',
+                    'translation_domain' => false,
+                    'download_uri' => 'resolved-uri',
+                    'value' => null,
+                    'attr' => [],
+                ],
+            ],
+            [
+                $object,
+                [
+                    'download_label' => function (Product $product) {
+                        return 'prefix-'.$product->getImageOriginalName();
+                    },
+                    'download_uri' => true,
+                ],
+                [
+                    'object' => $object,
+                    'download_label' => 'prefix-image.jpeg',
+                    'translation_domain' => false,
+                    'download_uri' => 'resolved-uri',
+                    'value' => null,
+                    'attr' => [],
+                ],
+            ],
+            [
+                $object,
+                [
+                    'download_label' => function (Product $product) {
+                        return [
+                            'download_label' => 'prefix-'.$product->getImageOriginalName(),
+                            'translation_domain' => 'messages',
+                        ];
+                    },
+                    'download_uri' => true,
+                ],
+                [
+                    'object' => $object,
+                    'download_label' => 'prefix-image.jpeg',
+                    'translation_domain' => 'messages',
+                    'download_uri' => 'resolved-uri',
+                    'value' => null,
+                    'attr' => [],
+                ],
+            ],
+            [
+                $object,
+                [
+                    'download_label' => new PropertyPath('title'),
+                    'download_uri' => true,
+                ],
+                [
+                    'object' => $object,
+                    'download_label' => $object->getTitle(),
+                    'translation_domain' => false,
+                    'download_uri' => 'resolved-uri',
+                    'value' => null,
+                    'attr' => [],
+                ],
             ],
         ];
     }

--- a/Tests/Vich/UploaderBundle/Tests/Form/Type/VichImageTypeTest.php
+++ b/Tests/Vich/UploaderBundle/Tests/Form/Type/VichImageTypeTest.php
@@ -2,8 +2,15 @@
 
 namespace Tests\Vich\UploaderBundle\Tests\Form\Type;
 
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Vich\TestBundle\Entity\Product;
 use Vich\UploaderBundle\Form\Type\VichImageType;
+use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Storage\StorageInterface;
 use Vich\UploaderBundle\Tests\Form\Type\VichFileTypeTest;
 
 class VichImageTypeTest extends VichFileTypeTest
@@ -17,37 +24,198 @@ class VichImageTypeTest extends VichFileTypeTest
         return [
             [
                 $object,
-                ['download_link' => true, 'download_uri' => null],
+                [
+                    'download_uri' => true,
+                    'download_label' => 'download',
+                    'image_uri' => false,
+                    'imagine_pattern' => null,
+                ],
                 [
                     'object' => $object,
-                    'show_download_link' => true,
                     'download_uri' => 'resolved-uri',
+                    'download_label' => 'download',
+                    'image_uri' => null,
+                    'show_download_link' => true,
                     'value' => null,
                     'attr' => [],
                 ],
             ],
             [
                 $object,
-                ['download_link' => false, 'download_uri' => null],
+                [
+                    'download_uri' => false,
+                    'download_label' => 'download',
+                    'image_uri' => true,
+                    'imagine_pattern' => null,
+                ],
                 [
                     'object' => $object,
+                    'download_uri' => false,
+                    'download_label' => 'download',
+                    'image_uri' => 'resolved-uri',
                     'show_download_link' => false,
-                    'download_uri' => 'resolved-uri',
                     'value' => null,
                     'attr' => [],
                 ],
             ],
             [
                 $object,
-                ['download_link' => true, 'download_uri' => 'custom-uri'],
+                [
+                    'download_label' => 'download',
+                    'download_uri' => 'custom-uri',
+                    'image_uri' => true,
+                    'imagine_pattern' => null,
+                ],
                 [
                     'object' => $object,
-                    'show_download_link' => true,
                     'download_uri' => 'custom-uri',
+                    'download_label' => 'download',
+                    'show_download_link' => true,
+                    'image_uri' => 'resolved-uri',
+                    'value' => null,
+                    'attr' => [],
+                ],
+            ],
+            [
+                $object,
+                [
+                    'download_label' => 'download',
+                    'download_uri' => 'custom-uri',
+                    'image_uri' => 'image_uri',
+                    'imagine_pattern' => null,
+                ],
+                [
+                    'object' => $object,
+                    'download_uri' => 'custom-uri',
+                    'download_label' => 'download',
+                    'show_download_link' => true,
+                    'image_uri' => 'image_uri',
+                    'value' => null,
+                    'attr' => [],
+                ],
+            ],
+            [
+                $object,
+                [
+                    'download_label' => 'download',
+                    'download_uri' => 'custom-uri',
+                    'image_uri' => function (Product $product, $resolvedUri) {
+                        return 'prefix-'.$resolvedUri;
+                    },
+                    'imagine_pattern' => null,
+                ],
+                [
+                    'object' => $object,
+                    'download_uri' => 'custom-uri',
+                    'download_label' => 'download',
+                    'show_download_link' => true,
+                    'image_uri' => 'prefix-resolved-uri',
                     'value' => null,
                     'attr' => [],
                 ],
             ],
         ];
+    }
+
+    public function testLiipImagineBundleIntegration()
+    {
+        if (!class_exists(CacheManager::class)) {
+            $this->markTestSkipped('LiipImagineBundle is not installed.');
+        }
+
+        $field = 'image';
+        $object = new Product();
+
+        $storage = $this->createMock(StorageInterface::class);
+        $storage
+            ->expects($this->any())
+            ->method('resolveUri')
+            ->with($object, $field)
+            ->will($this->returnValue('resolved-uri'));
+
+        $parentForm = $this->createMock(FormInterface::class);
+        $parentForm
+            ->expects($this->any())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
+        $form = $this->createMock(FormInterface::class);
+        $form
+            ->expects($this->any())
+            ->method('getParent')
+            ->will($this->returnValue($parentForm));
+        $form
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue($field));
+
+        $uploadHandler = $this->createMock(UploadHandler::class);
+        $propertyMappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        $propertyAccessor = $this->createMock(PropertyAccessor::class);
+        $cacheManager = $this->createMock(CacheManager::class);
+
+        $cacheManager
+            ->expects($this->once())
+            ->method('getBrowserPath')
+            ->with('resolved-uri', 'product_sq200')
+            ->will($this->returnValue('product_sq200/resolved-uri'));
+
+        $testedType = static::TESTED_TYPE;
+
+        $view = new FormView();
+        $type = new $testedType($storage, $uploadHandler, $propertyMappingFactory, $propertyAccessor, $cacheManager);
+
+        $options = [
+            'download_label' => 'download',
+            'download_uri' => 'custom-uri',
+            'image_uri' => true,
+            'imagine_pattern' => 'product_sq200',
+        ];
+
+        $vars = [
+            'object' => $object,
+            'download_uri' => 'custom-uri',
+            'download_label' => 'download',
+            'show_download_link' => true,
+            'image_uri' => 'product_sq200/resolved-uri',
+            'value' => null,
+            'attr' => [],
+        ];
+
+        $type->buildView($view, $form, $options);
+        $this->assertEquals($vars, $view->vars);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage LiipImagineBundle must be installed and configured for using "imagine_pattern" option.
+     */
+    public function testLiipImagineBundleIntegrationThrownExceptionIfNotAvailable()
+    {
+        $object = new Product();
+
+        $testedType = static::TESTED_TYPE;
+
+        $storage = $this->createMock(StorageInterface::class);
+        $uploadHandler = $this->createMock(UploadHandler::class);
+        $propertyMappingFactory = $this->createMock(PropertyMappingFactory::class);
+        $propertyAccessor = $this->createMock(PropertyAccessor::class);
+
+        $parentForm = $this->createMock(FormInterface::class);
+        $parentForm
+            ->expects($this->any())
+            ->method('getData')
+            ->will($this->returnValue($object));
+
+        $form = $this->createMock(FormInterface::class);
+        $form
+            ->expects($this->any())
+            ->method('getParent')
+            ->will($this->returnValue($parentForm));
+
+        $view = new FormView();
+        $type = new $testedType($storage, $uploadHandler, $propertyMappingFactory, $propertyAccessor);
+        $type->buildView($view, $form, ['imagine_pattern' => 'product_sq200']);
     }
 }

--- a/Twig/Extension/UploaderExtension.php
+++ b/Twig/Extension/UploaderExtension.php
@@ -56,7 +56,7 @@ class UploaderExtension extends \Twig_Extension
      * @param string $fieldName The field name
      * @param string $className The object's class. Mandatory if $obj can't be used to determine it
      *
-     * @return string The public path
+     * @return string|null The public path or null if file not stored
      */
     public function asset($obj, $fieldName, $className = null)
     {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,8 +1,10 @@
-Upgrading from v1.0.0 to master
-===============================
+Upgrading from v1.0.0 to 1.6.0
+==============================
 
-The transliteration is now using `behat\transliterator` instead of a custom one. Some minor
+- the transliteration is now using `behat\transliterator` instead of a custom one. Some minor
 differences are that dash is not preserved anymore and names are lowercased.
+- the form option `download_link` now is deprecated, use `download_uri` instead.
+
 
 Upgrading from v0.14.0 to v1.0.0
 ================================
@@ -15,7 +17,7 @@ Upgrading from v0.13.0 to v0.14.0
 No BC breaks.
 
 Upgrading from v0.12.0 to v0.13.0
-================================
+=================================
 
 - the `resolvePath` and `resolveUri` Storage methods now take a field name
   instead of a mapping name. The same goes for the UploaderExtension and
@@ -25,7 +27,7 @@ Upgrading from v0.12.0 to v0.13.0
   inferred from the field's name.
 
 Upgrading from v0.11.0 to v0.12.0
-================================
+=================================
 
 - the `storage` configuration paramater changed. It accepts the name of the
   storage engine to use (file_system, gaufrette or flysystem).
@@ -49,7 +51,7 @@ Upgrading from v0.9.0 to v0.10.0
   UploaderHelper `asset` method.
 
 Upgrading from v0.5.0 to 0.6.0
-===============================
+==============================
 
 - `getUriPrefix` default value is now /uploads
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,10 @@
     "name": "vich/uploader-bundle",
     "type": "symfony-bundle",
     "description": "Ease file uploads attached to entities",
-    "keywords": ["file uploads", "upload"],
+    "keywords": [
+        "file uploads",
+        "upload"
+    ],
     "homepage": "https://github.com/dustin10/VichUploaderBundle",
     "license": "MIT",
     "authors": [
@@ -30,15 +33,12 @@
         "jms/metadata": "^1.6"
     },
     "require-dev": {
-        "ext-sqlite3" : "*",
-
+        "ext-sqlite3": "*",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/orm": "^2.5",
         "doctrine/mongodb-odm": "^1.1",
-
         "knplabs/knp-gaufrette-bundle": "^0.4",
         "oneup/flysystem-bundle": "^1.7",
-
         "symfony/browser-kit": "^2.8|^3.1",
         "symfony/css-selector": "^2.8|^3.1",
         "symfony/dom-crawler": "^2.8|^3.1",
@@ -47,7 +47,6 @@
         "symfony/twig-bundle": "^2.8|^3.1",
         "symfony/validator": "^2.8|^3.1",
         "symfony/yaml": "^2.8|^3.1",
-
         "phpunit/phpunit": "^6.0",
         "mikey179/vfsStream": "^1.6",
         "matthiasnoback/symfony-dependency-injection-test": "^2.0"
@@ -59,7 +58,8 @@
         "doctrine/mongodb-odm-bundle": "*",
         "knplabs/knp-gaufrette-bundle": "^0.4",
         "willdurand/propel-eventdispatcher-bundle": "^1.2",
-        "symfony/yaml": "^2.8|^3.1"
+        "symfony/yaml": "^2.8|^3.1",
+        "liip/imagine-bundle": "^1.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Notable changes:
- form theme is automatically registered now - no config changes required (DX, also needed for https://github.com/symfony/recipes-contrib/pull/22 )
- `VichFileType`: `download_link` deprecated with `download_uri`, which supports callable
- `VichFileType`: `download_label` now supports `true` (use original file name), `callable` and instances of `PropertyPath`
- `VichFileType`: unified `translation_domain` option usage
- `VichImageType`: added option `image_uri`
- `VichImageType`: added optional integration with LiipImagineBundle
- download handler now supports `true` (use original file name) as served file name
- fixed phpdocs for `StorageInterface`, `UploaderHelper`, `DownloadHandler`
- reorganized test suite: validate docs separately from unit tests