### PR TITLE
add SmartUniqueNamer

### DIFF
--- a/Naming/SmartUniqueNamer.php
+++ b/Naming/SmartUniqueNamer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+use Behat\Transliterator\Transliterator;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
+/**
+ * This namer makes filename unique by appending a uniqid.
+ * Also, filename is made web-friendly by transliteration.
+ *
+ * @author Massimiliano Arione <garakkio@gmail.com>
+ */
+final class SmartUniqueNamer implements NamerInterface
+{
+    public function name($object, PropertyMapping $mapping): string
+    {
+        $file = $mapping->getFile($object);
+        $originalName = $file->getClientOriginalName();
+        $originalExtension = \pathinfo($originalName, PATHINFO_EXTENSION);
+        $originalBasename = \basename($originalName, '.'.$originalExtension);
+        $originalBasename = Transliterator::transliterate($originalBasename);
+
+        return \sprintf('%s%s.%s', $originalBasename, \str_replace('.', '', \uniqid('-', true)), $originalExtension);
+    }
+}

--- a/Resources/config/namer.xml
+++ b/Resources/config/namer.xml
@@ -19,6 +19,7 @@
             <argument type="service" id="vich_uploader.current_date_time_helper" on-invalid="null"/>
             <argument type="service" id="property_accessor" on-invalid="null"/>
         </service>
+        <service id="Vich\UploaderBundle\Naming\SmartUniqueNamer" public="true"/>
 
         <service id="vich_uploader.namer_uniqid" alias="Vich\UploaderBundle\Naming\UniqidNamer" public="true"/>
         <service id="vich_uploader.namer_property" alias="Vich\UploaderBundle\Naming\PropertyNamer" public="true"/>
@@ -28,5 +29,6 @@
         <service id="vich_uploader.directory_namer_subdir" alias="Vich\UploaderBundle\Naming\SubdirDirectoryNamer" public="true"/>
         <service id="vich_uploader.namer_directory_property" alias="Vich\UploaderBundle\Naming\PropertyDirectoryNamer" public="true"/>
         <service id="vich_uploader.namer_directory_current_date_time" alias="Vich\UploaderBundle\Naming\CurrentDateTimeDirectoryNamer" public="true"/>
+        <service id="vich_uploader.namer_smart_unique" alias="Vich\UploaderBundle\Naming\SmartUniqueNamer" public="true"/>        
     </services>
 </container>

--- a/Resources/doc/namers.md
+++ b/Resources/doc/namers.md
@@ -17,9 +17,10 @@ At the moment there are several available namers:
   * `Vich\UploaderBundle\Naming\PropertyNamer`
   * `Vich\UploaderBundle\Naming\HashNamer`
   * `Vich\UploaderBundle\Naming\Base64Namer`
+  * `Vich\UploaderBundle\Naming\SmartUniqeNamer`
 
 **UniqidNamer** will rename your uploaded files using a uniqueid for the name and
-keep the extension. Using this namer, foo.jpg will be uploaded as something like 50eb3db039715.jpg.
+keep the extension. Using this namer, foo.jpg will be uploaded as something like 0eb3db03971550eb3b0371.jpg.
 
 **OrignameNamer** will rename your uploaded files using a uniqueid as the prefix of the
 filename and keeping the original name and extension. Using this namer, foo.jpg will be uploaded as
@@ -35,6 +36,10 @@ hash `algorithm` and result `length` of the file
 You can specify the `length` of the random string. Using this namer, foo.jpg will be uploaded as something
 like 6FMNgvkdUs.jpg
 
+**SmartUniqeNamer** will rename your uploaded files appending a strong uniqueid to the original name, while 
+apllying a transliteration. Using this namer, a Strange name.jpg will be uploaded as something like
+a-strange-name-0eb3db03971550eb3b0371.jpg.
+
 To use it, you just have to specify the service for the `namer` configuration option of your mapping:
 
 ``` yaml
@@ -43,7 +48,7 @@ vich_uploader:
     mappings:
         product_image:
             upload_destination: product_image_fs
-            namer: Vich\UploaderBundle\Naming\UniqidNamer
+            namer: Vich\UploaderBundle\Naming\SmartUniqeNamer
 ```
 
 If no namer is configured for a mapping, the bundle will simply use the name of the file that

--- a/Resources/doc/namers.md
+++ b/Resources/doc/namers.md
@@ -37,7 +37,7 @@ You can specify the `length` of the random string. Using this namer, foo.jpg wil
 like 6FMNgvkdUs.jpg
 
 **SmartUniqeNamer** will rename your uploaded files appending a strong uniqueid to the original name, while 
-apllying a transliteration. Using this namer, a Strange name.jpg will be uploaded as something like
+applying a transliteration. Using this namer, a Strange name.jpg will be uploaded as something like
 a-strange-name-0eb3db03971550eb3b0371.jpg.
 
 To use it, you just have to specify the service for the `namer` configuration option of your mapping:

--- a/Tests/Naming/SmartUniqidNamerTest.php
+++ b/Tests/Naming/SmartUniqidNamerTest.php
@@ -41,11 +41,10 @@ final class SmartUniqidNamerTest extends TestCase
             ->method('getFile')
             ->with($entity)
             ->will($this->returnValue($file))
-        ; 
+        ;
 
         $namer = new SmartUniqueNamer();
 
         $this->assertRegExp($pattern, $namer->name($entity, $mapping));
     }
 }
-

--- a/Tests/Naming/SmartUniqidNamerTest.php
+++ b/Tests/Naming/SmartUniqidNamerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Naming;
+
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Naming\SmartUniqueNamer;
+use Vich\UploaderBundle\Tests\TestCase;
+
+final class SmartUniqidNamerTest extends TestCase
+{
+    public function fileDataProvider(): array
+    {
+        return [
+            // case -> original name, result pattern
+            'typical' => ['lala.jpeg', '/lala-[[:xdigit:]]{22}\.jpeg/'],
+            'accented' => ['làlà.mp3', '/lala-[[:xdigit:]]{22}\.mp3/'],
+            'spaced' => ['a Foo Bar.txt', '/a-foo-bar-[[:xdigit:]]{22}\.txt/'],
+            'special char' => ['yezz!.png', '/yezz-[[:xdigit:]]{22}\.png/'],
+        ];
+    }
+
+    /**
+     * @dataProvider fileDataProvider
+     */
+    public function testNameReturnsAnUniqueName(string $originalName, string $pattern): void
+    {
+        $file = $this->getUploadedFileMock();
+        $file
+            ->expects($this->once())
+            ->method('getClientOriginalName')
+            ->will($this->returnValue($originalName))
+        ;
+
+        $entity = new \StdClass();
+
+        $mapping = $this->getMockBuilder(PropertyMapping::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $mapping->expects($this->once())
+            ->method('getFile')
+            ->with($entity)
+            ->will($this->returnValue($file))
+        ; 
+
+        $namer = new SmartUniqueNamer();
+
+        $this->assertRegExp($pattern, $namer->name($entity, $mapping));
+    }
+}
+


### PR DESCRIPTION
Currently, this bundle has a namer for uniqueness that is too harsh (using simply uniqid) and a namer that tries to keep original name, that is too dumb (not transforming name and prepending uniqid).
This namer tries to get the best of both worlds, so it's named "smart" 😎