### PR TITLE
Fix `imagine_pattern` option behavior in VichImageType

### DIFF
--- a/Form/Type/VichImageType.php
+++ b/Form/Type/VichImageType.php
@@ -61,9 +61,9 @@ class VichImageType extends VichFileType
                     throw new \RuntimeException('LiipImagineBundle must be installed and configured for using "imagine_pattern" option.');
                 }
 
-                $uri = $this->storage->resolveUri($object, $form->getName());
-                if ($uri) {
-                    $view->vars['image_uri'] = $this->cacheManager->getBrowserPath($uri, $options['imagine_pattern']);
+                $path = $this->storage->resolvePath($object, $form->getName(), null, true);
+                if (null !== $path) {
+                    $view->vars['image_uri'] = $this->cacheManager->getBrowserPath($path, $options['imagine_pattern']);
                 }
             } else {
                 $view->vars['image_uri'] = $this->resolveUriOption($options['image_uri'], $object, $form);

--- a/Tests/Form/Type/VichImageTypeTest.php
+++ b/Tests/Form/Type/VichImageTypeTest.php
@@ -146,9 +146,9 @@ class VichImageTypeTest extends VichFileTypeTest
         $storage = $this->createMock(StorageInterface::class);
         $storage
             ->expects($this->any())
-            ->method('resolveUri')
-            ->with($object, $field)
-            ->will($this->returnValue('resolved-uri'));
+            ->method('resolvePath')
+            ->with($object, $field, null, true)
+            ->will($this->returnValue('resolved-path'));
 
         $parentForm = $this->createMock(FormInterface::class);
         $parentForm
@@ -175,7 +175,7 @@ class VichImageTypeTest extends VichFileTypeTest
         $cacheManager
             ->expects($this->once())
             ->method('getBrowserPath')
-            ->with('resolved-uri', 'product_sq200')
+            ->with('resolved-path', 'product_sq200')
             ->will($this->returnValue('product_sq200/resolved-uri'));
 
         $testedType = static::TESTED_TYPE;


### PR DESCRIPTION
`Liip\ImagineBundle\Imagine\Cache\CacheManager::getBrowserPath` should receive a relative path in the first argument but not an URI.
Moreover this works if `LiipImagineBundle` and `VichUploaderBundle` properly configured, config options `vich_uploader.mappings.default.upload_destination` and `liip_imagine.loaders.default.filesystem.data_root` must point to the same directory.
Current version might only work if URI that returned by the Storage equals to relative path for Imagine.