### PR TITLE
Fix issue with not loading the profiler template

### DIFF
--- a/Resources/config/collector.xml
+++ b/Resources/config/collector.xml
@@ -7,7 +7,7 @@
     <services>
         <service class="Vich\UploaderBundle\DataCollector\MappingCollector" id="Vich\UploaderBundle\DataCollector\MappingCollector" public="false">
             <argument type="service" id="vich_uploader.metadata_reader" />
-            <tag name="data_collector" template="VichUploaderBundle::Collector/mapping_collector.html.twig" id="vich_uploader.mapping_collector" />
+            <tag name="data_collector" template="@VichUploader/Collector/mapping_collector.html.twig" id="vich_uploader.mapping_collector" />
         </service>
     </services>
 

--- a/Resources/views/Collector/mapping_collector.html.twig
+++ b/Resources/views/Collector/mapping_collector.html.twig
@@ -2,7 +2,7 @@
 
 {% block toolbar %}
     {% set icon %}
-        {% include '@VichUploaderBundle/Resources/views/Collector/icon_grey.html.twig' %}
+        {% include '@VichUploader/Collector/icon_grey.html.twig' %}
         <span class="sf-toolbar-value">{{ collector.mappingsCount }}</span>
     {% endset %}
 
@@ -20,7 +20,7 @@
     {# This left-hand menu appears when using the full-screen profiler. #}
     <span class="label">
         <span class="icon">
-            {% include '@VichUploaderBundle/Resources/views/Collector/icon_white.html.twig' %}
+            {% include '@VichUploader/Collector/icon_white.html.twig' %}
         </span>
         <strong>VichUploader</strong>
     </span>


### PR DESCRIPTION
Possible fix for #961.

I am not sure about the implications about this change, nor how to cover it with a test case. But it seems to solve the profiler toolbar issue under Symfony 4.2