### PR TITLE
Make it possible to use 0 as a directory or filename.

### DIFF
--- a/src/Naming/PropertyDirectoryNamer.php
+++ b/src/Naming/PropertyDirectoryNamer.php
@@ -72,7 +72,7 @@ class PropertyDirectoryNamer implements DirectoryNamerInterface, ConfigurableInt
         }
 
         // Check if string is empty (Better solution than empty())
-        if ($name === '') {
+        if ('' === $name) {
             throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s is empty.', $this->propertyPath));
         }
 

--- a/src/Naming/PropertyDirectoryNamer.php
+++ b/src/Naming/PropertyDirectoryNamer.php
@@ -71,7 +71,8 @@ class PropertyDirectoryNamer implements DirectoryNamerInterface, ConfigurableInt
             throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s does not exist.', $this->propertyPath), $e->getCode(), $e);
         }
 
-        if (empty($name)) {
+        // Check if string is empty (Better solution than empty())
+        if ($name === '') {
             throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s is empty.', $this->propertyPath));
         }
 

--- a/src/Naming/PropertyNamer.php
+++ b/src/Naming/PropertyNamer.php
@@ -68,7 +68,8 @@ class PropertyNamer implements NamerInterface, ConfigurableInterface
             throw new NameGenerationException(\sprintf('File name could not be generated: property %s does not exist.', $this->propertyPath), $e->getCode(), $e);
         }
 
-        if (empty($name)) {
+        // Check if string is empty (Better solution than empty())
+        if ($name === '') {
             throw new NameGenerationException(\sprintf('File name could not be generated: property %s is empty.', $this->propertyPath));
         }
 

--- a/src/Naming/PropertyNamer.php
+++ b/src/Naming/PropertyNamer.php
@@ -69,7 +69,7 @@ class PropertyNamer implements NamerInterface, ConfigurableInterface
         }
 
         // Check if string is empty (Better solution than empty())
-        if ($name === '') {
+        if ('' === $name) {
             throw new NameGenerationException(\sprintf('File name could not be generated: property %s is empty.', $this->propertyPath));
         }
 


### PR DESCRIPTION
The testing if $name is empty has been made with empty(), which treats a string with value 0 as zero. 
In this case this seems not correct to me, since it should be able to name a directory or even a file as 0.