### PR TITLE
Avoid the creation of a notnull constraint

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,7 +105,7 @@ class Product
      * 
      * @Vich\UploadableField(mapping="product_image", fileNameProperty="imageName", size="imageSize")
      * 
-     * @var ?File
+     * @var File|null
      */
     private $imageFile;
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,7 +105,7 @@ class Product
      * 
      * @Vich\UploadableField(mapping="product_image", fileNameProperty="imageName", size="imageSize")
      * 
-     * @var File
+     * @var ?File
      */
     private $imageFile;
 


### PR DESCRIPTION
I don't know if it's the auto-validation added since symfony4.3 that does that. 
but if I don't add the ? in the annotation: 
@var File   ->  @var ?File
I have a notnull constraint that prevents the normal behaviour of the form even if it is configured with required=false
When I edit an uploadable without wanting to change the image, the validator blocks on "imageFile can't be null".