### PR TITLE
Add aliases to be able to extend VichImageType

### DIFF
--- a/Resources/config/factory.xml
+++ b/Resources/config/factory.xml
@@ -10,5 +10,7 @@
             <argument>%vich_uploader.mappings%</argument>
             <argument>%vich_uploader.default_filename_attribute_suffix%</argument>
         </service>
+
+        <service id="Vich\UploaderBundle\Mapping\PropertyMappingFactory" alias="vich_uploader.property_mapping_factory" public="false"/>
     </services>
 </container>

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -20,5 +20,8 @@
             <argument type="service" id="liip_imagine.cache.manager" on-invalid="null" />
             <tag name="form.type" alias="vich_image" />
         </service>
+
+        <service id="Vich\UploaderBundle\Form\Type\VichFileType" alias="vich_uploader.form.type.file" public="false"/>
+        <service id="Vich\UploaderBundle\Form\Type\VichImageType" alias="vich_uploader.form.type.image" public="false"/>
     </services>
 </container>

--- a/Resources/config/handler.xml
+++ b/Resources/config/handler.xml
@@ -16,5 +16,8 @@
             <argument type="service" id="vich_uploader.file_injector" />
             <argument type="service" id="event_dispatcher" />
         </service>
+
+        <service id="Vich\UploaderBundle\Handler\DownloadHandlerHandler" alias="vich_uploader.download_handler" public="false"/>
+        <service id="Vich\UploaderBundle\Handler\UploadHandler" alias="vich_uploader.upload_handler" public="false"/>
     </services>
 </container>

--- a/Resources/config/storage.xml
+++ b/Resources/config/storage.xml
@@ -7,5 +7,7 @@
         <service id="vich_uploader.storage.file_system" class="Vich\UploaderBundle\Storage\FileSystemStorage" public="false">
             <argument type="service" id="vich_uploader.property_mapping_factory" />
         </service>
+
+        <service id="Vich\UploaderBundle\Storage\StorageInterface" alias="vich_uploader.storage.file_system" public="false"/>
     </services>
 </container>

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -11,6 +11,7 @@
             <argument type="service" id="vich_uploader.storage" />
         </service>
 
+        <service id="Vich\UploaderBundle\Templating\Helper\UploaderHelper" alias="vich_uploader.templating.helper.uploader_helper" public="false"/>
     </services>
 
 </container>


### PR DESCRIPTION
I extended the VichImageType class and I had to put aliases on 3 services to be able to use the autowiring.

Maybe we could also add alias for PropertyAccessorInterface and CacheManager too.