### PR TITLE
Fix #774 and covers #923

### DIFF
--- a/Tests/Handler/DownloadHandlerTest.php
+++ b/Tests/Handler/DownloadHandlerTest.php
@@ -160,10 +160,12 @@ class DownloadHandlerTest extends TestCase
         $this->object->setImageOriginalName('original-name.jpeg');
 
         $this->mapping
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('readProperty')
-            ->with($this->object, 'originalName')
-            ->will($this->returnValue($this->object->getImageOriginalName()));
+            ->will($this->returnValueMap([
+                [$this->object, 'originalName', $this->object->getImageOriginalName()],
+                [$this->object, 'mimeType', $this->object->getImageMimeType()],
+            ]));
 
         $file = $this->getUploadedFileMock();
 
@@ -176,7 +178,7 @@ class DownloadHandlerTest extends TestCase
         $file
             ->expects($this->once())
             ->method('getMimeType')
-            ->will($this->returnValue(null));
+            ->will($this->returnValue('application/octet-stream'));
 
         $this->storage
             ->expects($this->once())


### PR DESCRIPTION
### Improvement

Fix: #774 and also covers #923 

|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | no
| BC Break    | no

#### Summary
Fixes null file and exception thrown during `$mapping->getFile($object)` for mimeType