### PR TITLE
New service requirement breaks bc

### DIFF
--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -8,7 +8,7 @@
             <argument type="service" id="vich_uploader.storage" />
             <argument type="service" id="vich_uploader.upload_handler" />
             <argument type="service" id="vich_uploader.property_mapping_factory" />
-            <argument type="service" id="form.property_accessor" />
+            <argument type="service" id="property_accessor" />
             <tag name="form.type" alias="vich_file" />
         </service>
 
@@ -16,7 +16,7 @@
             <argument type="service" id="vich_uploader.storage" />
             <argument type="service" id="vich_uploader.upload_handler" />
             <argument type="service" id="vich_uploader.property_mapping_factory" />
-            <argument type="service" id="form.property_accessor" />
+            <argument type="service" id="property_accessor" />
             <argument type="service" id="liip_imagine.cache.manager" on-invalid="null" />
             <tag name="form.type" alias="vich_image" />
         </service>


### PR DESCRIPTION
The `form.property_accessor` service is a dependency since 1.6.0. This requires symfony's form component to be enabled or other measures from the user if that was not the case. This service happens to be an alias for the more common `property_accessor`.
While I can come up with a reason to use `form.property_accessor`, using this service is more likely to break applications then while using `property_accessor`, like in my case, where I'm building an API and thus don't need the form component to be enabled in the framework, where `form.property_accessor` is part of.
So while this still is not bc proof, this pr could mitigate the problem a bit.