### PR TITLE
Uses FileExtensionTrait in all files namers.

### DIFF
--- a/Naming/Base64Namer.php
+++ b/Naming/Base64Namer.php
@@ -12,6 +12,8 @@ use Vich\UploaderBundle\Mapping\PropertyMapping;
  */
 class Base64Namer implements NamerInterface, ConfigurableInterface
 {
+    use Polyfill\FileExtensionTrait;
+
     protected const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_';
 
     /** @var int Length of the resulting name. 10 can be decoded to a 64-bit integer. */
@@ -39,7 +41,7 @@ class Base64Namer implements NamerInterface, ConfigurableInterface
             $name .= $this->getRandomChar();
         }
 
-        if ($extension = $file->getClientOriginalExtension()) {
+        if ($extension = $this->getExtension($file)) {
             $name = "$name.$extension";
         }
 

--- a/Naming/HashNamer.php
+++ b/Naming/HashNamer.php
@@ -11,6 +11,8 @@ use Vich\UploaderBundle\Mapping\PropertyMapping;
  */
 class HashNamer implements NamerInterface, ConfigurableInterface
 {
+    use Polyfill\FileExtensionTrait;
+
     private $algorithm = 'sha1';
 
     private $length;
@@ -37,7 +39,7 @@ class HashNamer implements NamerInterface, ConfigurableInterface
             $name = substr($name, 0, $this->length);
         }
 
-        if ($extension = $file->guessExtension()) {
+        if ($extension = $this->getExtension($file)) {
             $name = sprintf('%s.%s', $name, $extension);
         }
 

--- a/Tests/Naming/Base64NamerTest.php
+++ b/Tests/Naming/Base64NamerTest.php
@@ -35,7 +35,10 @@ class Base64NamerTest extends TestCase
     {
         $file = $this->getUploadedFileMock();
         $file->expects($this->once())
-            ->method('getClientOriginalExtension')
+            ->method('getClientOriginalName');
+
+        $file->expects($this->once())
+            ->method('guessExtension')
             ->will($this->returnValue($extension));
 
         $entity = new DummyEntity();

--- a/Tests/Naming/HashNamerTest.php
+++ b/Tests/Naming/HashNamerTest.php
@@ -36,6 +36,9 @@ class HashNamerTest extends TestCase
     {
         $file = $this->getUploadedFileMock();
         $file->expects($this->once())
+            ->method('getClientOriginalName');
+
+        $file->expects($this->once())
             ->method('guessExtension')
             ->will($this->returnValue($extension));
 


### PR DESCRIPTION
It appears that files namers are currently determining file extension in different ways.

This PR unifies it by using `Polyfill\FileExtensionTrait` in all file namers.