### PR TITLE
Upgrade jms/metadata to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 7.1
     - 7.2
     - 7.3
     - nightly
@@ -18,10 +17,8 @@ env:
 
 matrix:
     include:
-        - php: 7.1
+        - php: 7.2
           env: VALIDATE_DOCS=true COMPOSER_FLAGS="--prefer-lowest"
-        - php: 7.1
-          env: SYMFONY_VERSION="~4.1.0" WITH_LIIP_IMAGINE=true
         - php: 7.2
           env: SYMFONY_VERSION="~4.2.0" WITH_LIIP_IMAGINE=true
         - php: 7.3

--- a/Command/MappingDebugClassCommand.php
+++ b/Command/MappingDebugClassCommand.php
@@ -34,16 +34,16 @@ class MappingDebugClassCommand extends Command
         $fqcn = $input->getArgument('fqcn');
 
         if (!$this->metadataReader->isUploadable($fqcn)) {
-            $output->writeln(sprintf('<error>"%s" is not uploadable.</error>', $fqcn));
+            $output->writeln(\sprintf('<error>"%s" is not uploadable.</error>', $fqcn));
 
             return 1;
         }
 
         $uploadableFields = $this->metadataReader->getUploadableFields($fqcn);
 
-        $output->writeln(sprintf('Introspecting class <info>%s</info>:', $fqcn));
+        $output->writeln(\sprintf('Introspecting class <info>%s</info>:', $fqcn));
         foreach ($uploadableFields as $data) {
-            $output->writeln(sprintf('Found field "<comment>%s</comment>", storing file name in <comment>"%s</comment>" and using mapping "<comment>%s</comment>"', $data['propertyName'], $data['fileNameProperty'], $data['mapping']));
+            $output->writeln(\sprintf('Found field "<comment>%s</comment>", storing file name in <comment>"%s</comment>" and using mapping "<comment>%s</comment>"', $data['propertyName'], $data['fileNameProperty'], $data['mapping']));
         }
 
         return 0;

--- a/Command/MappingDebugCommand.php
+++ b/Command/MappingDebugCommand.php
@@ -34,13 +34,13 @@ class MappingDebugCommand extends Command
         $mapping = $input->getArgument('mapping');
 
         if (!isset($this->mappings[$mapping])) {
-            throw new MappingNotFoundException(sprintf('Mapping "%s" does not exist.', $mapping));
+            throw new MappingNotFoundException(\sprintf('Mapping "%s" does not exist.', $mapping));
         }
 
-        $output->writeln(sprintf('Debug information for mapping <info>%s</info>', $mapping));
+        $output->writeln(\sprintf('Debug information for mapping <info>%s</info>', $mapping));
 
         foreach ($this->mappings[$mapping] as $key => $value) {
-            $output->writeln(sprintf('<comment>%s</comment>: %s', $key, var_export($value, true)));
+            $output->writeln(\sprintf('<comment>%s</comment>: %s', $key, \var_export($value, true)));
         }
     }
 }

--- a/Command/MappingListClassesCommand.php
+++ b/Command/MappingListClassesCommand.php
@@ -34,10 +34,10 @@ class MappingListClassesCommand extends Command
         $uploadableClasses = $this->metadataReader->getUploadableClasses();
 
         foreach ($uploadableClasses as $class) {
-            $output->writeln(sprintf('Found <comment>%s</comment>', $class));
+            $output->writeln(\sprintf('Found <comment>%s</comment>', $class));
         }
 
-        $output->writeln(sprintf('Found <comment>%d</comment> classes.', \count($uploadableClasses)));
+        $output->writeln(\sprintf('Found <comment>%d</comment> classes.', \count($uploadableClasses)));
         $output->writeln('<info>NOTE:</info> Only classes configured using XML or YAML are displayed.');
     }
 }

--- a/DependencyInjection/Compiler/RegisterMappingDriversPass.php
+++ b/DependencyInjection/Compiler/RegisterMappingDriversPass.php
@@ -19,7 +19,7 @@ class RegisterMappingDriversPass implements CompilerPassInterface
             $drivers[] = new Reference('vich_uploader.metadata_driver.annotation');
         }
 
