### PR TITLE
Added symfony validation for non ascii characters

### DIFF
--- a/Tests/Handler/DownloadHandlerTest.php
+++ b/Tests/Handler/DownloadHandlerTest.php
@@ -130,7 +130,7 @@ class DownloadHandlerTest extends TestCase
             ->with($this->object, 'file_field')
             ->will($this->returnValue('something not null'));
 
-        $response = $this->handler->downloadObject($this->object, 'file_field', null, 'ÉÁŰÚŐPÓÜÉŰÍÍÍÍ$$$$$$$++4334');
+        $response = $this->handler->downloadObject($this->object, 'file_field', null, 'ÉÁŰÚŐPÓÜÉŰÍÍÍÍ$$$$$$$++4334º');
 
         $this->assertInstanceof('\Symfony\Component\HttpFoundation\StreamedResponse', $response);
     }

--- a/Util/Transliterator.php
+++ b/Util/Transliterator.php
@@ -12,6 +12,7 @@ class Transliterator
             $string = $transliterator->transliterate($string);
             $string = preg_replace('/[^\\pL\d._]+/u', '-', $string);
             $string = preg_replace('/[-\s]+/', '-', $string);
+            $string = preg_replace('/[^\x20-\x7e]/', '', $string); // symfony validate by this
         } else {
             // uses iconv
             $string = preg_replace('~[^\\pL0-9_\.]+~u', '-', $string); // substitutes anything but letters, numbers and '-' with separator
@@ -20,6 +21,7 @@ class Transliterator
                 $string = iconv('utf-8', 'us-ascii//TRANSLIT', $string); // TRANSLIT does the whole job
             }
             $string = preg_replace('~[^-a-zA-Z0-9_\.]+~', '', $string); // keep only letters, numbers, '_' and separator
+            $string = preg_replace('/[^\x20-\x7e]/', '', $string); // symfony validate by this
         }
 
         $string = trim($string, '-');


### PR DESCRIPTION
I have a problem with the character º in a filename. Does not pass symfony validations to accept only ascii characters

Symfony make this validation for non ascii characters for filename. See the code [here](https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php#L287)

So, I added a replace with the same regex in the funcion Vich\UploaderBundle\Util\Transliterator::transliterate