### PR TITLE
Change file open mode

### DIFF
--- a/Storage/FlysystemStorage.php
+++ b/Storage/FlysystemStorage.php
@@ -34,7 +34,7 @@ class FlysystemStorage extends AbstractStorage
         $fs = $this->getFilesystem($mapping);
         $path = !empty($dir) ? $dir.'/'.$name : $name;
 
-        $stream = fopen($file->getRealPath(), 'r');
+        $stream = fopen($file->getRealPath(), 'rb');
         $fs->putStream($path, $stream, [
             'mimetype' => $file->getMimeType(),
         ]);


### PR DESCRIPTION
According to the official documentation : « If you do not specify the 'b' flag when working with binary files, you may experience strange problems with your data, including broken image files and strange problems with \r\n characters. »