### PR TITLE
Allow entity property for directory namer

### DIFF
--- a/Naming/PropertyDirectoryNamer.php
+++ b/Naming/PropertyDirectoryNamer.php
@@ -69,6 +69,10 @@ class PropertyDirectoryNamer implements DirectoryNamerInterface, ConfigurableInt
             throw new NameGenerationException(sprintf('Directory name could not be generated: property %s is empty.', $this->propertyPath));
         }
 
+        if (is_object($name) && method_exists($name, 'getId')) {
+            $name = $name->getId();
+        }
+
         if ($this->transliterate) {
             $name = Transliterator::transliterate($name);
         }

--- a/Tests/DummyEntity.php
+++ b/Tests/DummyEntity.php
@@ -72,7 +72,7 @@ class DummyEntity
         return 'generated-file-name';
     }
 
-    public function setParent(DummyEntity $parent): void
+    public function setParent(self $parent): void
     {
         $this->parent = $parent;
     }

--- a/Tests/DummyEntity.php
+++ b/Tests/DummyEntity.php
@@ -22,6 +22,21 @@ class DummyEntity
 
     public $someProperty;
 
+    protected $parent;
+
+    protected $id;
+
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
     public function getFile()
     {
         return $this->file;
@@ -55,5 +70,15 @@ class DummyEntity
     public function generateFileName(): string
     {
         return 'generated-file-name';
+    }
+
+    public function setParent(DummyEntity $parent): void
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
     }
 }

--- a/Tests/DummyEntity.php
+++ b/Tests/DummyEntity.php
@@ -29,6 +29,7 @@ class DummyEntity
     public function setId(int $id): self
     {
         $this->id = $id;
+
         return $this;
     }
 

--- a/Tests/Naming/PropertyDirectoryNamerTest.php
+++ b/Tests/Naming/PropertyDirectoryNamerTest.php
@@ -18,6 +18,9 @@ class PropertyDirectoryNamerTest extends TestCase
         $entity = new DummyEntity();
         $entity->someProperty = 'foo';
 
+        $parent_entity = (new DummyEntity())->setId(12);
+        $entity->setParent($parent_entity);
+
         $weird_entity = new DummyEntity();
         $weird_entity->someProperty = 'Yéô';
 
@@ -25,6 +28,7 @@ class PropertyDirectoryNamerTest extends TestCase
             ['foo',                 $entity,       'someProperty',     false],
             ['generated-file-name', $entity,       'generateFileName', false], // method call
             ['yeo',                 $weird_entity, 'someProperty',     true],  // transliteration enabled
+            ['12',                  $entity,       'parent',           false],  // hit an object
         ];
     }
 


### PR DESCRIPTION
For a project I have to "group" files using a directory. I created a custom namer but I think it could be nice for VichUploaderBundle to be able to handle entity for the directory namer:

```yaml
vich_uploader:
    db_driver: orm

    mappings:
        blog_upload:
            upload_destination: upload
            directory_namer:
                service: App\Uploader\PropertyDirectoryNamer
                options: { property: 'category' }
```

if `getCategory()` returns an entity the namer will look for a `getId()` method instead of throwing an error.