-        if (class_exists(Yaml::class)) {
+        if (\class_exists(Yaml::class)) {
             $drivers[] = new Reference('vich_uploader.metadata_driver.yaml');
         }
 

--- a/DependencyInjection/Compiler/RegisterPropelModelsPass.php
+++ b/DependencyInjection/Compiler/RegisterPropelModelsPass.php
@@ -56,11 +56,11 @@ class RegisterPropelModelsPass implements CompilerPassInterface
                 }
 
                 foreach ($serviceTypes as $type) {
-                    if (!$container->has(sprintf('vich_uploader.listener.%s.%s', $type, $field['mapping']))) {
+                    if (!$container->has(\sprintf('vich_uploader.listener.%s.%s', $type, $field['mapping']))) {
                         continue;
                     }
 
-                    $definition = $container->getDefinition(sprintf('vich_uploader.listener.%s.%s', $type, $field['mapping']));
+                    $definition = $container->getDefinition(\sprintf('vich_uploader.listener.%s.%s', $type, $field['mapping']));
                     $definition->setClass($container->getDefinition($definition->getParent())->getClass());
                     $definition->setPublic(true);
                     $definition->addTag('propel.event_subscriber', ['class' => $class]);

--- a/DependencyInjection/VichUploaderExtension.php
+++ b/DependencyInjection/VichUploaderExtension.php
@@ -38,8 +38,8 @@ class VichUploaderExtension extends Extension
         $container->setParameter('vich_uploader.default_filename_attribute_suffix', $config['default_filename_attribute_suffix']);
         $container->setParameter('vich_uploader.mappings', $config['mappings']);
 
-        if (0 === strpos($config['storage'], '@')) {
-            $container->setAlias('vich_uploader.storage', substr($config['storage'], 1));
+        if (0 === \strpos($config['storage'], '@')) {
+            $container->setAlias('vich_uploader.storage', \substr($config['storage'], 1));
         } else {
             $container->setAlias('vich_uploader.storage', 'vich_uploader.storage.'.$config['storage']);
         }
@@ -93,7 +93,7 @@ class VichUploaderExtension extends Extension
                 $ref = new \ReflectionClass($class);
                 $directory = \dirname($ref->getFileName()).'/Resources/config/vich_uploader';
 
-                if (!is_dir($directory)) {
+                if (!\is_dir($directory)) {
                     continue;
                 }
 
@@ -102,20 +102,20 @@ class VichUploaderExtension extends Extension
         }
 
         foreach ($config['metadata']['directories'] as $directory) {
-            $directory['path'] = rtrim(str_replace('\\', '/', $directory['path']), '/');
+            $directory['path'] = \rtrim(\str_replace('\\', '/', $directory['path']), '/');
 
             if ('@' === $directory['path'][0]) {
-                $bundleName = substr($directory['path'], 1, strpos($directory['path'], '/') - 1);
+                $bundleName = \substr($directory['path'], 1, \strpos($directory['path'], '/') - 1);
 
                 if (!isset($bundles[$bundleName])) {
-                    throw new \RuntimeException(sprintf('The bundle "%s" has not been registered with AppKernel. Available bundles: %s', $bundleName, implode(', ', array_keys($bundles))));
+                    throw new \RuntimeException(\sprintf('The bundle "%s" has not been registered with AppKernel. Available bundles: %s', $bundleName, \implode(', ', \array_keys($bundles))));
                 }
 
                 $ref = new \ReflectionClass($bundles[$bundleName]);
-                $directory['path'] = \dirname($ref->getFileName()).substr($directory['path'], \strlen('@'.$bundleName));
+                $directory['path'] = \dirname($ref->getFileName()).\substr($directory['path'], \strlen('@'.$bundleName));
             }
 
-            $directories[rtrim($directory['namespace_prefix'], '\\')] = rtrim($directory['path'], '\\/');
+            $directories[\rtrim($directory['namespace_prefix'], '\\')] = \rtrim($directory['path'], '\\/');
         }
 
         $container
@@ -135,8 +135,8 @@ class VichUploaderExtension extends Extension
             ;
 
             $dir = $container->getParameterBag()->resolveValue($config['metadata']['file_cache']['dir']);
-            if (!file_exists($dir) && !@mkdir($dir, 0777, true)) {
-                throw new \RuntimeException(sprintf('Could not create cache directory "%s".', $dir));
+            if (!\file_exists($dir) && !@\mkdir($dir, 0777, true)) {
+                throw new \RuntimeException(\sprintf('Could not create cache directory "%s".', $dir));
             }
         } else {
             $container->setAlias('vich_uploader.metadata.cache', new Alias($config['metadata']['cache'], false));
@@ -191,7 +191,7 @@ class VichUploaderExtension extends Extension
 
     protected function createNamerService(ContainerBuilder $container, string $mappingName, array $mapping): array
     {
-        $serviceId = sprintf('%s.%s', $mapping['namer']['service'], $mappingName);
+        $serviceId = \sprintf('%s.%s', $mapping['namer']['service'], $mappingName);
         $container->setDefinition(
             $serviceId, new ChildDefinition($mapping['namer']['service'])
         );
@@ -209,7 +209,7 @@ class VichUploaderExtension extends Extension
         int $priority = 0
     ): void {
         $definition = $container
-            ->setDefinition(sprintf('vich_uploader.listener.%s.%s', $type, $name), new ChildDefinition(sprintf('vich_uploader.listener.%s.%s', $type, $driver)))
+            ->setDefinition(\sprintf('vich_uploader.listener.%s.%s', $type, $name), new ChildDefinition(\sprintf('vich_uploader.listener.%s.%s', $type, $driver)))
             ->replaceArgument(0, $name)
             ->replaceArgument(1, new Reference('vich_uploader.adapter.'.$driver));
 
@@ -224,7 +224,7 @@ class VichUploaderExtension extends Extension
         $resources = $container->hasParameter('twig.form.resources') ?
             $container->getParameter('twig.form.resources') : [];
 
-        array_unshift($resources, '@VichUploader/Form/fields.html.twig');
+        \array_unshift($resources, '@VichUploader/Form/fields.html.twig');
         $container->setParameter('twig.form.resources', $resources);
     }
 }

--- a/Form/Type/VichFileType.php
+++ b/Form/Type/VichFileType.php
@@ -79,7 +79,7 @@ class VichFileType extends AbstractType
 
         $downloadUriNormalizer = function (Options $options, $downloadUri) {
             if (null !== $options['download_link']) {
-                @trigger_error('The "download_link" option is deprecated since version 1.6 and will be removed in 2.0. You should use "download_uri" instead.', E_USER_DEPRECATED);
+                @\trigger_error('The "download_link" option is deprecated since version 1.6 and will be removed in 2.0. You should use "download_uri" instead.', E_USER_DEPRECATED);
 
                 return $options['download_link'];
             }
@@ -153,7 +153,7 @@ class VichFileType extends AbstractType
         $view->vars['download_uri'] = null;
         if ($options['download_uri'] && $object) {
             $view->vars['download_uri'] = $this->resolveUriOption($options['download_uri'], $object, $form);
-            $view->vars = array_replace(
+            $view->vars = \array_replace(
                 $view->vars,
                 $this->resolveDownloadLabel($options['download_label'], $object, $form)
             );

--- a/Form/Type/VichImageType.php
+++ b/Form/Type/VichImageType.php
@@ -74,7 +74,7 @@ class VichImageType extends VichFileType
                 $view->vars['image_uri'] = $this->resolveUriOption($options['image_uri'], $object, $form);
             }
 
-            $view->vars = array_replace(
+            $view->vars = \array_replace(
                 $view->vars,
                 $this->resolveDownloadLabel($options['download_label'], $object, $form)
             );

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Metadata\Driver;
 
 use Doctrine\Common\Annotations\Reader as AnnotationReader;
+use Metadata\ClassMetadata as JMSClassMetadata;
 use Metadata\Driver\AdvancedDriverInterface;
 use Vich\UploaderBundle\Mapping\Annotation\Uploadable;
 use Vich\UploaderBundle\Mapping\Annotation\UploadableField;
@@ -31,10 +32,10 @@ class AnnotationDriver implements AdvancedDriverInterface
         $this->reader = $reader;
     }
 
-    public function loadMetadataForClass(\ReflectionClass $class)
+    public function loadMetadataForClass(\ReflectionClass $class): ?JMSClassMetadata
     {
         if (!$this->isUploadable($class)) {
-            return;
+            return null;
         }
 
         $classMetadata = new ClassMetadata($class->name);
@@ -65,7 +66,7 @@ class AnnotationDriver implements AdvancedDriverInterface
         return $classMetadata;
     }
 
-    public function getAllClassNames()
+    public function getAllClassNames(): array
     {
         return [];
     }

--- a/Metadata/Driver/XmlDriver.php
+++ b/Metadata/Driver/XmlDriver.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Metadata\Driver;
 
+use Metadata\ClassMetadata as JMSClassMetadata;
 use Metadata\Driver\AbstractFileDriver;
 use Symfony\Component\Config\Util\XmlUtils;
 use Vich\UploaderBundle\Metadata\ClassMetadata;
@@ -12,10 +13,10 @@ use Vich\UploaderBundle\Metadata\ClassMetadata;
  */
 class XmlDriver extends AbstractFileDriver
 {
-    protected function loadMetadataFromFile(\ReflectionClass $class, $file)
+    protected function loadMetadataFromFile(\ReflectionClass $class, string $file): ?JMSClassMetadata
     {
         $elem = XmlUtils::loadFile($file);
-        $elem = simplexml_import_dom($elem);
+        $elem = \simplexml_import_dom($elem);
 
         $className = $this->guessClassName($file, $elem, $class);
         $classMetadata = new ClassMetadata($className);
@@ -42,7 +43,7 @@ class XmlDriver extends AbstractFileDriver
     /**
      * {@inheritdoc}
      */
-    protected function getExtension()
+    protected function getExtension(): string
     {
         return 'xml';
     }
@@ -54,7 +55,7 @@ class XmlDriver extends AbstractFileDriver
         }
 
         if ($class->name !== (string) $elem->attributes()->class) {
-            throw new \RuntimeException(sprintf('Expected metadata for class %s to be defined in %s.', $class->name, $file));
+            throw new \RuntimeException(\sprintf('Expected metadata for class %s to be defined in %s.', $class->name, $file));
         }
 
         return $class->name;

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Metadata\Driver;
 
+use Metadata\ClassMetadata as JMSClassMetadata;
 use Metadata\Driver\AbstractFileDriver;
 use Symfony\Component\Yaml\Yaml as YmlParser;
 use Vich\UploaderBundle\Metadata\ClassMetadata;
@@ -15,7 +16,7 @@ class YamlDriver extends AbstractFileDriver
     /**
      * {@inheritdoc}
      */
-    protected function loadMetadataFromFile(\ReflectionClass $class, $file)
+    protected function loadMetadataFromFile(\ReflectionClass $class, string $file): ?JMSClassMetadata
     {
         $config = $this->loadMappingFile($file);
         $className = $this->guessClassName($file, $config, $class);
@@ -27,11 +28,11 @@ class YamlDriver extends AbstractFileDriver
             $fieldMetadata = [
                 'mapping' => $mappingData['mapping'],
                 'propertyName' => $field,
-                'fileNameProperty' => isset($mappingData['filename_property']) ? $mappingData['filename_property'] : null,
-                'size' => isset($mappingData['size']) ? $mappingData['size'] : null,
-                'mimeType' => isset($mappingData['mime_type']) ? $mappingData['mime_type'] : null,
-                'originalName' => isset($mappingData['original_name']) ? $mappingData['original_name'] : null,
-                'dimensions' => isset($mappingData['dimensions']) ? $mappingData['dimensions'] : null,
+                'fileNameProperty' => $mappingData['filename_property'] ?? null,
+                'size' => $mappingData['size'] ?? null,
+                'mimeType' => $mappingData['mime_type'] ?? null,
+                'originalName' => $mappingData['original_name'] ?? null,
+                'dimensions' => $mappingData['dimensions'] ?? null,
             ];
 
             $classMetadata->fields[$field] = $fieldMetadata;
@@ -42,13 +43,13 @@ class YamlDriver extends AbstractFileDriver
 
     protected function loadMappingFile($file)
     {
-        return YmlParser::parse(file_get_contents($file));
+        return YmlParser::parse(\file_get_contents($file));
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getExtension()
+    protected function getExtension(): string
     {
         return 'yml';
     }
@@ -56,11 +57,11 @@ class YamlDriver extends AbstractFileDriver
     protected function guessClassName($file, array $config, \ReflectionClass $class = null)
     {
         if (null === $class) {
-            return current(array_keys($config));
+            return \current(\array_keys($config));
         }
 
         if (!isset($config[$class->name])) {
-            throw new \RuntimeException(sprintf('Expected metadata for class %s to be defined in %s.', $class->name, $file));
+            throw new \RuntimeException(\sprintf('Expected metadata for class %s to be defined in %s.', $class->name, $file));
         }
 
         return $class->name;

--- a/Tests/Adapter/ODM/MongoDB/MongoDBAdapterTest.php
+++ b/Tests/Adapter/ODM/MongoDB/MongoDBAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Adapter\ODM\MongoDB;
 
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use PHPUnit\Framework\TestCase;
 use Vich\UploaderBundle\Adapter\ODM\MongoDB\MongoDBAdapter;
 use Vich\UploaderBundle\Tests\DummyEntity;
@@ -15,7 +16,7 @@ class MongoDBAdapterTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        if (!class_exists('Doctrine\ODM\MongoDB\Event\LifecycleEventArgs')) {
+        if (!\class_exists(LifecycleEventArgs::class)) {
             self::markTestSkipped('Doctrine\ODM\MongoDB\Event\LifecycleEventArgs does not exist.');
         }
     }
@@ -27,7 +28,7 @@ class MongoDBAdapterTest extends TestCase
     {
         $entity = new DummyEntity();
 
-        $args = $this->getMockBuilder('Doctrine\ODM\MongoDB\Event\LifecycleEventArgs')
+        $args = $this->getMockBuilder(LifecycleEventArgs::class)
             ->disableOriginalConstructor()
             ->getMock();
         $args

--- a/Tests/Adapter/ORM/DoctrineORMAdapterTest.php
+++ b/Tests/Adapter/ORM/DoctrineORMAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Adapter\ORM;
 
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use PHPUnit\Framework\TestCase;
 use Vich\UploaderBundle\Adapter\ORM\DoctrineORMAdapter;
 use Vich\UploaderBundle\Tests\DummyEntity;
@@ -15,7 +16,7 @@ class DoctrineORMAdapterTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        if (!class_exists('Doctrine\ORM\Event\LifecycleEventArgs')) {
+        if (!\class_exists(LifecycleEventArgs::class)) {
             self::markTestSkipped('Doctrine\ORM\Event\LifecycleEventArgs does not exist.');
         }
     }
@@ -27,7 +28,7 @@ class DoctrineORMAdapterTest extends TestCase
     {
         $entity = new DummyEntity();
 
-        $args = $this->getMockBuilder('Doctrine\ORM\Event\LifecycleEventArgs')
+        $args = $this->getMockBuilder(LifecycleEventArgs::class)
             ->disableOriginalConstructor()
             ->getMock();
         $args

--- a/Tests/Adapter/PHPCR/PHPCRAdapterTest.php
+++ b/Tests/Adapter/PHPCR/PHPCRAdapterTest.php
@@ -14,7 +14,7 @@ class PHPCRAdapterTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        if (!class_exists(LifecycleEventArgs::class)) {
+        if (!\class_exists(LifecycleEventArgs::class)) {
             self::markTestSkipped('Doctrine\Common\Persistence\Event\LifecycleEventArgs does not exist.');
         }
     }

--- a/Tests/Adapter/Propel/PropelORMAdapterTest.php
+++ b/Tests/Adapter/Propel/PropelORMAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Tests\Adapter\Propel;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Vich\UploaderBundle\Adapter\Propel\PropelORMAdapter;
 
 /**
@@ -16,7 +17,7 @@ class PropelORMAdapterTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\GenericEvent')) {
+        if (!\class_exists(GenericEvent::class)) {
             self::markTestSkipped('Symfony\Component\EventDispatcher\GenericEvent does not exist.');
         }
     }
@@ -28,7 +29,7 @@ class PropelORMAdapterTest extends TestCase
 
     public function testGetObjectFromArgs(): void
     {
-        $event = $this->createMock('\Symfony\Component\EventDispatcher\GenericEvent');
+        $event = $this->createMock(GenericEvent::class);
         $event
             ->expects($this->once())
             ->method('getSubject')
@@ -39,7 +40,7 @@ class PropelORMAdapterTest extends TestCase
 
     public function testRecomputeChangeset(): void
     {
-        $event = $this->createMock('\Symfony\Component\EventDispatcher\GenericEvent');
+        $event = $this->createMock(GenericEvent::class);
 
         // does nothing but should be callable
         $this->adapter->recomputeChangeSet($event);

--- a/Tests/DependencyInjection/VichUploaderExtensionTest.php
+++ b/Tests/DependencyInjection/VichUploaderExtensionTest.php
@@ -5,6 +5,8 @@ namespace Vich\UploaderBundle\Tests\DependencyInjection;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 use Vich\UploaderBundle\DependencyInjection\VichUploaderExtension;
+use Vich\UploaderBundle\Storage\FlysystemStorage;
+use Vich\UploaderBundle\Twig\Extension\UploaderExtension;
 
 class VichUploaderExtensionTest extends AbstractExtensionTestCase
 {
@@ -30,7 +32,7 @@ class VichUploaderExtensionTest extends AbstractExtensionTestCase
         $this->container->setParameter('kernel.bundles_metadata', []);
         $this->container->setParameter('kernel.root_dir', __DIR__.'/../Fixtures/App/app');
         $this->container->setParameter('kernel.project_dir', __DIR__.'/../Fixtures/App');
-        $this->container->setParameter('kernel.cache_dir', sys_get_temp_dir());
+        $this->container->setParameter('kernel.cache_dir', \sys_get_temp_dir());
         $this->container->setParameter('kernel.debug', true);
     }
 
@@ -59,8 +61,8 @@ class VichUploaderExtensionTest extends AbstractExtensionTestCase
             'storage' => 'flysystem',
         ]);
 
-        $this->assertContainerBuilderHasService('vich_uploader.storage.flysystem', 'Vich\UploaderBundle\Storage\FlysystemStorage');
-        $this->assertContainerBuilderHasService('vich_uploader.twig.extension.uploader', 'Vich\UploaderBundle\Twig\Extension\UploaderExtension');
+        $this->assertContainerBuilderHasService('vich_uploader.storage.flysystem', FlysystemStorage::class);
+        $this->assertContainerBuilderHasService('vich_uploader.twig.extension.uploader', UploaderExtension::class);
     }
 
     public function testMappingsServiceParameterIsSet(): void

--- a/Tests/EventListener/Doctrine/CleanListenerTest.php
+++ b/Tests/EventListener/Doctrine/CleanListenerTest.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Tests\EventListener\Doctrine;
 
 use Vich\UploaderBundle\EventListener\Doctrine\CleanListener;
+use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
  * Doctrine CleanListener test.
@@ -39,13 +40,13 @@ class CleanListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+            ->with(DummyEntity::class, self::MAPPING_NAME)
             ->will($this->returnValue([
                 ['propertyName' => 'field_name'],
             ]));
@@ -71,7 +72,7 @@ class CleanListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(false));
 
         $this->handler

--- a/Tests/EventListener/Doctrine/InjectListenerTest.php
+++ b/Tests/EventListener/Doctrine/InjectListenerTest.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Tests\EventListener\Doctrine;
 
 use Vich\UploaderBundle\EventListener\Doctrine\InjectListener;
+use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
  * Doctrine InjectListener test.
@@ -39,13 +40,13 @@ class InjectListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+            ->with(DummyEntity::class, self::MAPPING_NAME)
             ->will($this->returnValue([
                 ['propertyName' => 'field_name'],
             ]));
@@ -66,7 +67,7 @@ class InjectListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(false));
 
         $this->handler

--- a/Tests/EventListener/Doctrine/ListenerTestCase.php
+++ b/Tests/EventListener/Doctrine/ListenerTestCase.php
@@ -75,7 +75,7 @@ class ListenerTestCase extends TestCase
      */
     protected function getAdapterMock()
     {
-        return $this->createMock('Vich\UploaderBundle\Adapter\AdapterInterface');
+        return $this->createMock(AdapterInterface::class);
     }
 
     /**
@@ -85,7 +85,7 @@ class ListenerTestCase extends TestCase
      */
     protected function getMetadataReaderMock()
     {
-        return $this->getMockBuilder('Vich\UploaderBundle\Metadata\MetadataReader')
+        return $this->getMockBuilder(MetadataReader::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -97,7 +97,7 @@ class ListenerTestCase extends TestCase
      */
     protected function getHandlerMock()
     {
-        return $this->getMockBuilder('Vich\UploaderBundle\Handler\UploadHandler')
+        return $this->getMockBuilder(UploadHandler::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -109,7 +109,7 @@ class ListenerTestCase extends TestCase
      */
     protected function getEventMock()
     {
-        return $this->getMockBuilder('Doctrine\Common\EventArgs')
+        return $this->getMockBuilder(EventArgs::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/EventListener/Doctrine/RemoveListenerTest.php
+++ b/Tests/EventListener/Doctrine/RemoveListenerTest.php
@@ -4,6 +4,7 @@ namespace Vich\UploaderBundle\Tests\EventListener\Doctrine;
 
 use Doctrine\Common\Persistence\Proxy;
 use Vich\UploaderBundle\EventListener\Doctrine\RemoveListener;
+use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
  * Doctrine RemoveListener test.
@@ -72,13 +73,13 @@ class RemoveListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+            ->with(DummyEntity::class, self::MAPPING_NAME)
             ->will($this->returnValue([
                 ['propertyName' => 'field_name'],
             ]));
@@ -99,7 +100,7 @@ class RemoveListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(false));
 
         $this->handler
@@ -116,7 +117,7 @@ class RemoveListenerTest extends ListenerTestCase
      */
     protected function getEntityProxyMock()
     {
-        return $this->getMockBuilder('Doctrine\Common\Persistence\Proxy')
+        return $this->getMockBuilder(Proxy::class)
             ->setMockClassName('VichUploaderEntityProxy')
             ->getMock();
     }

--- a/Tests/EventListener/Doctrine/UploadListenerTest.php
+++ b/Tests/EventListener/Doctrine/UploadListenerTest.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Tests\EventListener\Doctrine;
 
 use Vich\UploaderBundle\EventListener\Doctrine\UploadListener;
+use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
  * Doctrine UploadListener test.
@@ -39,13 +40,13 @@ class UploadListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+            ->with(DummyEntity::class, self::MAPPING_NAME)
             ->will($this->returnValue([
                 ['propertyName' => 'field_name'],
             ]));
@@ -66,7 +67,7 @@ class UploadListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(false));
 
         $this->handler
@@ -89,13 +90,13 @@ class UploadListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+            ->with(DummyEntity::class, self::MAPPING_NAME)
             ->will($this->returnValue([
                 ['propertyName' => 'field_name'],
             ]));
@@ -116,7 +117,7 @@ class UploadListenerTest extends ListenerTestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(false));
 
         $this->adapter

--- a/Tests/EventListener/Propel/ListenerTestCase.php
+++ b/Tests/EventListener/Propel/ListenerTestCase.php
@@ -71,7 +71,7 @@ class ListenerTestCase extends TestCase
         $this->metadata
             ->expects($this->any())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity', self::MAPPING_NAME)
+            ->with(DummyEntity::class, self::MAPPING_NAME)
             ->will($this->returnValue([
                 ['propertyName' => self::FIELD_NAME],
             ]));
@@ -84,7 +84,7 @@ class ListenerTestCase extends TestCase
      */
     protected function getAdapterMock()
     {
-        return $this->createMock('Vich\UploaderBundle\Adapter\AdapterInterface');
+        return $this->createMock(AdapterInterface::class);
     }
 
     /**
@@ -94,7 +94,7 @@ class ListenerTestCase extends TestCase
      */
     protected function getHandlerMock()
     {
-        return $this->getMockBuilder('Vich\UploaderBundle\Handler\UploadHandler')
+        return $this->getMockBuilder(UploadHandler::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -106,7 +106,7 @@ class ListenerTestCase extends TestCase
      */
     protected function getEventMock()
     {
-        return $this->getMockBuilder('\Symfony\Component\EventDispatcher\GenericEvent')
+        return $this->getMockBuilder(GenericEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -118,7 +118,7 @@ class ListenerTestCase extends TestCase
      */
     protected function getMetadataReaderMock()
     {
-        return $this->getMockBuilder('Vich\UploaderBundle\Metadata\MetadataReader')
+        return $this->getMockBuilder(MetadataReader::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Fixtures/App/app/AppKernel.php
+++ b/Tests/Fixtures/App/app/AppKernel.php
@@ -24,11 +24,11 @@ class AppKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir().'/VichUploaderBundle/cache';
+        return \sys_get_temp_dir().'/VichUploaderBundle/cache';
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir().'/VichUploaderBundle/logs';
+        return \sys_get_temp_dir().'/VichUploaderBundle/logs';
     }
 }

--- a/Tests/Form/Type/VichImageTypeTest.php
+++ b/Tests/Form/Type/VichImageTypeTest.php
@@ -136,7 +136,7 @@ class VichImageTypeTest extends VichFileTypeTest
 
     public function testLiipImagineBundleIntegration(): void
     {
-        if (!class_exists(CacheManager::class)) {
+        if (!\class_exists(CacheManager::class)) {
             $this->markTestSkipped('LiipImagineBundle is not installed.');
         }
 

--- a/Tests/Functional/WebTestCase.php
+++ b/Tests/Functional/WebTestCase.php
@@ -21,8 +21,7 @@ class WebTestCase extends BaseWebTestCase
         return new UploadedFile(
             $this->getImagesDir($client).\DIRECTORY_SEPARATOR.$name,
             $name,
-            $mimeType,
-            123
+            $mimeType
         );
     }
 

--- a/Tests/Handler/DownloadHandlerTest.php
+++ b/Tests/Handler/DownloadHandlerTest.php
@@ -87,7 +87,7 @@ class DownloadHandlerTest extends TestCase
         $response = $this->handler->downloadObject($this->object, 'file_field');
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertRegexp(sprintf('/attachment; filename=["]{0,1}%s["]{0,1}/', $expectedFileName), $response->headers->get('Content-Disposition'));
+        $this->assertRegexp(\sprintf('/attachment; filename=["]{0,1}%s["]{0,1}/', $expectedFileName), $response->headers->get('Content-Disposition'));
     }
 
     /**
@@ -123,7 +123,7 @@ class DownloadHandlerTest extends TestCase
         $response = $this->handler->downloadObject($this->object, 'file_field', null, null, false);
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertRegexp(sprintf('/inline; filename=["]{0,1}%s["]{0,1}/', $expectedFileName), $response->headers->get('Content-Disposition'));
+        $this->assertRegexp(\sprintf('/inline; filename=["]{0,1}%s["]{0,1}/', $expectedFileName), $response->headers->get('Content-Disposition'));
     }
 
     /**
@@ -152,7 +152,7 @@ class DownloadHandlerTest extends TestCase
         $response = $this->handler->downloadObject($this->object, 'file_field');
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertRegexp(sprintf('/attachment; filename=["]{0,1}%s["]{0,1}/', $expectedFileName), $response->headers->get('Content-Disposition'));
+        $this->assertRegexp(\sprintf('/attachment; filename=["]{0,1}%s["]{0,1}/', $expectedFileName), $response->headers->get('Content-Disposition'));
     }
 
     public function testDownloadObjectCallOriginalName(): void
@@ -188,7 +188,7 @@ class DownloadHandlerTest extends TestCase
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
         $expectedFileName = $this->object->getImageOriginalName();
-        $this->assertRegexp(sprintf('/attachment; filename=["]{0,1}%s["]{0,1}/', $expectedFileName), $response->headers->get('Content-Disposition'));
+        $this->assertRegexp(\sprintf('/attachment; filename=["]{0,1}%s["]{0,1}/', $expectedFileName), $response->headers->get('Content-Disposition'));
     }
 
     public function testNonAsciiFilenameIsTransliterated(): void

--- a/Tests/Handler/UploadHandlerTest.php
+++ b/Tests/Handler/UploadHandlerTest.php
@@ -2,10 +2,13 @@
 
 namespace Vich\UploaderBundle\Tests\Handler;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Vich\TestBundle\Entity\Article;
 use Vich\UploaderBundle\Event\Event;
 use Vich\UploaderBundle\Event\Events;
 use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Injector\FileInjectorInterface;
+use Vich\UploaderBundle\Storage\StorageInterface;
 use Vich\UploaderBundle\Tests\TestCase;
 
 /**
@@ -207,17 +210,17 @@ class UploadHandlerTest extends TestCase
 
     protected function getStorageMock()
     {
-        return $this->createMock('Vich\UploaderBundle\Storage\StorageInterface');
+        return $this->createMock(StorageInterface::class);
     }
 
     protected function getInjectorMock()
     {
-        return $this->createMock('Vich\UploaderBundle\Injector\FileInjectorInterface');
+        return $this->createMock(FileInjectorInterface::class);
     }
 
     protected function getDispatcherMock()
     {
-        return $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        return $this->createMock(EventDispatcherInterface::class);
     }
 
     protected function validEvent()

--- a/Tests/Injector/FileInjectorTest.php
+++ b/Tests/Injector/FileInjectorTest.php
@@ -3,8 +3,10 @@
 namespace Vich\UploaderBundle\Tests\Injector;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Injector\FileInjector;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Storage\GaufretteStorage;
+use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
  * FileInjectorTest.
@@ -31,9 +33,9 @@ class FileInjectorTest extends TestCase
      */
     public function testInjectsOneFile(): void
     {
-        $obj = $this->createMock('Vich\UploaderBundle\Tests\DummyEntity');
+        $obj = $this->createMock(DummyEntity::class);
 
-        $fileMapping = $this->getMockBuilder('Vich\UploaderBundle\Mapping\PropertyMapping')
+        $fileMapping = $this->getMockBuilder(PropertyMapping::class)
             ->disableOriginalConstructor()
             ->getMock();
         $fileMapping
@@ -60,9 +62,9 @@ class FileInjectorTest extends TestCase
      */
     public function testPropertyIsNullWhenFileNamePropertyIsNull(): void
     {
-        $obj = $this->createMock('Vich\UploaderBundle\Tests\DummyEntity');
+        $obj = $this->createMock(DummyEntity::class);
 
-        $fileMapping = $this->getMockBuilder('Vich\UploaderBundle\Mapping\PropertyMapping')
+        $fileMapping = $this->getMockBuilder(PropertyMapping::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -82,7 +84,7 @@ class FileInjectorTest extends TestCase
      */
     protected function getMockStorage()
     {
-        return $this->getMockBuilder('Vich\UploaderBundle\Storage\GaufretteStorage')
+        return $this->getMockBuilder(GaufretteStorage::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Mapping/PropertyMappingFactoryTest.php
+++ b/Tests/Mapping/PropertyMappingFactoryTest.php
@@ -2,10 +2,13 @@
 
 namespace Vich\UploaderBundle\Tests\Mapping;
 
+use Doctrine\Common\Persistence\Proxy;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 use Vich\UploaderBundle\Metadata\MetadataReader;
+use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
+use Vich\UploaderBundle\Naming\NamerInterface;
 use Vich\UploaderBundle\Tests\DummyEntity;
 
 /**
@@ -87,7 +90,7 @@ class PropertyMappingFactoryTest extends TestCase
 
         $this->assertCount(1, $mappings);
 
-        $mapping = current($mappings);
+        $mapping = \current($mappings);
 
         $this->assertEquals('dummy_file', $mapping->getMappingName());
         $this->assertEquals('images', $mapping->getUploadDestination());
@@ -98,13 +101,13 @@ class PropertyMappingFactoryTest extends TestCase
     public function fromObjectProvider(): array
     {
         $obj = new DummyEntity();
-        $proxy = $this->createMock('Doctrine\Common\Persistence\Proxy');
+        $proxy = $this->createMock(Proxy::class);
 
         return [
-            [$obj, null, 'Vich\UploaderBundle\Tests\DummyEntity'],
-            [$obj, 'Vich\UploaderBundle\Tests\DummyEntity', 'Vich\UploaderBundle\Tests\DummyEntity'],
-            [$proxy, 'Vich\UploaderBundle\Tests\DummyEntity', 'Vich\UploaderBundle\Tests\DummyEntity'],
-            [[], 'Vich\UploaderBundle\Tests\DummyEntity', 'Vich\UploaderBundle\Tests\DummyEntity'],
+            [$obj, null, DummyEntity::class],
+            [$obj, DummyEntity::class, DummyEntity::class],
+            [$proxy, DummyEntity::class, DummyEntity::class],
+            [[], DummyEntity::class, DummyEntity::class],
         ];
     }
 
@@ -131,13 +134,13 @@ class PropertyMappingFactoryTest extends TestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue([
                 'file' => [
                     'mapping' => 'dummy_file',
@@ -150,7 +153,7 @@ class PropertyMappingFactoryTest extends TestCase
 
         $this->assertCount(1, $mappings);
 
-        $mapping = current($mappings);
+        $mapping = \current($mappings);
 
         $this->assertEquals('dummy_file', $mapping->getMappingName());
         $this->assertEquals('images', $mapping->getUploadDestination());
@@ -177,13 +180,13 @@ class PropertyMappingFactoryTest extends TestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue([
                 'file' => [
                     'mapping' => 'dummy_file',
@@ -204,7 +207,7 @@ class PropertyMappingFactoryTest extends TestCase
 
         $this->assertCount(1, $mappings);
 
-        $mapping = current($mappings);
+        $mapping = \current($mappings);
 
         $this->assertEquals('other_mapping', $mapping->getMappingName());
     }
@@ -224,13 +227,13 @@ class PropertyMappingFactoryTest extends TestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue([
                 'file' => [
                     'mapping' => 'dummy_file',
@@ -282,13 +285,13 @@ class PropertyMappingFactoryTest extends TestCase
     public function fromFieldProvider(): array
     {
         $obj = new DummyEntity();
-        $proxy = $this->createMock('Doctrine\Common\Persistence\Proxy');
+        $proxy = $this->createMock(Proxy::class);
 
         return [
-            [$obj, null, 'Vich\UploaderBundle\Tests\DummyEntity'],
-            [$obj, 'Vich\UploaderBundle\Tests\DummyEntity', 'Vich\UploaderBundle\Tests\DummyEntity'],
-            [$proxy, 'Vich\UploaderBundle\Tests\DummyEntity', 'Vich\UploaderBundle\Tests\DummyEntity'],
-            [[], 'Vich\UploaderBundle\Tests\DummyEntity', 'Vich\UploaderBundle\Tests\DummyEntity'],
+            [$obj, null, DummyEntity::class],
+            [$obj, DummyEntity::class, DummyEntity::class],
+            [$proxy, DummyEntity::class, DummyEntity::class],
+            [[], DummyEntity::class, DummyEntity::class],
         ];
     }
 
@@ -301,13 +304,13 @@ class PropertyMappingFactoryTest extends TestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableField')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(null));
 
         $factory = new PropertyMappingFactory($this->container, $this->metadata, []);
@@ -328,13 +331,13 @@ class PropertyMappingFactoryTest extends TestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableField')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue([
                 'mapping' => 'dummy_file',
                 'propertyName' => 'file',
@@ -356,8 +359,8 @@ class PropertyMappingFactoryTest extends TestCase
             ],
         ];
 
-        $namer = $this->createMock('Vich\UploaderBundle\Naming\NamerInterface');
-        $directoryNamer = $this->createMock('Vich\UploaderBundle\Naming\DirectoryNamerInterface');
+        $namer = $this->createMock(NamerInterface::class);
+        $directoryNamer = $this->createMock(DirectoryNamerInterface::class);
 
         $this->container
             ->method('get')
@@ -369,13 +372,13 @@ class PropertyMappingFactoryTest extends TestCase
         $this->metadata
             ->expects($this->once())
             ->method('isUploadable')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue(true));
 
         $this->metadata
             ->expects($this->once())
             ->method('getUploadableFields')
-            ->with('Vich\UploaderBundle\Tests\DummyEntity')
+            ->with(DummyEntity::class)
             ->will($this->returnValue([
                 'file' => [
                     'mapping' => 'dummy_file',
@@ -389,7 +392,7 @@ class PropertyMappingFactoryTest extends TestCase
 
         $this->assertCount(1, $mappings);
 
-        $mapping = current($mappings);
+        $mapping = \current($mappings);
 
         $this->assertEquals($namer, $mapping->getNamer());
         $this->assertTrue($mapping->hasNamer());
@@ -404,7 +407,7 @@ class PropertyMappingFactoryTest extends TestCase
      */
     protected function getContainerMock()
     {
-        return $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        return $this->createMock(ContainerInterface::class);
     }
 
     /**
@@ -414,7 +417,7 @@ class PropertyMappingFactoryTest extends TestCase
      */
     protected function getMetadataReaderMock()
     {
-        return $this->getMockBuilder('Vich\UploaderBundle\Metadata\MetadataReader')
+        return $this->getMockBuilder(MetadataReader::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Mapping/PropertyMappingTest.php
+++ b/Tests/Mapping/PropertyMappingTest.php
@@ -4,6 +4,7 @@ namespace Vich\UploaderBundle\Tests\Mapping;
 
 use Vich\TestBundle\Entity\Article;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
 use Vich\UploaderBundle\Naming\NamerInterface;
 use Vich\UploaderBundle\Tests\DummyEntity;
 use Vich\UploaderBundle\Tests\TestCase;
@@ -44,7 +45,7 @@ class PropertyMappingTest extends TestCase
             'upload_destination' => '/tmp',
         ]);
 
-        $namer = $this->createMock('Vich\UploaderBundle\Naming\DirectoryNamerInterface');
+        $namer = $this->createMock(DirectoryNamerInterface::class);
         $namer
             ->expects($this->once())
             ->method('directoryName')

--- a/Tests/Metadata/ClassMetadataTest.php
+++ b/Tests/Metadata/ClassMetadataTest.php
@@ -13,7 +13,7 @@ class ClassMetadataTest extends TestCase
         $metadata = new ClassMetadata('DateTime');
         $metadata->fields = $fields;
 
-        $deserializedMetadata = unserialize(serialize($metadata));
+        $deserializedMetadata = \unserialize(\serialize($metadata));
 
         $this->assertSame($fields, $deserializedMetadata->fields);
     }

--- a/Tests/Metadata/Driver/AnnotationDriverTest.php
+++ b/Tests/Metadata/Driver/AnnotationDriverTest.php
@@ -2,6 +2,8 @@
 
 namespace Vich\UploaderBundle\Tests\Metadata\Driver;
 
+use Doctrine\Common\Annotations\Reader;
+use Metadata\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Vich\TestBundle\Entity\Article;
 use Vich\UploaderBundle\Mapping\Annotation\UploadableField;
@@ -19,7 +21,7 @@ class AnnotationDriverTest extends TestCase
     {
         $entity = new DummyEntity();
 
-        $reader = $this->createMock('Doctrine\Common\Annotations\Reader');
+        $reader = $this->createMock(Reader::class);
         $reader
             ->expects($this->once())
             ->method('getClassAnnotation')
@@ -35,7 +37,7 @@ class AnnotationDriverTest extends TestCase
         $driver = new AnnotationDriver($reader);
         $metadata = $driver->loadMetadataForClass(new \ReflectionClass($entity));
 
-        $this->assertInstanceOf('\Vich\UploaderBundle\Metadata\ClassMetadata', $metadata);
+        $this->assertInstanceOf(ClassMetadata::class, $metadata);
         $this->assertObjectHasAttribute('fields', $metadata);
         $this->assertEquals([
             'file' => [
@@ -54,7 +56,7 @@ class AnnotationDriverTest extends TestCase
     {
         $entity = new DummyEntity();
 
-        $reader = $this->createMock('Doctrine\Common\Annotations\Reader');
+        $reader = $this->createMock(Reader::class);
         $reader
             ->expects($this->once())
             ->method('getClassAnnotation')
@@ -73,7 +75,7 @@ class AnnotationDriverTest extends TestCase
     {
         $entity = new Article();
 
-        $reader = $this->createMock('Doctrine\Common\Annotations\Reader');
+        $reader = $this->createMock(Reader::class);
         $reader
             ->expects($this->once())
             ->method('getClassAnnotation')
@@ -126,7 +128,7 @@ class AnnotationDriverTest extends TestCase
     {
         $entity = new DummyEntity();
 
-        $reader = $this->createMock('Doctrine\Common\Annotations\Reader');
+        $reader = $this->createMock(Reader::class);
         $reader
             ->expects($this->once())
             ->method('getClassAnnotation')

--- a/Tests/Metadata/MetadataReaderTest.php
+++ b/Tests/Metadata/MetadataReaderTest.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Metadata;
 
+use Metadata\AdvancedMetadataFactoryInterface;
 use PHPUnit\Framework\TestCase;
 use Vich\UploaderBundle\Metadata\MetadataReader;
 
@@ -13,7 +14,7 @@ class MetadataReaderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->factory = $this->createMock('Metadata\AdvancedMetadataFactoryInterface');
+        $this->factory = $this->createMock(AdvancedMetadataFactoryInterface::class);
         $this->reader = new MetadataReader($this->factory);
     }
 

--- a/Tests/Naming/CurrentDateTimeDirectoryNamerTest.php
+++ b/Tests/Naming/CurrentDateTimeDirectoryNamerTest.php
@@ -30,7 +30,7 @@ class CurrentDateTimeDirectoryNamerTest extends TestCase
      * @dataProvider directoryNameDataProvider
      *
      * @param int         $timestamp
-     * @param null|string $dateTimeFormat
+     * @param string|null $dateTimeFormat
      * @param string      $expectedName
      */
     public function testNameReturnsTheRightName(int $timestamp, ?string $dateTimeFormat, string $expectedName): void

--- a/Tests/Naming/OrignameNamerTest.php
+++ b/Tests/Naming/OrignameNamerTest.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Naming;
 
+use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Naming\OrignameNamer;
 use Vich\UploaderBundle\Tests\TestCase;
 
@@ -34,7 +35,7 @@ class OrignameNamerTest extends TestCase
 
         $entity = new \DateTime();
 
-        $mapping = $this->getMockBuilder('Vich\UploaderBundle\Mapping\PropertyMapping')
+        $mapping = $this->getMockBuilder(PropertyMapping::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mapping->expects($this->once())

--- a/Tests/Naming/UniqidNamerTest.php
+++ b/Tests/Naming/UniqidNamerTest.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Naming;
 
+use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Naming\UniqidNamer;
 use Vich\UploaderBundle\Tests\TestCase;
 
@@ -40,7 +41,7 @@ class UniqidNamerTest extends TestCase
 
         $entity = new \DateTime();
 
-        $mapping = $this->getMockBuilder('Vich\UploaderBundle\Mapping\PropertyMapping')
+        $mapping = $this->getMockBuilder(PropertyMapping::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mapping->expects($this->once())

--- a/Tests/Storage/FileSystemStorageTest.php
+++ b/Tests/Storage/FileSystemStorageTest.php
@@ -99,7 +99,7 @@ class FileSystemStorageTest extends StorageTestCase
 
         $path = $this->storage->resolvePath($this->object, 'file_field');
 
-        $this->assertEquals(sprintf('/tmp%sfile.txt', \DIRECTORY_SEPARATOR), $path);
+        $this->assertEquals(\sprintf('/tmp%sfile.txt', \DIRECTORY_SEPARATOR), $path);
     }
 
     /**
@@ -125,7 +125,7 @@ class FileSystemStorageTest extends StorageTestCase
 
         $path = $this->storage->resolvePath($this->object, 'file_field', null, true);
 
-        $this->assertEquals(sprintf('upload_dir%sfile.txt', \DIRECTORY_SEPARATOR), $path);
+        $this->assertEquals(\sprintf('upload_dir%sfile.txt', \DIRECTORY_SEPARATOR), $path);
     }
 
     public function testResolveUriReturnsNullIfNoFile(): void

--- a/Tests/Storage/FlysystemStorageTest.php
+++ b/Tests/Storage/FlysystemStorageTest.php
@@ -28,7 +28,7 @@ class FlysystemStorageTest extends StorageTestCase
 
     public static function setUpBeforeClass(): void
     {
-        if (!class_exists('League\Flysystem\MountManager')) {
+        if (!\class_exists(MountManager::class)) {
             self::markTestSkipped('Flysystem is not installed.');
         }
     }
@@ -41,7 +41,7 @@ class FlysystemStorageTest extends StorageTestCase
     protected function setUp(): void
     {
         $this->mountManager = $this->getMountManagerMock();
-        $this->filesystem = $this->createMock('League\Flysystem\FilesystemInterface');
+        $this->filesystem = $this->createMock(FilesystemInterface::class);
 
         $this->mountManager
             ->expects($this->any())
@@ -180,7 +180,7 @@ class FlysystemStorageTest extends StorageTestCase
     protected function getMountManagerMock()
     {
         return $this
-            ->getMockBuilder('League\Flysystem\MountManager')
+            ->getMockBuilder(MountManager::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Storage/GaufretteStorageTest.php
+++ b/Tests/Storage/GaufretteStorageTest.php
@@ -2,6 +2,8 @@
 
 namespace Vich\UploaderBundle\Tests\Storage;
 
+use Gaufrette\Adapter;
+use Gaufrette\Adapter\MetadataSupporter;
 use Gaufrette\Exception\FileNotFound;
 use Gaufrette\Filesystem;
 use Knp\Bundle\GaufretteBundle\FilesystemMap;
@@ -203,7 +205,7 @@ class GaufretteStorageTest extends StorageTestCase
     {
         $filesystem = $this->getFilesystemMock();
         $file = $this->getUploadedFileMock();
-        $adapter = $this->createMock('\Gaufrette\Adapter\MetadataSupporter');
+        $adapter = $this->createMock(MetadataSupporter::class);
 
         $file
             ->expects($this->once())
@@ -256,7 +258,7 @@ class GaufretteStorageTest extends StorageTestCase
 
     public function testUploadDoesNotSetMetadataWhenUsingNonMetadataSupporterAdapter(): void
     {
-        $adapter = $this->createMock('\Gaufrette\Adapter');
+        $adapter = $this->createMock(Adapter::class);
         $filesystem = $this->getFilesystemMock();
         $file = $this->getUploadedFileMock();
 

--- a/Tests/Templating/Helper/UploadHelperTest.php
+++ b/Tests/Templating/Helper/UploadHelperTest.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Tests\Templating\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Vich\UploaderBundle\Storage\StorageInterface;
 use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
 
 /**
@@ -18,7 +19,7 @@ class UploadHelperTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->storage = $this->createMock('Vich\UploaderBundle\Storage\StorageInterface');
+        $this->storage = $this->createMock(StorageInterface::class);
         $this->helper = new UploaderHelper($this->storage);
     }
 

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -12,7 +12,7 @@ class TestCase extends BaseTestCase
     protected function getUploadedFileMock(): UploadedFile
     {
         return $this->getMockBuilder(UploadedFile::class)
-            ->setConstructorArgs(['lala', 'lala', $mimeType = null, $size = null, $error = 9, $test = true])
+            ->setConstructorArgs(['lala', 'lala', $mimeType = null, $error = 9, $test = true])
             ->getMock();
     }
 

--- a/Tests/Twig/Extension/UploaderExtensionTest.php
+++ b/Tests/Twig/Extension/UploaderExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
 use Vich\UploaderBundle\Twig\Extension\UploaderExtension;
 
 /**
@@ -18,7 +19,7 @@ class UploaderExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->helper = $this->getMockBuilder('Vich\UploaderBundle\Templating\Helper\UploaderHelper')->disableOriginalConstructor()->getMock();
+        $this->helper = $this->getMockBuilder(UploaderHelper::class)->disableOriginalConstructor()->getMock();
         $this->extension = new UploaderExtension($this->helper);
     }
 

--- a/Util/ClassUtils.php
+++ b/Util/ClassUtils.php
@@ -22,7 +22,7 @@ class ClassUtils
      */
     public static function getClass($object): string
     {
-        if (class_exists(DoctrineClassUtils::class)) {
+        if (\class_exists(DoctrineClassUtils::class)) {
             return DoctrineClassUtils::getClass($object);
         }
 

--- a/Util/FilenameUtils.php
+++ b/Util/FilenameUtils.php
@@ -20,10 +20,10 @@ final class FilenameUtils
      */
     public static function spitNameByExtension(string $filename): array
     {
-        if (false === $pos = strrpos($filename, '.')) {
+        if (false === $pos = \strrpos($filename, '.')) {
             return [$filename, ''];
         }
 
-        return [substr($filename, 0, $pos), substr($filename, $pos + 1)];
+        return [\substr($filename, 0, $pos), \substr($filename, $pos + 1)];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
+        "ext-simplexml": "*",
         "behat/transliterator": "^1.2",
-        "jms/metadata": "^1.6",
+        "jms/metadata": "^2.0",
         "symfony/config": "^3.4|^4.0",
         "symfony/dependency-injection": "^3.4|^4.0",
         "symfony/event-dispatcher": "^3.4|^4.0",
@@ -40,7 +41,7 @@
         "doctrine/orm": "^2.5",
         "knplabs/knp-gaufrette-bundle": "^0.5",
         "matthiasnoback/symfony-dependency-injection-test": "^2.3|^3.0",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "oneup/flysystem-bundle": "^3.0",
         "phpunit/phpunit": "^6.5|^7.0",
         "symfony/browser-kit": "^3.4|^4.0",


### PR DESCRIPTION
Hello,

This is the continuation of #918.
PR also contains:
- Up minimum php version to 7.2
- Used ::class instead of FQCN string
- phpcsfixer fix
- remove php 7.1 from travis
- fix some tests deprecations