### PR TITLE
Fixes typo in method's name and uses pathinfo to extract ext and name.

### DIFF
--- a/Tests/Util/FilenameUtilsTest.php
+++ b/Tests/Util/FilenameUtilsTest.php
@@ -8,14 +8,14 @@ use Vich\UploaderBundle\Util\FilenameUtils;
 class FilenameUtilsTest extends TestCase
 {
     /**
-     * @dataProvider spitNameByExtensionProvider
+     * @dataProvider splitNameByExtensionProvider
      */
-    public function testSpitNameByExtension($filename, $basename, $extension): void
+    public function testSplitNameByExtension($filename, $basename, $extension): void
     {
-        $this->assertSame([$basename, $extension], FilenameUtils::spitNameByExtension($filename));
+        $this->assertSame([$basename, $extension], FilenameUtils::splitNameByExtension($filename));
     }
 
-    public function spitNameByExtensionProvider()
+    public function splitNameByExtensionProvider()
     {
         return [
             'simple filename with extension' => ['filename.extension', 'filename', 'extension'],

--- a/Util/FilenameUtils.php
+++ b/Util/FilenameUtils.php
@@ -18,12 +18,10 @@ final class FilenameUtils
      *
      * @return array An array of basename and extension
      */
-    public static function spitNameByExtension(string $filename): array
+    public static function splitNameByExtension(string $filename): array
     {
-        if (false === $pos = strrpos($filename, '.')) {
-            return [$filename, ''];
-        }
+        $pathInfo = pathinfo($filename);
 
-        return [substr($filename, 0, $pos), substr($filename, $pos + 1)];
+        return [$pathInfo['filename'], $pathInfo['extension'] ?? ''];
     }
 }

--- a/Util/Transliterator.php
+++ b/Util/Transliterator.php
@@ -23,7 +23,7 @@ class Transliterator
      */
     public static function transliterate(string $string, string $separator = '-'): string
     {
-        [$filename, $extension] = FilenameUtils::spitNameByExtension($string);
+        [$filename, $extension] = FilenameUtils::splitNameByExtension($string);
 
         $transliterated = BehatTransliterator::transliterate($filename, $separator);
         if ('' !== $extension) {


### PR DESCRIPTION
There's a typo in `spitNameByExtension` method.

Previously this method was using combination of `strpos` and `substr` to extract filename and extension. I've switched it to much simpler `pathinfo` and `??` operator approach.