### PR TITLE
add `dimensions` property for image/* types

### DIFF
--- a/Entity/File.php
+++ b/Entity/File.php
@@ -30,6 +30,11 @@ class File
     protected $size;
 
     /**
+     * @ORM\Column(name="dimensions", type="simple_array", nullable=true)
+     */
+    protected $dimensions;
+
+    /**
      * @return string|null
      */
     public function getName()
@@ -91,5 +96,21 @@ class File
     public function setSize($size)
     {
         $this->size = $size;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getDimensions()
+    {
+        return $this->dimensions;
+    }
+
+    /**
+     * @param array $dimensions
+     */
+    public function setDimensions($dimensions)
+    {
+        $this->dimensions = $dimensions;
     }
 }

--- a/Mapping/Annotation/UploadableField.php
+++ b/Mapping/Annotation/UploadableField.php
@@ -39,6 +39,11 @@ class UploadableField
     protected $originalName;
 
     /**
+     * @var array
+     */
+    protected $dimensions;
+
+    /**
      * Constructs a new instance of UploadableField.
      *
      * @param array $options The options
@@ -102,5 +107,13 @@ class UploadableField
     public function getOriginalName()
     {
         return $this->originalName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDimensions()
+    {
+        return $this->dimensions;
     }
 }

--- a/Mapping/Annotation/UploadableField.php
+++ b/Mapping/Annotation/UploadableField.php
@@ -110,7 +110,7 @@ class UploadableField
     }
 
     /**
-     * @return array
+     * @return array|null
      */
     public function getDimensions()
     {

--- a/Mapping/PropertyMapping.php
+++ b/Mapping/PropertyMapping.php
@@ -43,6 +43,7 @@ class PropertyMapping
         'size' => null,
         'mimeType' => null,
         'originalName' => null,
+        'dimensions' => null,
     ];
 
     /**
@@ -117,7 +118,7 @@ class PropertyMapping
      */
     public function erase($obj)
     {
-        foreach (['name', 'size', 'mimeType', 'originalName'] as $property) {
+        foreach (['name', 'size', 'mimeType', 'originalName', 'dimensions'] as $property) {
             $this->writeProperty($obj, $property, null);
         }
     }

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -55,6 +55,7 @@ class AnnotationDriver implements AdvancedDriverInterface
                 'size' => $uploadableField->getSize(),
                 'mimeType' => $uploadableField->getMimeType(),
                 'originalName' => $uploadableField->getOriginalName(),
+                'dimensions' => $uploadableField->getDimensions(),
             ];
 
             //TODO: store UploadableField object instead of array

--- a/Metadata/Driver/XmlDriver.php
+++ b/Metadata/Driver/XmlDriver.php
@@ -30,6 +30,7 @@ class XmlDriver extends AbstractFileDriver
                 'size' => (string) $field->attributes()->size,
                 'mimeType' => (string) $field->attributes()->mime_type,
                 'originalName' => (string) $field->attributes()->original_name,
+                'dimensions' => $field->attributes()->dimensions,
             ];
 
             $classMetadata->fields[(string) $field->attributes()->name] = $fieldMetadata;

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -31,6 +31,7 @@ class YamlDriver extends AbstractFileDriver
                 'size' => isset($mappingData['size']) ? $mappingData['size'] : null,
                 'mimeType' => isset($mappingData['mime_type']) ? $mappingData['mime_type'] : null,
                 'originalName' => isset($mappingData['original_name']) ? $mappingData['original_name'] : null,
+                'dimensions' => isset($mappingData['dimensions']) ? $mappingData['dimensions'] : null,
             ];
 
             $classMetadata->fields[$field] = $fieldMetadata;

--- a/Resources/doc/mapping/xml.md
+++ b/Resources/doc/mapping/xml.md
@@ -9,7 +9,7 @@ format and comes with the following syntax to declare your uploadable fields:
 <!-- Attributes "mapping", "name" and "filename_property" are required -->
 <vich_uploader class="Acme\DemoBundle\Entity\Product">
     <field mapping="product_image" name="image" filename_property="imageName"
-           size="imageSize", dimensions="imageDimensions" mime_type="imageMimeType" original_name="imageOriginalName" />
+           size="imageSize" dimensions="imageDimensions" mime_type="imageMimeType" original_name="imageOriginalName" />
 </vich_uploader>
 ```
 

--- a/Resources/doc/mapping/xml.md
+++ b/Resources/doc/mapping/xml.md
@@ -9,7 +9,7 @@ format and comes with the following syntax to declare your uploadable fields:
 <!-- Attributes "mapping", "name" and "filename_property" are required -->
 <vich_uploader class="Acme\DemoBundle\Entity\Product">
     <field mapping="product_image" name="image" filename_property="imageName"
-           size="imageSize" mime_type="imageMimeType" original_name="imageOriginalName" />
+           size="imageSize", dimensions="imageDimensions" mime_type="imageMimeType" original_name="imageOriginalName" />
 </vich_uploader>
 ```
 

--- a/Resources/doc/mapping/yaml.md
+++ b/Resources/doc/mapping/yaml.md
@@ -13,6 +13,7 @@ Acme\DemoBundle\Entity\Product:
         size:              imageSize
         mime_type:         imageMimeType
         original_name:     imageOriginalName
