### PR TITLE
Implement support for the official Flysystem bundle and adapt documentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,8 @@
         "doctrine/mongodb-odm": "^1.2",
         "doctrine/orm": "^2.7",
         "knplabs/knp-gaufrette-bundle": "^0.7",
+        "league/flysystem-bundle": "^1.4",
+        "league/flysystem-memory": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "mikey179/vfsstream": "^1.6",
         "oneup/flysystem-bundle": "^3.3",

--- a/config/flysystem.xml
+++ b/config/flysystem.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="vich_uploader.storage.flysystem" class="Vich\UploaderBundle\Storage\FlysystemStorage" public="false">
             <argument type="service" id="vich_uploader.property_mapping_factory" />
-            <argument type="service" id="oneup_flysystem.mount_manager" />
+            <argument /><!-- Populated by RegisterFlysystemRegistryPass -->
         </service>
         <service id="Vich\UploaderBundle\Storage\FlysystemStorage" alias="vich_uploader.storage.flysystem" public="false"/>
     </services>

--- a/docs/storage/flysystem.md
+++ b/docs/storage/flysystem.md
@@ -1,15 +1,72 @@
 Flysystem
 =========
 
-> Flysystem is a filesystem abstraction which allows you to easily swap out a
-> local filesystem for a remote one.
+> Flysystem is a filesystem abstraction library for PHP. It provides an abstraction 
+> for the filesystem in order to change the storage backend depending on the execution 
+> environment (local files in development, cloud storage in production and memory in tests)
+> and your configuration.
 
