### PR TITLE
Accept entity inside Transliterator

### DIFF
--- a/Util/Transliterator.php
+++ b/Util/Transliterator.php
@@ -16,13 +16,18 @@ class Transliterator
     /**
      * Transliterate a string. If string represents a filename, extension is kept.
      *
-     * @param string $string
+     * @param string|object $string
      * @param string $separator
      *
      * @return string
      */
-    public static function transliterate(string $string, string $separator = '-'): string
+    public static function transliterate($string, string $separator = '-'): string
     {
+        if (is_object($string) && method_exists($string, 'getId')) {
+            $string = $string->getId();
+        } else if (is_object($string)) {
+            throw new \TypeError("Argument 1 passed to Vich\UploaderBundle\Util\Transliterator::transliterate() must be of the type string or an object with the method getId()");
+        }
         [$filename, $extension] = FilenameUtils::spitNameByExtension($string);
 
         $transliterated = BehatTransliterator::transliterate($filename, $separator);


### PR DESCRIPTION
If an entity is linked to another the namer should be able to handle entities

```yaml
mappings:
    post_upload:
        service: vich_uploader.namer_directory_property
        options: { property: 'category', transliterate: true}
```