+        dimensions:        imageDimensions
 ```
 
 To be automatically found, the mapping configuration MUST be in the `Resources/config/vich_uploader`

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -72,6 +72,7 @@ The `UploadableField` annotation has a few options. They are as follows:
   * `size`: the property that will contain the size in bytes of the uploaded file;
   * `mimeType`: the property that will contain the mime type of the uploaded file;
   * `originalName`: the property that will contain the original name of the uploaded file.
+  * `dimensions`: the property that will contain the dimensions of uploaded **image file**
 
 **Note**:
 
@@ -239,7 +240,7 @@ class Product
     /**
      * NOTE: This is not a mapped field of entity metadata, just a simple property.
      * 
-     * @Vich\UploadableField(mapping="product_image", fileNameProperty="image.name", size="image.size", mimeType="image.mimeType", originalName="image.originalName")
+     * @Vich\UploadableField(mapping="product_image", fileNameProperty="image.name", size="image.size", mimeType="image.mimeType", originalName="image.originalName", dimensions="image.dimensions")
      * 
      * @var File
      */

--- a/Storage/AbstractStorage.php
+++ b/Storage/AbstractStorage.php
@@ -55,14 +55,14 @@ abstract class AbstractStorage implements StorageInterface
         $name = $mapping->getUploadName($obj);
         $mapping->setFileName($obj, $name);
 
-        $accessors = [
-            'size' => 'getSize',
-            'mimeType' => 'getMimeType',
-            'originalName' => 'getClientOriginalName',
-        ];
+        $mapping->writeProperty($obj, 'size', $file->getSize());
+        $mapping->writeProperty($obj, 'mimeType', $file->getMimeType());
+        $mapping->writeProperty($obj, 'originalName', $file->getClientOriginalName());
 
-        foreach ($accessors as $property => $accessor) {
-            $mapping->writeProperty($obj, $property, $file->$accessor());
+        if (strpos($file->getMimeType(), 'image/') !== false)
+        {
+            $dimensions = getimagesize($file);
+            $mapping->writeProperty($obj, 'dimensions', array_splice($dimensions, 0, 2));
         }
 
         $dir = $mapping->getUploadDir($obj);

--- a/Storage/AbstractStorage.php
+++ b/Storage/AbstractStorage.php
@@ -59,8 +59,7 @@ abstract class AbstractStorage implements StorageInterface
         $mapping->writeProperty($obj, 'mimeType', $file->getMimeType());
         $mapping->writeProperty($obj, 'originalName', $file->getClientOriginalName());
 
-        if (strpos($file->getMimeType(), 'image/') !== false)
-        {
+        if (strpos($file->getMimeType(), 'image/') !== false) {
             $dimensions = getimagesize($file);
             $mapping->writeProperty($obj, 'dimensions', array_splice($dimensions, 0, 2));
         }

--- a/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -45,6 +45,7 @@ class AnnotationDriverTest extends TestCase
                 'size' => null,
                 'mimeType' => null,
                 'originalName' => null,
+                'dimensions' => null,
             ],
         ], $metadata->fields);
     }
@@ -93,6 +94,7 @@ class AnnotationDriverTest extends TestCase
                 'size' => 'sizeField',
                 'mimeType' => 'mimeTypeField',
                 'originalName' => 'originalNameField',
+                'dimensions' => null,
             ])));
 
         $driver = new AnnotationDriver($reader);
@@ -106,6 +108,7 @@ class AnnotationDriverTest extends TestCase
                 'size' => null,
                 'mimeType' => null,
                 'originalName' => null,
+                'dimensions' => null,
             ],
             'image' => [
                 'mapping' => 'dummy_image',
@@ -114,6 +117,7 @@ class AnnotationDriverTest extends TestCase
                 'size' => 'sizeField',
                 'mimeType' => 'mimeTypeField',
                 'originalName' => 'originalNameField',
+                'dimensions' => null,
             ],
         ], $metadata->fields);
     }

--- a/Tests/Metadata/Driver/FileDriverTestCase.php
+++ b/Tests/Metadata/Driver/FileDriverTestCase.php
@@ -40,6 +40,7 @@ abstract class FileDriverTestCase extends TestCase
                     'size' => 'imageSize',
                     'mimeType' => 'imageMimeType',
                     'originalName' => 'imageOriginalName',
+                    'dimensions' => null,
                 ],
             ],
         ];
@@ -55,6 +56,7 @@ abstract class FileDriverTestCase extends TestCase
                     'size' => null,
                     'mimeType' => null,
                     'originalName' => null,
+                    'dimensions' => null,
                 ],
                 'image' => [
                     'mapping' => 'dummy_image',
@@ -63,6 +65,7 @@ abstract class FileDriverTestCase extends TestCase
                     'size' => 'imageSize',
                     'mimeType' => 'imageMimeType',
                     'originalName' => 'imageOriginalName',
+                    'dimensions' => null,
                 ],
             ],
         ];


### PR DESCRIPTION
support for missing `dimensions` property for `image/*` types.

* [x] tests updated.
* [x] documents updated.