### PR TITLE
Base64Namer

### DIFF
--- a/Naming/Base64Namer.php
+++ b/Naming/Base64Namer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
+/**
+ * Namer using a random base64 string. The resulting name will contain lower- and uppercase alphanumeric
+ * characters, '-' and '_', so it can be safely used in URLs.
+ *
+ * @author Keleti Márton <tejes@hac.hu>
+ */
+class Base64Namer implements NamerInterface, ConfigurableInterface
+{
+    const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_';
+
+    /** @var int Length of the resulting name. 10 can be decoded to a 64-bit integer. */
+    protected $length = 10;
+
+    /**
+     * Injects configuration options.
+     *
+     * @param array $options Options for this namer. The following options are accepted:
+     *                       - length: the length of the resulting name.
+     */
+    public function configure(array $options)
+    {
+        if (isset($options['length'])) {
+            $this->length = $options['length'];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name($object, PropertyMapping $mapping)
+    {
+        $file = $mapping->getFile($object);
+
+        $name = '';
+        for ($i = 0; $i < $this->length; ++$i) {
+            $name .= $this->getRandomChar();
+        }
+
+        if ($extension = $file->getClientOriginalExtension()) {
+            $name = "$name.$extension";
+        }
+
+        return $name;
+    }
+
+    protected function getRandomChar()
+    {
+        return self::ALPHABET[random_int(0, 63)];
+    }
+}

--- a/Resources/config/namer.xml
+++ b/Resources/config/namer.xml
@@ -9,6 +9,7 @@
         <service id="vich_uploader.namer_property" class="Vich\UploaderBundle\Naming\PropertyNamer" public="true" />
         <service id="vich_uploader.namer_origname" class="Vich\UploaderBundle\Naming\OrignameNamer" public="true" />
         <service id="vich_uploader.namer_hash" class="Vich\UploaderBundle\Naming\HashNamer" public="true" />
+        <service id="vich_uploader.namer_base64" class="Vich\UploaderBundle\Naming\Base64Namer" public="true" />
 
         <service id="vich_uploader.directory_namer_subdir" class="Vich\UploaderBundle\Naming\SubdirDirectoryNamer" public="true" />
         <service id="vich_uploader.namer_directory_property" class="Vich\UploaderBundle\Naming\PropertyDirectoryNamer" public="true">

--- a/Resources/doc/namers.md
+++ b/Resources/doc/namers.md
@@ -16,6 +16,7 @@ At the moment there are several available namers:
   * `vich_uploader.namer_origname`
   * `vich_uploader.namer_property`
   * `vich_uploader.namer_hash`
+  * `vich_uploader.namer_base64`
 
 **vich_uploader.namer_uniqid** will rename your uploaded files using a uniqueid for the name and
 keep the extension. Using this namer, foo.jpg will be uploaded as something like 50eb3db039715.jpg.
@@ -29,6 +30,10 @@ file.
 
 **vich_uploader.namer_hash** will use a hash of random string to name the file. You also can specify
 hash `algorithm` and result `length` of the file
+
+**vich_uploader.namer_base64** will generate a URL-safe base64 decodable random string to name the file.
+You can specify the `length` of the random string. Using this namer, foo.jpg will be uploaded as something
+like 6FMNgvkdUs.jpg
 
 To use it, you just have to specify the service id for the `namer` configuration option of your mapping:
 

--- a/Tests/Naming/Base64NamerTest.php
+++ b/Tests/Naming/Base64NamerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Naming;
+
+use Vich\UploaderBundle\Tests\DummyEntity;
+use Vich\UploaderBundle\Tests\TestCase;
+
+class Base64Namer extends \Vich\UploaderBundle\Naming\Base64Namer
+{
+    protected function getRandomChar()
+    {
+        return 'a';
+    }
+}
+
+/**
+ * @author Keleti Márton <tejes@hac.hu>
+ */
+class Base64NamerTest extends TestCase
+{
+    public function fileDataProvider()
+    {
+        return [
+            ['aaaaaaaaaa.jpg', 'jpg', null],
+            ['aaaaaaaaaa', '', null],
+            ['aaaaaaaa.jpg', 'jpg', 8],
+            ['aaaaaaaaaaaaaaaa.png', 'png', 16],
+        ];
+    }
+
+    /**
+     * @dataProvider fileDataProvider
+     */
+    public function testNameReturnsTheRightName($expectedFileName, $extension, $length)
+    {
+        $file = $this->getUploadedFileMock();
+        $file->expects($this->once())
+            ->method('getClientOriginalExtension')
+            ->will($this->returnValue($extension));
+
+        $entity = new DummyEntity();
+        $entity->setFile($file);
+
+        $mapping = $this->getPropertyMappingMock();
+        $mapping->expects($this->once())
+            ->method('getFile')
+            ->with($entity)
+            ->will($this->returnValue($file));
+
+        $namer = new Base64Namer();
+        $namer->configure(['length' => $length]);
+
+        $this->assertSame($expectedFileName, $namer->name($entity, $mapping));
+    }
+}


### PR DESCRIPTION
I wanted a namer in my application which creates shorter IDs similar to YouTube video IDs. I hope it can be useful to others.
The implementation is based on HashNamer, but since this bundle is targeting PHP7, I used the random_int() function instead. The name is URL-safe and has configurable length.