### PR TITLE
fix to problem with uppercase extension, issue #1125

### DIFF
--- a/src/Naming/SmartUniqueNamer.php
+++ b/src/Naming/SmartUniqueNamer.php
@@ -28,7 +28,7 @@ final class SmartUniqueNamer implements NamerInterface
         $file = $mapping->getFile($object);
         $originalName = $file->getClientOriginalName();
         $originalExtension = \strtolower(\pathinfo($originalName, PATHINFO_EXTENSION));
-        $originalBasename = \basename($originalName, '.'.$originalExtension);
+        $originalBasename = pathinfo($originalName, PATHINFO_FILENAME);
         $originalBasename = $this->transliterator->transliterate($originalBasename);
         $uniqId = \str_replace('.', '', \uniqid('-', true));
         $uniqExtension = \sprintf('%s.%s', $uniqId, $originalExtension);

--- a/src/Naming/SmartUniqueNamer.php
+++ b/src/Naming/SmartUniqueNamer.php
@@ -28,7 +28,7 @@ final class SmartUniqueNamer implements NamerInterface
         $file = $mapping->getFile($object);
         $originalName = $file->getClientOriginalName();
         $originalExtension = \strtolower(\pathinfo($originalName, PATHINFO_EXTENSION));
-        $originalBasename = pathinfo($originalName, PATHINFO_FILENAME);
+        $originalBasename = \pathinfo($originalName, PATHINFO_FILENAME);
         $originalBasename = $this->transliterator->transliterate($originalBasename);
         $uniqId = \str_replace('.', '', \uniqid('-', true));
         $uniqExtension = \sprintf('%s.%s', $uniqId, $originalExtension);

--- a/tests/Naming/SmartUniqidNamerTest.php
+++ b/tests/Naming/SmartUniqidNamerTest.php
@@ -23,7 +23,6 @@ final class SmartUniqidNamerTest extends TestCase
             'double extension' => ['lala.png.jpg', '/lala\.png-[[:xdigit:]]{22}\.jpg/'],
             'uppercase extension' => ['lala.JPEG', '/lala-[[:xdigit:]]{22}\.jpeg/'],
             'double uppercase extension' => ['lala.JPEG.JPEG', '/lala\.jpeg-[[:xdigit:]]{22}\.jpeg/'],
-
         ];
     }
 

--- a/tests/Naming/SmartUniqidNamerTest.php
+++ b/tests/Naming/SmartUniqidNamerTest.php
@@ -20,6 +20,10 @@ final class SmartUniqidNamerTest extends TestCase
             'long extension' => ['a.'.\str_repeat('a', 256), '/a-[[:xdigit:]]{22}\.a{230}/'],
             'long basename and extension' => [\str_repeat('a', 256).'.txt'.\str_repeat('a', 256),
                                               '/a{228}-[[:xdigit:]]{22}\.txt/', ],
+            'double extension' => ['lala.png.jpg', '/lala\.png-[[:xdigit:]]{22}\.jpg/'],
+            'uppercase extension' => ['lala.JPEG', '/lala-[[:xdigit:]]{22}\.jpeg/'],
+            'double uppercase extension' => ['lala.JPEG.JPEG', '/lala\.jpeg-[[:xdigit:]]{22}\.jpeg/'],
+
         ];
     }
 


### PR DESCRIPTION
I replaced 
line: $originalBasename = \basename($originalName, '.' .$originalExtension);
with: $originalBasename = pathinfo($originalName, PATHINFO_FILENAME);

all tests are passed