### PR TITLE
Compatibility with doctrine/mongodb-odm v.2.0; Drop DoctrineClassUtils;

### DIFF
--- a/Util/ClassUtils.php
+++ b/Util/ClassUtils.php
@@ -22,10 +22,25 @@ class ClassUtils
      */
     public static function getClass($object): string
     {
-        if (\class_exists(DoctrineClassUtils::class)) {
-            return DoctrineClassUtils::getClass($object);
+        $className = \get_class($object);
+
+        // __CG__: Doctrine Common Marker for Proxy (ODM < 2.0 and ORM < 3.0)
+        // __PM__: Ocramius Proxy Manager (ODM >= 2.0)
+        if ((false === $positionCg = strrpos($className, '\\__CG__\\')) &&
+            (false === $positionPm = strrpos($className, '\\__PM__\\'))) {
+            return $className;
         }
 
-        return \get_class($object);
+        if (false !== $positionCg) {
+            return substr($className, $positionCg + 8);
+        }
+
+        $className = ltrim($className, '\\');
+
+        return substr(
+            $className,
+            8 + $positionPm,
+            strrpos($className, '\\') - ($positionPm + 8)
+        );
     }
 }

--- a/Util/ClassUtils.php
+++ b/Util/ClassUtils.php
@@ -22,6 +22,7 @@ class ClassUtils
     {
         $className = \get_class($object);
 
+        // see original code @ https://github.com/api-platform/core/blob/6e9ccf7418bf973d273b125d55ccc521b89afb06/src/Util/ClassInfoTrait.php#L38
         // __CG__: Doctrine Common Marker for Proxy (ODM < 2.0 and ORM < 3.0)
         // __PM__: Ocramius Proxy Manager (ODM >= 2.0)
         if ((false === $positionCg = strrpos($className, '\\__CG__\\')) &&

--- a/Util/ClassUtils.php
+++ b/Util/ClassUtils.php
@@ -2,8 +2,6 @@
 
 namespace Vich\UploaderBundle\Util;
 
-use Doctrine\Common\Util\ClassUtils as DoctrineClassUtils;
-
 class ClassUtils
 {
     /**

--- a/Util/ClassUtils.php
+++ b/Util/ClassUtils.php
@@ -18,7 +18,7 @@ class ClassUtils
      *
      * @return string The FQCN of the given object
      */
-    public static function getClass($object): string
+    public static function getClass(object $object): string
     {
         $className = \get_class($object);
 


### PR DESCRIPTION
Trying to read metadata on a referenced document class (proxy) results in a critical exception.
Since Doctrine\Common\Util\ClassUtils is considered as deprecated:
https://github.com/doctrine/common/issues/867
I suggest this implementation:
https://github.com/api-platform/core/blob/master/src/Util/ClassInfoTrait.php#L38