### PR TITLE
Stop using deprecated code

### DIFF
--- a/Adapter/PHPCR/PHPCRAdapter.php
+++ b/Adapter/PHPCR/PHPCRAdapter.php
@@ -5,8 +5,6 @@ namespace Vich\UploaderBundle\Adapter\PHPCR;
 use Vich\UploaderBundle\Adapter\AdapterInterface;
 
 /**
- * PHPCRAdapter.
- *
  * @author Ben Glassman <bglassman@gmail.com>
  */
 class PHPCRAdapter implements AdapterInterface
@@ -16,7 +14,7 @@ class PHPCRAdapter implements AdapterInterface
      */
     public function getObjectFromArgs($event)
     {
-        return $event->getEntity();
+        return $event->getObject();
     }
 
     /**

--- a/Tests/Adapter/PHPCR/PHPCRAdapterTest.php
+++ b/Tests/Adapter/PHPCR/PHPCRAdapterTest.php
@@ -2,20 +2,19 @@
 
 namespace Vich\UploaderBundle\Tests\Adapter\PHPCR;
 
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use PHPUnit\Framework\TestCase;
 use Vich\UploaderBundle\Adapter\PHPCR\PHPCRAdapter;
 use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
- * PHPCRAdapterTest.
- *
  * @author Ben Glassman <bglassman@gmail.com>
  */
 class PHPCRAdapterTest extends TestCase
 {
     public static function setUpBeforeClass()
     {
-        if (!class_exists('Doctrine\Common\Persistence\Event\LifecycleEventArgs')) {
+        if (!class_exists(LifecycleEventArgs::class)) {
             self::markTestSkipped('Doctrine\Common\Persistence\Event\LifecycleEventArgs does not exist.');
         }
     }
@@ -27,12 +26,10 @@ class PHPCRAdapterTest extends TestCase
     {
         $entity = new DummyEntity();
 
-        $args = $this->getMockBuilder('Doctrine\Common\Persistence\Event\LifecycleEventArgs')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $args = $this->createMock(LifecycleEventArgs::class);
         $args
             ->expects($this->once())
-            ->method('getEntity')
+            ->method('getObject')
             ->will($this->returnValue($entity));
 
         $adapter = new PHPCRAdapter();

--- a/Tests/Fixtures/App/app/config/routing.yml
+++ b/Tests/Fixtures/App/app/config/routing.yml
@@ -1,19 +1,19 @@
 upload:
-    path:           /upload/{formType}
-    defaults:       { _controller: VichTestBundle:Default:upload }
-    requirements:   { _method: GET }
+    path: /upload/{formType}
+    methods: GET
+    defaults: { _controller: VichTestBundle:Default:upload }
 
 upload_send:
-    path:           /upload/{formType}/send
-    defaults:       { _controller: VichTestBundle:Default:submit }
-    requirements:   { _method: POST }
+    path: /upload/{formType}/send
+    methods: POST
+    defaults: { _controller: VichTestBundle:Default:submit }
 
 upload_edit:
-    path:           /upload/{formType}/send/{imageId}
-    defaults:       { _controller: VichTestBundle:Default:submit }
-    requirements:   { _method: POST }
+    path: /upload/{formType}/send/{imageId}
+    methods: POST
+    defaults: { _controller: VichTestBundle:Default:submit }
 
 view:
-    path:           /upload/{imageId}/{formType}
-    defaults:       { _controller: VichTestBundle:Default:edit }
-    requirements:   { _method: GET }
+    path: /upload/{imageId}/{formType}
+    methods: GET
+    defaults: { _controller: VichTestBundle:Default:edit }


### PR DESCRIPTION
see https://travis-ci.org/dustin10/VichUploaderBundle/jobs/243216587
1. `getEntity` is deprecated, use `getObject` insetad.
2. `_method` requirements is deprecated, use `methods` option instead