### PR TITLE
Fix PHPUnit 8 warnings

### DIFF
--- a/tests/Form/Type/VichFileTypeTest.php
+++ b/tests/Form/Type/VichFileTypeTest.php
@@ -40,7 +40,11 @@ class VichFileTypeTest extends TestCase
         $type->configureOptions($optionsResolver);
 
         $resolved = $optionsResolver->resolve($options);
-        $this->assertArraySubset($resolvedOptions, $resolved);
+
+        foreach ($resolvedOptions as $key => $value) {
+            $this->assertArrayHasKey($key, $resolved);
+            $this->assertSame($value, $resolved[$key]);
+        }
     }
 
     public function configureOptionsBCDataProvider(): array
@@ -67,7 +71,11 @@ class VichFileTypeTest extends TestCase
         $type->configureOptions($optionsResolver);
 
         $resolved = $optionsResolver->resolve([]);
-        $this->assertArraySubset(['download_uri' => true, 'download_link' => null], $resolved);
+
+        foreach (['download_uri' => true, 'download_link' => null] as $key => $value) {
+            $this->assertArrayHasKey($key, $resolved);
+            $this->assertSame($value, $resolved[$key]);
+        }
     }
 
     /**

--- a/tests/Handler/UploadHandlerTest.php
+++ b/tests/Handler/UploadHandlerTest.php
@@ -183,8 +183,7 @@ final class UploadHandlerTest extends TestCase
         $this->mapping
             ->expects($this->once())
             ->method('erase')
-            ->with($this->object)
-            ->willReturn(null);
+            ->with($this->object);
 
         $this->storage
             ->expects($this->once())


### PR DESCRIPTION
The following warnings were raised each time I ran the tests using PHPUnit 8:

```
There were 7 warnings:

1) Vich\UploaderBundle\Tests\Form\Type\VichFileTypeTest::testConfigureOptionsBC with data set #0 (array(true), array(true))
assertArraySubset() is deprecated and will be removed in PHPUnit 9.

2) Vich\UploaderBundle\Tests\Form\Type\VichFileTypeTest::testConfigureOptionsBC with data set #1 (array(false), array(false))
assertArraySubset() is deprecated and will be removed in PHPUnit 9.

3) Vich\UploaderBundle\Tests\Form\Type\VichFileTypeTest::testEmptyDownloadLinkDoNotThrowsDeprecation
assertArraySubset() is deprecated and will be removed in PHPUnit 9.

4) Vich\UploaderBundle\Tests\Form\Type\VichImageTypeTest::testConfigureOptionsBC with data set #0 (array(true), array(true))
assertArraySubset() is deprecated and will be removed in PHPUnit 9.

5) Vich\UploaderBundle\Tests\Form\Type\VichImageTypeTest::testConfigureOptionsBC with data set #1 (array(false), array(false))
assertArraySubset() is deprecated and will be removed in PHPUnit 9.

6) Vich\UploaderBundle\Tests\Form\Type\VichImageTypeTest::testEmptyDownloadLinkDoNotThrowsDeprecation
assertArraySubset() is deprecated and will be removed in PHPUnit 9.

7) Vich\UploaderBundle\Tests\Handler\UploadHandlerTest::testRemove
Method erase may not return value of type NULL, its return declaration is ": void"
```

This PR fixes these warnings.