### PR TITLE
Callback namers

### DIFF
--- a/Naming/CallableDirectoryNameProviderInterface.php
+++ b/Naming/CallableDirectoryNameProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+interface CallableDirectoryNameProviderInterface
+{
+    public function getUploadedDirectoryName(): string;
+}

--- a/Naming/CallableNameProviderInterface.php
+++ b/Naming/CallableNameProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+interface CallableNameProviderInterface
+{
+    public function getUploadedFileName(): string;
+}

--- a/Naming/CallbackDirectoryNamer.php
+++ b/Naming/CallbackDirectoryNamer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+use Vich\UploaderBundle\Exception\NameGenerationException;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
+class CallbackDirectoryNamer implements DirectoryNamerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function directoryName($object, PropertyMapping $mapping): string
+    {
+        if (!$object instanceof CallableDirectoryNameProviderInterface) {
+            throw new NameGenerationException(
+                sprintf(
+                    'Object "%s" must implement the "%s" interface to use the directory namer "%s".',
+                    get_class($object),
+                    CallableDirectoryNameProviderInterface::class,
+                    CallbackDirectoryNamer::class
+                )
+            );
+        }
+
+        return $object->getUploadedDirectoryName();
+    }
+}

--- a/Naming/CallbackNamer.php
+++ b/Naming/CallbackNamer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+use Vich\UploaderBundle\Exception\NameGenerationException;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
+class CallbackNamer implements NamerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function name($object, PropertyMapping $mapping): string
+    {
+        if (!$object instanceof CallableNameProviderInterface) {
+            throw new NameGenerationException(
+                sprintf(
+                    'Object "%s" must implement the "%s" interface to use the namer "%s".',
+                    get_class($object),
+                    CallableNameProviderInterface::class,
+                    CallbackNamer::class
+                )
+            );
+        }
+
+        return $object->getUploadedFileName();
+    }
+}

--- a/Tests/Naming/CallbackDirectoryNamerTest.php
+++ b/Tests/Naming/CallbackDirectoryNamerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Naming;
+
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Naming\CallableDirectoryNameProviderInterface;
+use Vich\UploaderBundle\Naming\CallableNameProviderInterface;
+use Vich\UploaderBundle\Naming\CallbackDirectoryNamer;
+use Vich\UploaderBundle\Naming\CallbackNamer;
+use Vich\UploaderBundle\Tests\TestCase;
+
+class CallbackDirectoryNamerTest extends TestCase
+{
+    /**
+     * @expectedException \Vich\UploaderBundle\Exception\NameGenerationException
+     * @expectedExceptionMessage Object "stdClass" must implement the "Vich\UploaderBundle\Naming\CallableDirectoryNameProviderInterface" interface to use the directory namer "Vich\UploaderBundle\Naming\CallbackDirectoryNamer".
+     */
+    public function testCallbackException(): void
+    {
+        $mapping = $this->getMockBuilder(PropertyMapping::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $namer = new CallbackDirectoryNamer();
+        $namer->directoryName(new \stdClass(), $mapping);
+    }
+
+    public function testCallback(): void
+    {
+        $object = $this->getMockBuilder(CallableDirectoryNameProviderInterface::class)
+            ->getMock();
+        $object->expects($this->once())
+            ->method('getUploadedDirectoryName')
+            ->will($this->returnValue('my_dir_name'));
+
+        $mapping = $this->getMockBuilder(PropertyMapping::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $namer = new CallbackDirectoryNamer();
+        $this->assertEquals('my_dir_name', $namer->directoryName($object, $mapping));
+    }
+}

--- a/Tests/Naming/CallbackNamerTest.php
+++ b/Tests/Naming/CallbackNamerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Naming;
+
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Naming\CallableNameProviderInterface;
+use Vich\UploaderBundle\Naming\CallbackNamer;
+use Vich\UploaderBundle\Tests\TestCase;
+
+class CallbackNamerTest extends TestCase
+{
+    /**
+     * @expectedException \Vich\UploaderBundle\Exception\NameGenerationException
+     * @expectedExceptionMessage Object "stdClass" must implement the "Vich\UploaderBundle\Naming\CallableNameProviderInterface" interface to use the namer "Vich\UploaderBundle\Naming\CallbackNamer".
+     */
+    public function testCallbackException(): void
+    {
+        $mapping = $this->getMockBuilder(PropertyMapping::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $namer = new CallbackNamer();
+        $namer->name(new \stdClass(), $mapping);
+    }
+
+    public function testCallback(): void
+    {
+        $object = $this->getMockBuilder(CallableNameProviderInterface::class)
+            ->getMock();
+        $object->expects($this->once())
+            ->method('getUploadedFileName')
+            ->will($this->returnValue('my_name'));
+
+        $mapping = $this->getMockBuilder(PropertyMapping::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $namer = new CallbackNamer();
+        $this->assertEquals('my_name', $namer->name($object, $mapping));
+    }
+}


### PR DESCRIPTION
Added callback namers. Objects using these namers must implement an interface, and return a file / directory name.

This would eliminate a huge percent of cases in which I had to create a namer.

Let me know if you are willing to merge this, and I will finish up docs / etc.