### PR TITLE
Added "delete_label" option to the documentation

### DIFF
--- a/docs/form/vich_file_type.md
+++ b/docs/form/vich_file_type.md
@@ -35,27 +35,13 @@ allow_delete
 
 delete_label
 --------------
-**type**: `string`, `callable`, `Symfony\Component\PropertyAccess\PropertyPath` **default**: `vich_uploader.form_label.delete_confirm`
-
-Can be string 
-```php
-use Vich\UploaderBundle\Form\Type\VichImageType;
-
-$builder->add('genericFile', VichImageType::class, [
-    'delete_label' => 'delete_file',
-]);
-
-```
-
-Can be callable
+**type**: `string` **default**: `vich_uploader.form_label.delete_confirm`
 
 ```php
 use Vich\UploaderBundle\Form\Type\VichImageType;
 
 $builder->add('genericFile', VichImageType::class, [
-    'delete_label' => static function (Product $product) {
-        return 'Delete ' . $product->getTitle();
-    },
+    'delete_label' => 'Remove file',
 ]);
 
 ```

--- a/docs/form/vich_file_type.md
+++ b/docs/form/vich_file_type.md
@@ -19,7 +19,8 @@ class Form extends AbstractType
 
         $builder->add('genericFile', VichFileType::class, [
             'required' => false,
-            'allow_delete' => true, 
+            'allow_delete' => true,
+            'delete_label' => '...',
             'download_uri' => '...',
             'download_label' => '...',
             'asset_helper' => true,
@@ -31,6 +32,33 @@ class Form extends AbstractType
 allow_delete
 ------------
 **type**: `bool` **default**: `true`
+
+delete_label
+--------------
+**type**: `string`, `callable`, `Symfony\Component\PropertyAccess\PropertyPath` **default**: `vich_uploader.form_label.delete_confirm`
+
+Can be string 
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'delete_label' => 'delete_file',
+]);
+
+```
+
+Can be callable
+
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'delete_label' => static function (Product $product) {
+        return 'Delete ' . $product->getTitle();
+    },
+]);
+
+```
 
 asset_helper
 ------------

--- a/docs/form/vich_image_type.md
+++ b/docs/form/vich_image_type.md
@@ -38,27 +38,13 @@ allow_delete
 
 delete_label
 --------------
-**type**: `string`, `callable`, `Symfony\Component\PropertyAccess\PropertyPath` **default**: `vich_uploader.form_label.delete_confirm`
-
-Can be string 
-```php
-use Vich\UploaderBundle\Form\Type\VichImageType;
-
-$builder->add('genericFile', VichImageType::class, [
-    'delete_label' => 'delete_file',
-]);
-
-```
-
-Can be callable
+**type**: `string` **default**: `vich_uploader.form_label.delete_confirm`
 
 ```php
 use Vich\UploaderBundle\Form\Type\VichImageType;
 
 $builder->add('genericFile', VichImageType::class, [
-    'delete_label' => static function (Product $product) {
-        return 'Delete ' . $product->getTitle();
-    },
+    'delete_label' => 'Remove Image',
 ]);
 
 ```

--- a/docs/form/vich_image_type.md
+++ b/docs/form/vich_image_type.md
@@ -20,6 +20,7 @@ class Form extends AbstractType
         $builder->add('imageFile', VichImageType::class, [
             'required' => false,
             'allow_delete' => true,
+            'delete_label' => '...',
             'download_label' => '...',
             'download_uri' => true,
             'image_uri' => true,
@@ -33,6 +34,34 @@ class Form extends AbstractType
 allow_delete
 ------------
 **type**: `bool` **default**: `true`
+
+
+delete_label
+--------------
+**type**: `string`, `callable`, `Symfony\Component\PropertyAccess\PropertyPath` **default**: `vich_uploader.form_label.delete_confirm`
+
+Can be string 
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'delete_label' => 'delete_file',
+]);
+
+```
+
+Can be callable
+
+```php
+use Vich\UploaderBundle\Form\Type\VichImageType;
+
+$builder->add('genericFile', VichImageType::class, [
+    'delete_label' => static function (Product $product) {
+        return 'Delete ' . $product->getTitle();
+    },
+]);
+
+```
 
 asset_helper
 ------------


### PR DESCRIPTION
Added the missing "delete_label" option to the docs.
Without this, "vich_uploader.form_label.delete_confirm" is shown (which also shows here an issue of translation)