### PR TITLE
Reduce number of calls to File::getMimeType() during upload.

### DIFF
--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -36,12 +36,13 @@ abstract class AbstractStorage implements StorageInterface
 
         $name = $mapping->getUploadName($obj);
         $mapping->setFileName($obj, $name);
+        $mimeType = $file->getMimeType();
 
         $mapping->writeProperty($obj, 'size', $file->getSize());
-        $mapping->writeProperty($obj, 'mimeType', $file->getMimeType());
+        $mapping->writeProperty($obj, 'mimeType', $mimeType);
         $mapping->writeProperty($obj, 'originalName', $file->getClientOriginalName());
 
-        if (false !== \strpos($file->getMimeType(), 'image/') && 'image/svg+xml' !== $file->getMimeType() && false !== $dimensions = @\getimagesize($file)) {
+        if (false !== \strpos($mimeType, 'image/') && 'image/svg+xml' !== $mimeType && false !== $dimensions = @\getimagesize($file)) {
             $mapping->writeProperty($obj, 'dimensions', \array_splice($dimensions, 0, 2));
         }
 


### PR DESCRIPTION
I had to implement a custom [`MimeTypeGuesserInterface`](https://symfony.com/doc/current/components/mime.html#adding-a-mime-type-guesser), which is quite costly to run.

This simple fix removes some redundant calls to File::getMimeType().

_Context_
_I need to handle SVG images, for which PHP's MIME detection is [somewhat bogus](https://bugs.php.net/bug.php?id=79045)_
_I will gladly share my implementation of `MimeTypeGuesserInterface` on demand. I was also able to extract [dimensions](https://github.com/dustin10/VichUploaderBundle/blob/master/src/Storage/AbstractStorage.php#L44) from the `width` and `height` SVG attributes. I would submit another PR if you are interested._