### PR TITLE
Fix test environment for the new environment requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,10 @@ matrix:
         - php: nightly
 
 before_install:
+    - if [ -z "$(pecl list | grep -w mongodb)" ]; then pecl install mongodb-1.3.4; fi
+    - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - composer self-update
     - phpenv config-rm xdebug.ini || true
-    - composer config platform.ext-mongo 1.6.14
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
     - if [ "$WITH_LIIP_IMAGINE" = true ] ; then composer require --no-update liip/imagine-bundle:"^1.7|^2.0@dev"; fi;
     - if [ "$VALIDATE_DOCS" = true ]; then composer require --dev --no-update kphoen/rusty dev-master; fi

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     },
     "require-dev": {
         "ext-sqlite3": "*",
+        "alcaeus/mongo-php-adapter": "^1.1",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/mongodb-odm": "^1.2",
         "doctrine/orm": "^2.5",
@@ -79,6 +80,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "ext-mongo": "1.6.16"
+        }
     }
 }

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SUPPORTED_SYMFONY_VERSIONS=('~2.8.0' '~3.3.0' '~3.4.0' '~4.0.0')
+SUPPORTED_SYMFONY_VERSIONS=('~3.4.0' '~4.0.0')
 GREEN='\033[0;32m'
 NC='\033[0m'
 


### PR DESCRIPTION
Actually, you cannot do a composer install nor run the tests because of 2 things:

1 - php7.1 is now the minimum and doctrine/mongodb-odm needs ext-mongo which doesn't exist for php7.1 so you need to do this: http://docs.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/reference/introduction.html#using-php-7

2 - you can't run the script runTests.sh because it tries to test SF 2.8 and 3.3 which is not possible anymore with the new requirements

Edit: travis failing because ext-mongodb is missing (which should be used with php7.1)