### PR TITLE
use default timezone UTC for phpunit tests

### DIFF
--- a/runTests.sh
+++ b/runTests.sh
@@ -36,7 +36,7 @@ for sf_version in ${SUPPORTED_SYMFONY_VERSIONS[@]}; do
   php composer.phar update --prefer-dist --ignore-platform-reqs || { restore_composer && exit 1; }
 
   echo -e "\n${GREEN}Launching tests${NC}"
-  vendor/bin/phpunit $@
+  php -d date.timezone='UTC' vendor/bin/phpunit $@
 done
 
 restore_composer


### PR DESCRIPTION
Hi there,

running the `./runTests.sh` on a machine where the php.ini has a different timezone set than UTC, for example 'America/Los_Angeles', fails some phpunit tests.

How about we set the timezone to default UTC for running the testsuite?

Cheers,
Kim