### PR TITLE
PropetyDirectoryNamer support for multiple properties

### DIFF
--- a/docs/namers.md
+++ b/docs/namers.md
@@ -142,6 +142,10 @@ vich_uploader:
             directory_namer:
                 service: vich_uploader.namer_directory_property
                 options: { property: 'slug', transliterate: true} # supposing that the object contains a "slug" attribute or a "getSlug" method
+                
+                #array version, order of properties matters
+                #both "parent" attribute and parent's "slug" attribute must be accessable
+                #options: { property: ['parent.slug', 'slug']} 
 ```
 
 **CurrentDateTimeDirectoryNamer** creates subdirs depending on the current locale datetime. By default, it will be 

--- a/src/Naming/PropertyDirectoryNamer.php
+++ b/src/Naming/PropertyDirectoryNamer.php
@@ -65,14 +65,32 @@ class PropertyDirectoryNamer implements DirectoryNamerInterface, ConfigurableInt
             throw new \LogicException('The property to use can not be determined. Did you call the configure() method?');
         }
 
+        if (!\is_array($this->propertyPath)) {
+            return $this->_directoryNameGenerator($object, $this->propertyPath);
+        }
+
+        $names = [];
+        foreach ($this->propertyPath as $p) {
+            $names[] = $this->_directoryNameGenerator($object, $p);
+        }
+
+        return \implode('/', $names);
+    }
+
+    private function _directoryNameGenerator($object, $properyPath)
+    {
+        if (empty($properyPath)) {
+            throw new \LogicException('The property to use can not be determined. Did you call the configure() method?');
+        }
+
         try {
-            $name = $this->propertyAccessor->getValue($object, $this->propertyPath);
+            $name = $this->propertyAccessor->getValue($object, $properyPath);
         } catch (NoSuchPropertyException $e) {
-            throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s does not exist.', $this->propertyPath), $e->getCode(), $e);
+            throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s does not exist.', $properyPath), $e->getCode(), $e);
         }
 
         if (empty($name)) {
-            throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s is empty.', $this->propertyPath));
+            throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s is empty.', $properyPath));
         }
 
         if ($this->transliterate) {

--- a/tests/Naming/PropertyDirectoryNamerTest.php
+++ b/tests/Naming/PropertyDirectoryNamerTest.php
@@ -25,6 +25,7 @@ class PropertyDirectoryNamerTest extends TestCase
             'plain' => ['foo',                       $entity,      'someProperty',     false],
             'method call' => ['generated-file-name', $entity,      'generateFileName', false],
             'translit.' => ['yeo',                   $weirdEntity, 'someProperty',     true],
+            'multiple property' => ['yeo/yeo',       $weirdEntity, ['someProperty', 'someProperty'], true],
         ];
     }
 
@@ -34,7 +35,7 @@ class PropertyDirectoryNamerTest extends TestCase
     public function testNameReturnsTheRightName(
         string $expectedDirectoryName,
         object $entity,
-        string $propertyName,
+        $propertyName,
         bool $transliterate
     ): void {
         $mapping = $this->getPropertyMappingMock();


### PR DESCRIPTION
Hi,
I added some enhancements to support multiple properties.
The reason to this change I needed this kind of directory structure: 
```
directory_namer:
                service: vich_uploader.namer_directory_property
                options: { property: ['user.company.id', 'user.id']}
```
given this configuration (companyId = 20, userId = 10) it generates `20/10` directory 