### PR TITLE
Fixed more usages of DefinitionDecorator

### DIFF
--- a/DependencyInjection/VichUploaderExtension.php
+++ b/DependencyInjection/VichUploaderExtension.php
@@ -194,10 +194,10 @@ class VichUploaderExtension extends Extension
 
     protected function createNamerService(ContainerBuilder $container, $mappingName, array $mapping)
     {
-        $defitionClassname = $this->getDefinitionClassname();
+        $definitionClassname = $this->getDefinitionClassname();
         $serviceId = sprintf('%s.%s', $mapping['namer']['service'], $mappingName);
         $container->setDefinition(
-            $serviceId, new $defitionClassname($mapping['namer']['service'])
+            $serviceId, new $definitionClassname($mapping['namer']['service'])
         );
 
         $mapping['namer']['service'] = $serviceId;
@@ -207,8 +207,9 @@ class VichUploaderExtension extends Extension
 
     protected function createListener(ContainerBuilder $container, $name, $type, $driver, $priority = 0)
     {
+        $definitionClassname = $this->getDefinitionClassname();
         $definition = $container
-            ->setDefinition(sprintf('vich_uploader.listener.%s.%s', $type, $name), new DefinitionDecorator(sprintf('vich_uploader.listener.%s.%s', $type, $driver)))
+            ->setDefinition(sprintf('vich_uploader.listener.%s.%s', $type, $name), new $definitionClassname(sprintf('vich_uploader.listener.%s.%s', $type, $driver)))
             ->replaceArgument(0, $name)
             ->replaceArgument(1, new Reference('vich_uploader.adapter.'.$driver));
 


### PR DESCRIPTION
This completes 49a32616471ade5eab0c3e50960153a0491662e9 fixing another usage of the deprecated `DefinitionDecorator`.