### PR TITLE
Fix naming files with ".0" extension

### DIFF
--- a/Naming/Polyfill/FileExtensionTrait.php
+++ b/Naming/Polyfill/FileExtensionTrait.php
@@ -17,11 +17,11 @@ trait FileExtensionTrait
     {
         $originalName = $file->getClientOriginalName();
 
-        if ($extension = \pathinfo($originalName, PATHINFO_EXTENSION)) {
+        if ('' !== ($extension = \pathinfo($originalName, PATHINFO_EXTENSION))) {
             return $extension;
         }
 
-        if ($extension = $file->guessExtension()) {
+        if ('' !== ($extension = $file->guessExtension())) {
             return $extension;
         }
 

--- a/Naming/UniqidNamer.php
+++ b/Naming/UniqidNamer.php
@@ -17,8 +17,9 @@ class UniqidNamer implements NamerInterface
     {
         $file = $mapping->getFile($object);
         $name = \str_replace('.', '', \uniqid('', true));
+        $extension = $this->getExtension($file);
 
-        if ($extension = $this->getExtension($file)) {
+        if (\is_string($extension) && '' !== $extension) {
             $name = \sprintf('%s.%s', $name, $extension);
         }
 

--- a/Tests/Naming/UniqidNamerTest.php
+++ b/Tests/Naming/UniqidNamerTest.php
@@ -21,6 +21,9 @@ class UniqidNamerTest extends TestCase
             ['lala.mp3',      'mpga',            '/[a-z0-9]{13}.mp3/'],
             ['lala',          'mpga',            '/[a-z0-9]{13}.mpga/'],
             ['lala',          null,              '/[a-z0-9]{13}/'],
+            ['lala.0',        null,              '/[a-z0-9]{13}\\.0/'],
+            ['lala.data.0',   null,              '/[a-z0-9]{13}\\.0/'],
+            ['lala.data.0',   'gzip',            '/[a-z0-9]{13}\\.0/'],
         ];
     }
 


### PR DESCRIPTION
Files with an extension ".0" typically occur as output of file split
operations and compression utilities. Although unusual, such extensions
are valid and should be processable by VichUploader.

Fixes #1030