### PR TITLE
Downloader handler mimeType guessing

### DIFF
--- a/Handler/DownloadHandler.php
+++ b/Handler/DownloadHandler.php
@@ -40,12 +40,17 @@ class DownloadHandler extends AbstractHandler
             $fileName = $mapping->readProperty($object, 'originalName');
         }
 
-        $file = $mapping->getFile($object);
+        $mimeType = $mapping->readProperty($object, 'mimeType');
+
+        if (empty($mimeType)) {
+            $file = $mapping->getFile($object);
+            $mimeType = null === $file ? null : $file->getMimeType();
+        }
 
         return $this->createDownloadResponse(
             $stream,
             $fileName ?: $mapping->getFileName($object),
-            null === $file ? null : $file->getMimeType(),
+            $mimeType,
             $forceDownload
         );
     }


### PR DESCRIPTION
---
name: Downloader handler mimeType guessing
about: Try to use file mimeType if it's already stored in object
---

### Improvement

<!-- Fill in the relevant information below to help triage your issue. -->

|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | no
| BC Break    | no

#### Summary

Try to use file mimeType if it's already stored in object
Otherwise use $file->getMimeType

It's usefull if mimetype is alread stored in database for exemple and use files store with Flystsem. (In my case Google Cloud Storage)

Possible fix of #841