### PR TITLE
Deprecation since Symfony 5.1: NodeDefinition::setDeprecated() requires 3 arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ jobs:
         - php: 7.3
           env: SYMFONY_VERSION="^4.4.0" WITH_LIIP_IMAGINE=true
         - php: 7.4
-          env: VALIDATE_DOCS=false SYMFONY_VERSION="5.0.*"
-        - php: 7.4
-          env: VALIDATE_DOCS=false SYMFONY_VERSION="5.1.*"
+          env: VALIDATE_DOCS=false SYMFONY_VERSION="^5.1.0"
     allow_failures:
         - php: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ jobs:
         - php: 7.3
           env: SYMFONY_VERSION="^4.4.0" WITH_LIIP_IMAGINE=true
         - php: 7.4
-          env: VALIDATE_DOCS=false SYMFONY_VERSION="^5.0.0"
+          env: VALIDATE_DOCS=false SYMFONY_VERSION="5.0.*"
+        - php: 7.4
+          env: VALIDATE_DOCS=false SYMFONY_VERSION="5.1.*"
     allow_failures:
         - php: nightly
 
@@ -34,9 +36,12 @@ before_install:
     - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - composer self-update
     - phpenv config-rm xdebug.ini || true
-    - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update "symfony/framework-bundle:${SYMFONY_VERSION}"; fi;
+    - |
+        if [ "$SYMFONY_VERSION" != "" ]; then
+            sed -ri 's/"symfony\/(.+)": "(\^4\.[0-9]+\s*\|+\s*\^5\.[0-9]+)"/"symfony\/\1": "'$SYMFONY_VERSION'"/' composer.json;
+        fi;
     - if [ "$WITH_LIIP_IMAGINE" = true ] ; then composer require --no-update liip/imagine-bundle:"^1.7|^2.0"; fi;
-    - if [ "$VALIDATE_DOCS" = true ]; then composer require --dev --no-update kphoen/rusty dev-update-php-parser; fi
+    - if [ "$VALIDATE_DOCS" != true ]; then composer remove --dev --no-update kphoen/rusty; fi
 
 install: php -d memory_limit=-1 $(phpenv which composer) update $COMPOSER_FLAGS --no-suggest
 

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/form": "^4.4 || ^5.0",
         "symfony/http-foundation": "^4.4 || ^5.0",
         "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/mime": "^4.4 || ^5.0",
         "symfony/property-access": "^4.4 || ^5.0",
         "symfony/string": "^5.0"
     },

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -57,7 +58,7 @@ final class Configuration implements ConfigurationInterface
                         ->thenInvalid('The storage %s is not supported. Please choose one of '.\implode(', ', $this->supportedStorages).' or provide a service name prefixed with "@".')
                     ->end()
                 ->end()
-            ->scalarNode('templating')->defaultFalse()->setDeprecated('The "%node%" option is deprecated.')->end()
+            ->scalarNode('templating')->defaultFalse()->setDeprecated(...$this->getTemplatingDeprecationMessage())->end()
             ->scalarNode('twig')->defaultTrue()->info('twig requires templating')->end()
             ->scalarNode('form')->defaultTrue()->end()
             ->end()
@@ -149,5 +150,24 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    /**
+     * Keep compatibility with symfony/config < 5.1.
+     *
+     * The signature of method NodeDefinition::setDeprecated() has been updated to
+     * NodeDefinition::setDeprecation(string $package, string $version, string $message).
+     *
+     * @return array
+     */
+    private function getTemplatingDeprecationMessage(): array
+    {
+        $message = 'The "%node%" option is deprecated.';
+
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            return ['vich/uploader-bundle', '1.13.2', $message];
+        }
+
+        return [$message];
     }
 }

--- a/tests/DependencyInjection/VichUploaderExtensionTest.php
+++ b/tests/DependencyInjection/VichUploaderExtensionTest.php
@@ -138,7 +138,11 @@ class VichUploaderExtensionTest extends AbstractExtensionTestCase
         $twigExtension = new TwigExtension();
         $this->container->registerExtension($twigExtension);
 
