### PR TITLE
Add support for a ContainerInterface instance in FlysystemStorage

### DIFF
--- a/tests/Storage/Flysystem/MountManagerFlysystemStorageTest.php
+++ b/tests/Storage/Flysystem/MountManagerFlysystemStorageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Storage\Flysystem;
+
+use League\Flysystem\FilesystemInterface;
+use League\Flysystem\MountManager;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+final class MountManagerFlysystemStorageTest extends AbstractFlysystemStorageTest
+{
+    protected function createRegistry(FilesystemInterface $filesystem)
+    {
+        $mountManager = $this
+            ->getMockBuilder(MountManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mountManager
+            ->expects($this->any())
+            ->method('getFilesystem')
+            ->with(self::FS_KEY)
+            ->willReturn($filesystem);
+
+        return $mountManager;
+    }
+}

--- a/tests/Storage/Flysystem/PsrContainerFlysystemStorageTest.php
+++ b/tests/Storage/Flysystem/PsrContainerFlysystemStorageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Storage\Flysystem;
+
+use League\Flysystem\FilesystemInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+final class PsrContainerFlysystemStorageTest extends AbstractFlysystemStorageTest
+{
+    protected function createRegistry(FilesystemInterface $filesystem)
+    {
+        $locator = $this
+            ->getMockBuilder(ContainerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $locator
+            ->expects($this->any())
+            ->method('get')
+            ->with(self::FS_KEY)
+            ->willReturn($filesystem);
+
+        return $locator;
+    }
+}


### PR DESCRIPTION
I am currently working on integrating the official Flysystem bundle (https://github.com/thephpleague/flysystem-bundle) into this one and I realized there is a huge downside in the current implementation: the MountManager provided by OneUpFlysystemBundle is public and references *directly* all the filesystems defined with the bundle. This means that 1/ the container can't be optimized to remove unused filesystems from the compiled code and 2/ each time the MountManager service is instanciated, all the filesystem services are instanciated as well at the same time, even if they are not useful in the context. This hurts performance and can lead to unstable application if a storage tries to connect to a service which is down or inaccessible.

This PR adds support for a PSR ContainerInterface instance instead of a MountManager, to rely on the lazyness a container can have. It will also let me finalize the integration with the official bundle afterwards.