### PR TITLE
fix: MappingCollector::collect declaration

### DIFF
--- a/src/DataCollector/MappingCollector.php
+++ b/src/DataCollector/MappingCollector.php
@@ -5,7 +5,6 @@ namespace Vich\UploaderBundle\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
-use Throwable;
 use Vich\UploaderBundle\Metadata\MetadataReader;
 
 final class MappingCollector extends DataCollector
@@ -20,7 +19,7 @@ final class MappingCollector extends DataCollector
         $this->metadataReader = $metadataReader;
     }
 
-    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $mappings = [];
         $uploadableClasses = $this->metadataReader->getUploadableClasses();

--- a/src/DataCollector/MappingCollector.php
+++ b/src/DataCollector/MappingCollector.php
@@ -5,6 +5,7 @@ namespace Vich\UploaderBundle\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Throwable;
 use Vich\UploaderBundle\Metadata\MetadataReader;
 
 final class MappingCollector extends DataCollector
@@ -19,7 +20,7 @@ final class MappingCollector extends DataCollector
         $this->metadataReader = $metadataReader;
     }
 
-    public function collect(Request $request, Response $response, \Exception $exception = null): void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $mappings = [];
         $uploadableClasses = $this->metadataReader->getUploadableClasses();


### PR DESCRIPTION
Fixes #1061 

```
PHP Fatal error:  Declaration of Vich\UploaderBundle\DataCollector\MappingCollector::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Exception $exception = NULL): void must be compatible with Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Throwable $exception = NULL)
```