-        $twigExtension->load([['strict_variables' => true, 'form_themes' => ['@Ololo/trololo.html.twig']]], $this->container);
+        $twigExtension->load([[
+            'strict_variables' => true,
+            'exception_controller' => null, // TODO remove after bumping symfony/twig-bundle to ^5.0
+            'form_themes' => ['@Ololo/trololo.html.twig'],
+        ]], $this->container);
         $vichUploaderExtension->load([$this->getMinimalConfiguration()], $this->container);
 
         $this->assertContainerBuilderHasParameter(

--- a/tests/Fixtures/App/app/config/config.yml
+++ b/tests/Fixtures/App/app/config/config.yml
@@ -1,7 +1,9 @@
 # Symfony Configuration
 framework:
     secret:             Hell yeah!
-    router:             { resource: "%kernel.project_dir%/app/config/routing.yml" }
+    router:
+        resource: "%kernel.project_dir%/app/config/routing.yml"
+        utf8: false
     form:               true
     csrf_protection:    true
     default_locale:     en
@@ -17,7 +19,7 @@ framework:
 twig:
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
-    exception_controller: ~
+    exception_controller: null
 
 # Doctrine Configuration
 doctrine:

--- a/tests/Handler/UploadHandlerTest.php
+++ b/tests/Handler/UploadHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Vich\UploaderBundle\Tests\Handler;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Vich\TestBundle\Entity\Article;
 use Vich\UploaderBundle\Event\Event;
 use Vich\UploaderBundle\Event\Events;
@@ -244,19 +243,11 @@ final class UploadHandlerTest extends TestCase
     protected function expectEvents(array $events): void
     {
         foreach ($events as $i => $event) {
-            if (\class_exists(LegacyEventDispatcherProxy::class)) {
-                $this->dispatcher
-                    ->expects($this->at($i))
-                    ->method('dispatch')
-                    ->with($this->validEvent(), $event)
-                ;
-            } else {
-                $this->dispatcher
-                    ->expects($this->at($i))
-                    ->method('dispatch')
-                    ->with($event, $this->validEvent())
-                ;
-            }
+            $this->dispatcher
+                ->expects($this->at($i))
+                ->method('dispatch')
+                ->with($this->validEvent(), $event)
+            ;
         }
     }
 }

--- a/tests/Kernel/FilesystemAppKernel.php
+++ b/tests/Kernel/FilesystemAppKernel.php
@@ -24,7 +24,15 @@ class FilesystemAppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(static function (ContainerBuilder $container): void {
-            $container->loadFromExtension('framework', ['secret' => '$ecret']);
+            $container->loadFromExtension('framework', [
+                'secret' => '$ecret',
+                'router' => [
+                    'resource' => 'kernel::loadRoutes',
+                    'type' => 'service',
+                    'utf8' => false,
+                ],
+            ]);
+
             $container->loadFromExtension('vich_uploader', [
                 'db_driver' => 'orm',
                 'mappings' => [

--- a/tests/Kernel/FlysystemOfficialAppKernel.php
+++ b/tests/Kernel/FlysystemOfficialAppKernel.php
@@ -24,7 +24,14 @@ class FlysystemOfficialAppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(static function (ContainerBuilder $container): void {
-            $container->loadFromExtension('framework', ['secret' => '$ecret']);
+            $container->loadFromExtension('framework', [
+                'secret' => '$ecret',
+                'router' => [
+                    'resource' => 'kernel::loadRoutes',
+                    'type' => 'service',
+                    'utf8' => false,
+                ],
+            ]);
 
             $container->loadFromExtension('flysystem', [
                 'storages' => [

--- a/tests/Kernel/FlysystemOneUpAppKernel.php
+++ b/tests/Kernel/FlysystemOneUpAppKernel.php
@@ -24,7 +24,14 @@ class FlysystemOneUpAppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(static function (ContainerBuilder $container): void {
-            $container->loadFromExtension('framework', ['secret' => '$ecret']);
+            $container->loadFromExtension('framework', [
+                'secret' => '$ecret',
+                'router' => [
+                    'resource' => 'kernel::loadRoutes',
+                    'type' => 'service',
+                    'utf8' => false,
+                ],
+            ]);
 
             $container->loadFromExtension('oneup_flysystem', [
                 'adapters' => ['memory_adapter' => ['memory' => null]],

--- a/tests/Kernel/SimpleAppKernel.php
+++ b/tests/Kernel/SimpleAppKernel.php
@@ -23,7 +23,15 @@ class SimpleAppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(static function (ContainerBuilder $container): void {
-            $container->loadFromExtension('framework', ['secret' => '$ecret']);
+            $container->loadFromExtension('framework', [
+                'secret' => '$ecret',
+                'router' => [
+                    'resource' => 'kernel::loadRoutes',
+                    'type' => 'service',
+                    'utf8' => false,
+                ],
+            ]);
+
             $container->loadFromExtension('vich_uploader', ['db_driver' => 'orm']);
         });
     }


### PR DESCRIPTION
The signature of method `NodeDefinition::setDeprecated()` has been updated to `NodeDefinition::setDeprecation(string $package, string $version, string $message)`.

See https://github.com/symfony/symfony/blob/5.1/UPGRADE-5.1.md