### PR TITLE
Check if parent is null

### DIFF
--- a/Form/Type/VichFileType.php
+++ b/Form/Type/VichFileType.php
@@ -113,7 +113,7 @@ class VichFileType extends AbstractType
             $form = $event->getForm();
             $parent = $form->getParent();
             // no object: no delete button
-            if(null === $parent) {
+            if (null === $parent) {
                 return;
             }
             $object = $parent->getData();

--- a/Form/Type/VichFileType.php
+++ b/Form/Type/VichFileType.php
@@ -111,7 +111,12 @@ class VichFileType extends AbstractType
         // add delete only if there is a file
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options): void {
             $form = $event->getForm();
-            $object = $form->getParent()->getData();
+            $parent = $form->getParent();
+            // no object: no delete button
+            if(null === $parent) {
+                return;
+            }
+            $object = $parent->getData();
 
             // no object or no uploaded file: no delete button
             if (null === $object || null === $this->storage->resolveUri($object, $form->getName())) {


### PR DESCRIPTION
When using NelmioApiDocBundle, the forms parent is null.
For this reason, it is necessary tocheck if it is null before getting its data