+[Read the official library documentation](https://flysystem.thephpleague.com)
 
-## Configuration
+VichUploaderBundle can use Flysystem as a storage engine by relying on one of two bundles: 
+[thephpleague/flysystem-bundle](https://github.com/thephpleague/flysystem-bundle)
+or
+[oneup/flysystem-bundle](https://github.com/1up-lab/OneupFlysystemBundle).
+
+**Note:**
+
+> When using `flysystem` as the storage engine, you can still use
+> the same mappings options that you would use with default storage.
+
+## Integrating with [thephpleague/flysystem-bundle](https://github.com/thephpleague/flysystem-bundle)
+
+To install the bundle, run the following command:
+
+```
+composer require league/flysystem-bundle
+```
+
+It will create a default YAML configuration using Symfony Flex:
+
+```yaml
+# config/packages/flysystem.yaml
+
+flysystem:
+    storages:
+        default.storage:
+            adapter: 'local'
+            options:
+                directory: '%kernel.project_dir%/var/storage/default'
+```
+
+You can adapt this configuration to your needs by reading the 
+[bundle documentation](https://github.com/thephpleague/flysystem-bundle/blob/master/docs/1-getting-started.md).
+
+Once you have a storage ready, you can use it in your VichUploaderBundle configuration:
+
+``` yaml
+vich_uploader:
+    db_driver: orm
+    storage: flysystem
+
+    mappings:
+        product_image:
+            uri_prefix: /images/products
+            upload_destination: default.storage # Use the name you defined for your storage here
+```
+
+## Integrating with [oneup/flysystem-bundle](https://github.com/1up-lab/OneupFlysystemBundle)
+
+To install the bundle, run the following command:
+
+```
+composer require oneup/flysystem-bundle
+```
 
 Here is a sample configuration that stores your file in your local filesystem,
 but you can use your preferred adapters and FS (for details on this topic you
-should refer to [the official documentation](https://github.com/1up-lab/OneupFlysystemBundle/blob/master/docs/index.md)).
+should refer to
+[the bundle documentation](https://github.com/1up-lab/OneupFlysystemBundle/blob/master/docs/index.md)).
 
 ``` yaml
 oneup_flysystem:
@@ -33,20 +90,7 @@ vich_uploader:
             upload_destination: product_image_fs
 ```
 
-Even when using `flysystem` as the storage engine you can still use
-the same mappings options that you would use with default storage.
-
-**Note:**
-
-> In this case `upload_destination` refers to a Flysystem FS.
-
-**Note:**
-
-> [OneupFlysystemBundle](https://github.com/1up-lab/OneupFlysystemBundle) needs
-> to be installed and activated to get the FlysystemStorage to work.
-
-
 ## That was it!
 
-Check out the docs for information on how to use the bundle! [Return to the
-index.](../index.md)
+Check out the docs for information on how to use the bundle!
+[Return to the index.](../index.md)

--- a/src/DependencyInjection/Compiler/RegisterFlysystemRegistryPass.php
+++ b/src/DependencyInjection/Compiler/RegisterFlysystemRegistryPass.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Vich\UploaderBundle\DependencyInjection\Compiler;
+
+use League\FlysystemBundle\FlysystemBundle;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Vich\UploaderBundle\Exception\MissingPackageException;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+final class RegisterFlysystemRegistryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('vich_uploader.storage.flysystem')) {
+            return;
+        }
+
+        $storageDefinition = $container->getDefinition('vich_uploader.storage.flysystem');
+
+        // OneupFlysystemBundle
+        if ($container->hasDefinition('oneup_flysystem.mount_manager')) {
+            $storageDefinition->replaceArgument(1, new Reference('oneup_flysystem.mount_manager'));
+
+            return;
+        }
+
+        // League\FlysystemBundle
+        if (!class_exists(FlysystemBundle::class)) {
+            throw new MissingPackageException("Missing package, to use the VichUploader \"flysystem\" storage, run either:\ncomposer require league/flysystem-bundle\nor:\ncomposer require oneup/flysystem-bundle");
+        }
+
+        $registry = [];
+        foreach ($container->findTaggedServiceIds('flysystem.storage') as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                if (isset($tag['storage'])) {
+                    $registry[$tag['storage']] = new Reference($serviceId);
+                }
+            }
+        }
+
+        $storageDefinition->replaceArgument(1, ServiceLocatorTagPass::register($container, $registry));
+    }
+}

--- a/src/Exception/MissingPackageException.php
+++ b/src/Exception/MissingPackageException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Vich\UploaderBundle\Exception;
+
+class MissingPackageException extends \RuntimeException
+{
+    public function __construct($message = '', \Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/VichUploaderBundle.php
+++ b/src/VichUploaderBundle.php
@@ -4,6 +4,7 @@ namespace Vich\UploaderBundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Vich\UploaderBundle\DependencyInjection\Compiler\RegisterFlysystemRegistryPass;
 use Vich\UploaderBundle\DependencyInjection\Compiler\RegisterMappingDriversPass;
 
 /**
@@ -16,6 +17,7 @@ final class VichUploaderBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new RegisterMappingDriversPass());
+        $container->addCompilerPass(new RegisterFlysystemRegistryPass());
     }
 
     public function getPath(): string

--- a/tests/Kernel/AppKernelTrait.php
+++ b/tests/Kernel/AppKernelTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Kernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+trait AppKernelTrait
+{
+    public function getCacheDir(): string
+    {
+        return $this->createTmpDir('cache');
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->createTmpDir('logs');
+    }
+
+    private function createTmpDir(string $type): string
+    {
+        $dir = sys_get_temp_dir().'/VichUploaderBundle/'.uniqid($type.'_', true);
+
+        if (!file_exists($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return $dir;
+    }
+}

--- a/tests/Kernel/FilesystemAppKernel.php
+++ b/tests/Kernel/FilesystemAppKernel.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Vich\UploaderBundle\VichUploaderBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class FilesystemAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles(): array
+    {
+        return [new FrameworkBundle(), new VichUploaderBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret']);
+            $container->loadFromExtension('vich_uploader', [
+                'db_driver' => 'orm',
+                'mappings' => [
+                    'product_image' => [
+                        'uri_prefix' => '/images/products',
+                        'upload_destination' => '%kernel.project_dir%/public/images/products',
+                    ],
+                ],
+            ]);
+        });
+    }
+}

--- a/tests/Kernel/FlysystemOfficialAppKernel.php
+++ b/tests/Kernel/FlysystemOfficialAppKernel.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Kernel;
+
+use League\FlysystemBundle\FlysystemBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Vich\UploaderBundle\VichUploaderBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class FlysystemOfficialAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles(): array
+    {
+        return [new FrameworkBundle(), new FlysystemBundle(), new VichUploaderBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret']);
+
+            $container->loadFromExtension('flysystem', [
+                'storages' => [
+                    'uploads.storage' => ['adapter' => 'memory'],
+                ],
+            ]);
+
+            $container->loadFromExtension('vich_uploader', [
+                'db_driver' => 'orm',
+                'storage' => 'flysystem',
+                'mappings' => [
+                    'product_image' => [
+                        'uri_prefix' => '/images/products',
+                        'upload_destination' => 'uploads.storage',
+                    ],
+                ],
+            ]);
+
+            $container->setAlias('test.vich_uploader.storage', 'vich_uploader.storage')->setPublic(true);
+            $container->setAlias('test.uploads.storage', 'uploads.storage')->setPublic(true);
+        });
+    }
+}

--- a/tests/Kernel/FlysystemOneUpAppKernel.php
+++ b/tests/Kernel/FlysystemOneUpAppKernel.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Kernel;
+
+use Oneup\FlysystemBundle\OneupFlysystemBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Vich\UploaderBundle\VichUploaderBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class FlysystemOneUpAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles(): array
+    {
+        return [new FrameworkBundle(), new OneupFlysystemBundle(), new VichUploaderBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret']);
+
+            $container->loadFromExtension('oneup_flysystem', [
+                'adapters' => ['memory_adapter' => ['memory' => null]],
+                'filesystems' => [
+                    'product_image_fs' => ['adapter' => 'memory_adapter', 'mount' => 'product_image_fs'],
+                ],
+            ]);
+
+            $container->loadFromExtension('vich_uploader', [
+                'db_driver' => 'orm',
+                'storage' => 'flysystem',
+                'mappings' => [
+                    'product_image' => [
+                        'uri_prefix' => '/images/products',
+                        'upload_destination' => 'product_image_fs',
+                    ],
+                ],
+            ]);
+
+            $container->setAlias('test.vich_uploader.storage', 'vich_uploader.storage')->setPublic(true);
+        });
+    }
+}

--- a/tests/Kernel/SimpleAppKernel.php
+++ b/tests/Kernel/SimpleAppKernel.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Vich\UploaderBundle\VichUploaderBundle;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class SimpleAppKernel extends Kernel
+{
+    use AppKernelTrait;
+
+    public function registerBundles(): array
+    {
+        return [new FrameworkBundle(), new VichUploaderBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', ['secret' => '$ecret']);
+            $container->loadFromExtension('vich_uploader', ['db_driver' => 'orm']);
+        });
+    }
+}

--- a/tests/Storage/Flysystem/PsrContainerFlysystemStorageTest.php
+++ b/tests/Storage/Flysystem/PsrContainerFlysystemStorageTest.php
@@ -6,7 +6,6 @@ use League\Flysystem\FilesystemInterface;
 use Psr\Container\ContainerInterface;
 
 /**
- * @author Markus Bachmann <markus.bachmann@bachi.biz>
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
 final class PsrContainerFlysystemStorageTest extends AbstractFlysystemStorageTest

--- a/tests/VichUploaderBundleTest.php
+++ b/tests/VichUploaderBundleTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests;
+
+use League\Flysystem\FilesystemInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Storage\FlysystemStorage;
+use Vich\UploaderBundle\Tests\Kernel\FilesystemAppKernel;
+use Vich\UploaderBundle\Tests\Kernel\FlysystemOfficialAppKernel;
+use Vich\UploaderBundle\Tests\Kernel\FlysystemOneUpAppKernel;
+use Vich\UploaderBundle\Tests\Kernel\SimpleAppKernel;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+final class VichUploaderBundleTest extends TestCase
+{
+    public function testSimpleKernel(): void
+    {
+        $kernel = new SimpleAppKernel('test', true);
+        $kernel->boot();
+
+        $this->assertArrayHasKey('VichUploaderBundle', $kernel->getBundles());
+        $this->assertInstanceOf(UploadHandler::class, $kernel->getContainer()->get('vich_uploader.upload_handler'));
+    }
+
+    public function testFilesystemKernel(): void
+    {
+        $kernel = new FilesystemAppKernel('test', true);
+        $kernel->boot();
+
+        $this->assertArrayHasKey('VichUploaderBundle', $kernel->getBundles());
+        $this->assertInstanceOf(UploadHandler::class, $kernel->getContainer()->get('vich_uploader.upload_handler'));
+    }
+
+    public function testFlysystemOfficialKernel(): void
+    {
+        $kernel = new FlysystemOfficialAppKernel('test', true);
+        $kernel->boot();
+
+        $this->assertArrayHasKey('VichUploaderBundle', $kernel->getBundles());
+
+        // Test the upload
+        /** @var FilesystemInterface $filesystem */
+        $filesystem = $kernel->getContainer()->get('test.uploads.storage');
+        $this->assertFalse($filesystem->has('filename.txt'));
+
+        /** @var FlysystemStorage $storage */
+        $storage = $kernel->getContainer()->get('test.vich_uploader.storage');
+        $this->assertInstanceOf(FlysystemStorage::class, $storage);
+
+        $object = new DummyEntity();
+
+        $mapping = $this->getPropertyMappingMock();
+
+        $mapping
+            ->expects($this->once())
+            ->method('getFile')
+            ->with($object)
+            ->willReturn($this->createUploadedFile());
+
+        $mapping
+            ->expects($this->once())
+            ->method('getUploadDestination')
+            ->willReturn('uploads.storage');
+
+        $mapping
+            ->expects($this->once())
+            ->method('getUploadName')
+            ->with($object)
+            ->willReturn('filename.txt');
+
+        $mapping
+            ->expects($this->once())
+            ->method('getUploadDir')
+            ->with($object)
+            ->willReturn('');
+
+        $storage->upload($object, $mapping);
+
+        /** @var FilesystemInterface $filesystem */
+        $filesystem = $kernel->getContainer()->get('test.uploads.storage');
+        $this->assertTrue($filesystem->has('filename.txt'));
+    }
+
+    public function testFlysystemOneUpKernel(): void
+    {
+        $kernel = new FlysystemOneUpAppKernel('test', true);
+        $kernel->boot();
+
+        $this->assertArrayHasKey('VichUploaderBundle', $kernel->getBundles());
+
+        // Test the upload
+        /** @var FilesystemInterface $filesystem */
+        $filesystem = $kernel->getContainer()->get('oneup_flysystem.product_image_fs_filesystem');
+        $this->assertFalse($filesystem->has('filename.txt'));
+
+        /** @var FlysystemStorage $storage */
+        $storage = $kernel->getContainer()->get('test.vich_uploader.storage');
+        $this->assertInstanceOf(FlysystemStorage::class, $storage);
+
+        $object = new DummyEntity();
+
+        $mapping = $this->getPropertyMappingMock();
+
+        $mapping
+            ->expects($this->once())
+            ->method('getFile')
+            ->with($object)
+            ->willReturn($this->createUploadedFile());
+
+        $mapping
+            ->expects($this->once())
+            ->method('getUploadDestination')
+            ->willReturn('product_image_fs');
+
+        $mapping
+            ->expects($this->once())
+            ->method('getUploadName')
+            ->with($object)
+            ->willReturn('filename.txt');
+
+        $mapping
+            ->expects($this->once())
+            ->method('getUploadDir')
+            ->with($object)
+            ->willReturn('');
+
+        $storage->upload($object, $mapping);
+
+        /** @var FilesystemInterface $filesystem */
+        $filesystem = $kernel->getContainer()->get('oneup_flysystem.product_image_fs_filesystem');
+        $this->assertTrue($filesystem->has('filename.txt'));
+    }
+
+    private function createUploadedFile(): UploadedFile
+    {
+        return new UploadedFile(
+            __DIR__.'/Fixtures/App/app/Resources/images/symfony_black_03.png',
+            'symfony_black_03.png',
+            null,
+            null,
+            true
+        );
+    }
+}


### PR DESCRIPTION
Based on https://github.com/dustin10/VichUploaderBundle/pull/1082

Fix https://github.com/dustin10/VichUploaderBundle/issues/1015

This PR implements support for the official Flysystem bundle (https://github.com/thephpleague/flysystem-bundle). It keeps backward compatibility with OneupFlysystemBundle while adding the possibility to wire a League FilesystemBundle storage too.

This PR also adds several tests to ensure the bundle boots using various configuration options and to ensure that I did not break the OneupFlysystemBundle usage.