### PR TITLE
Add options to not load form and templating services

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -66,7 +66,9 @@ class Configuration implements ConfigurationInterface
                         ->thenInvalid('The storage %s is not supported. Please choose one of '.implode(', ', $this->supportedStorages).' or provide a service name prefixed with "@".')
                     ->end()
                 ->end()
-                ->scalarNode('twig')->defaultTrue()->end()
+            ->scalarNode('templating')->defaultTrue()->end()
+            ->scalarNode('twig')->defaultTrue()->info('twig requires templating')->end()
+            ->scalarNode('form')->defaultTrue()->end()
             ->end()
         ;
     }

--- a/DependencyInjection/VichUploaderExtension.php
+++ b/DependencyInjection/VichUploaderExtension.php
@@ -63,8 +63,7 @@ class VichUploaderExtension extends Extension
 
         $toLoad = [
             'adapter.xml', 'listener.xml', 'storage.xml', 'injector.xml',
-            'templating.xml', 'mapping.xml', 'factory.xml', 'namer.xml',
-            'form.xml', 'handler.xml',
+            'mapping.xml', 'factory.xml', 'namer.xml', 'handler.xml',
         ];
         foreach ($toLoad as $file) {
             $loader->load($file);
@@ -74,7 +73,13 @@ class VichUploaderExtension extends Extension
             $loader->load($config['storage'].'.xml');
         }
 
-        if ($config['twig']) {
+        if ($config['form']) {
+            $loader->load('form.xml');
+        }
+        if ($config['templating']) {
+            $loader->load('templating.xml');
+        }
+        if ($config['twig'] && $config['templating']) {
             $loader->load('twig.xml');
         }
     }

--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -8,8 +8,10 @@ Below is the full default configuration for the bundle:
 ``` yaml
 # app/config/config.yml
 vich_uploader:
-    db_driver:  orm # or mongodb or propel or phpcr - default db driver
-    twig:       true
+    db_driver:  orm         # or mongodb or propel or phpcr - default db driver
+    templating: true        # set to false to disable templating integration 
+    twig:       true        # set to false to disable twig integration (requires templating)                  
+    form:       true        # set to false to disable form integration
     storage:    file_system # or gaufrette or flysystem
     mappings:
         product_image:

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "symfony/dependency-injection": "^2.8|^3.1",
         "symfony/finder": "^2.8|^3.1",
         "symfony/framework-bundle": "^2.8|^3.1",
-        "symfony/property-access": "^2.8|^3.1",
-        "symfony/templating": "^2.8|^3.1"
+        "symfony/property-access": "^2.8|^3.1"
     },
     "require-dev": {
         "ext-sqlite3": "*",
@@ -46,7 +45,8 @@
         "symfony/form": "^2.8|^3.1",
         "symfony/twig-bridge": "^2.8.10|^3.1",
         "symfony/twig-bundle": "^2.8|^3.1",
-        "symfony/yaml": "^2.8|^3.1"
+        "symfony/yaml": "^2.8|^3.1",
+        "symfony/templating": "^2.8|^3.1"
     },
     "suggest": {
         "doctrine/orm": "^2.5",


### PR DESCRIPTION
This makes loading of form and templating services optional, like it's already optional to load twig stuff.
This helps minimize APIs, and also offers a ways to work around requiring `form.property_access`, that is a dependency of this bundle since 1.6.0.