### PR TITLE
Use whitespace control tags instead of spaceless

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -1,47 +1,43 @@
-{% block vich_file_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
-{%- endblock %}
+{%- block vich_file_row -%}
+    {%- set force_error = true -%}
+    {{- block('form_row') -}}
+{%- endblock -%}
 
-{% block vich_file_widget %}
-    {% filter spaceless %}
-        <div class="vich-file">
-            {{ form_widget(form.file) }}
-            {% if form.delete is defined %}
-                {{ form_row(form.delete) }}
-            {% endif %}
+{%- block vich_file_widget -%}
+    <div class="vich-file">
+        {{- form_widget(form.file) -}}
+        {%- if form.delete is defined -%}
+            {{- form_row(form.delete) -}}
+        {%- endif -%}
 
-            {% if download_uri %}
-                <a href="{{ download_uri }}">{{ translation_domain is same as(false) ? download_label : download_label|trans({}, translation_domain) }}</a>
-            {% endif %}
-        </div>
-    {% endfilter  %}
-{% endblock %}
+        {%- if download_uri -%}
+            <a href="{{ download_uri }}">{{ translation_domain is same as(false) ? download_label : download_label|trans({}, translation_domain) }}</a>
+        {%- endif -%}
+    </div>
+{%- endblock -%}
 
-{% block vich_image_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
-{%- endblock %}
+{%- block vich_image_row -%}
+    {%- set force_error = true -%}
+    {{- block('form_row') -}}
+{%- endblock -%}
 
-{% block vich_image_widget %}
-    {% filter spaceless %}
-        <div class="vich-image">
-            {{ form_widget(form.file) }}
-            {% if form.delete is defined %}
-                {{ form_row(form.delete) }}
-            {% endif %}
+{%- block vich_image_widget -%}
+    <div class="vich-image">
+        {{- form_widget(form.file) -}}
+        {%- if form.delete is defined -%}
+            {{- form_row(form.delete) -}}
+        {%- endif -%}
 
-            {% if image_uri %}
-                <a href="{{ image_uri }}"><img src="{{ image_uri }}" alt="" /></a>
-            {% endif %}
-            {% if download_uri %}
-                <a href="{{ download_uri }}">{{ translation_domain is same as(false) ? download_label : download_label|trans({}, translation_domain) }}</a>
-            {% endif %}
-        </div>
-    {% endfilter  %}
-{% endblock %}
+        {%- if image_uri -%}
+            <a href="{{ image_uri }}"><img src="{{ image_uri }}" alt="" /></a>
+        {%- endif -%}
+        {%- if download_uri -%}
+            <a href="{{ download_uri }}">{{ translation_domain is same as(false) ? download_label : download_label|trans({}, translation_domain) }}</a>
+        {%- endif -%}
+    </div>
+{%- endblock -%}
 
-{% block vich_file_label %}
-    {% set label = label|trans|default(label) %}
-    {{- block('form_label') }}
-{% endblock %}
+{%- block vich_file_label -%}
+    {%- set label = label|trans|default(label) -%}
+    {{- block('form_label') -}}
+{%- endblock -%}


### PR DESCRIPTION
This allows the whitespace removal to be done at compile time, rather than runtime (thus improving performance).

Additionally, this will be more compatible, as the spaceless filter does not exist until Twig 2.7 (and composer.json does not declaring any particular version of Twig as a requirement).

This is a strict improvement to #968.