### PR TITLE
Add cancellability for pre events

### DIFF
--- a/docs/events/events.md
+++ b/docs/events/events.md
@@ -15,6 +15,8 @@ The following is a list of events you can listen to:
 |`vich_uploader.pre_remove`|`Events::PRE_REMOVE`|before a file is removed|
 |`vich_uploader.post_remove`|`Events::POST_REMOVE`|after a file is removed|
 
+The `vich_uploader.pre_remove` event is cancelable, that means that the actual remove request will not take place, and you have to take action.
+
 Example
 -------
 
@@ -50,4 +52,4 @@ services:
             - { name: kernel.event_listener, event: vich_uploader.pre_upload }
 ```
 
-[Return to the index](index.md)
+[Return to the index](../index.md)

--- a/docs/events/howto/remove_files_asynchronously.md
+++ b/docs/events/howto/remove_files_asynchronously.md
@@ -1,0 +1,114 @@
+Remove files asynchronously
+=========================
+
+To remove files asynchronously, ensure you have the [Messenger](https://symfony.com/doc/current/messenger.html) installed.
+The messenger allows you to run tasks asynchronously, in our example the file removal.
+
+**Note**:
+
+> We recommend you to create a message and message handler for each mapping.
+> Use `instanceof` checks to send different messages in the event subscriber.
+
+**Important**:
+
+> Do not transfer the whole object and mapping or the whole event in the message.
+> The `UploadedFile` which will be stored in the object while uploading is not serializable.
+
+Create a message containing the filename of the file to be deleted.
+
+```php
+<?php
+
+namespace App\Message;
+
+class RemoveFileMessage
+{
+
+    private $filename;
+
+    public function __construct(string $filename)
+    {
+        $this->filename = $filename;
+    }
+
+    public function getFilename()
+    {
+        return $this->filename;
+    }
+
+}
+```
+
+Create a message handler that will do the actual removal.
+
+```php
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\RemoveFileMessage;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+class RemoveFileMessageHandler implements MessageHandlerInterface
+{
+    public function __invoke(RemoveFileMessage $message)
+    {
+        $filename = $message->getFilename();
+
+        // delete your file according to your mapping configuration
+    }
+
+}
+```
+
+Create a event subscriber that will cancel the remove request and dispatch a remove message.
+
+```php
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Message\RemoveFileMessage;
+use App\Entity\Foo;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Vich\UploaderBundle\Event\Event;
+use Vich\UploaderBundle\Event\Events;
+
+class RemoveFileEventSubscriber implements EventSubscriberInterface
+{
+
+    private $messageBus;
+
+    public function __construct(MessageBusInterface $messageBus)
+    {
+        $this->messageBus = $messageBus;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PRE_REMOVE => ['onPreRemove'],
+        ];
+    }
+
+    public function onPreRemove(Event $event): void
+    {
+        $event->cancel();
+
+        $object = $event->getObject();
+        $mapping = $event->getMapping();
+
+        $filename = $mapping->getFileName($object);
+
+        $message = new RemoveFileMessage($filename);
+
+        $this->messageBus->dispatch($message);
+    }
+
+}
+```
+
+## That was it!
+
+Check out the docs for information on how to use the bundle! [Return to the index.](/docs/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,10 +49,14 @@ Don't worry, it will be quick and easy (I promise!):
 
   * [Serving files with a controller](downloads/serving_files_with_a_controller.md)
 
+### Event-related
+
+  * [Events](events/events.md)
+  * [Remove files asynchronously](events/howto/remove_files_asynchronously.md)
+
 ## Useful resources
 
   * [Configuration reference](configuration_reference.md)
-  * [Events](events.md)
   * [Console commands](commands.md)
   * [Known issues](known_issues.md)
   * [Symfony support policy](symfony_support_policy.md)

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -16,6 +16,8 @@ class Event extends ContractEvent
 
     protected $mapping;
 
+    protected $cancel = false;
+
     public function __construct($object, PropertyMapping $mapping)
     {
         $this->object = $object;
@@ -39,4 +41,22 @@ class Event extends ContractEvent
     {
         return $this->mapping;
     }
+
+    /**
+     * Cancels the execution of the actual request.
+     * Only works for the vich_uploader.pre_remove event.
+     */
+    public function cancel(): void
+    {
+        $this->cancel = true;
+    }
+
+    /**
+     * Returns whether further processing of the request should be executed.
+     */
+    public function isCanceled(): bool
+    {
+        return $this->cancel;
+    }
+
 }

--- a/src/Handler/UploadHandler.php
+++ b/src/Handler/UploadHandler.php
@@ -98,7 +98,13 @@ class UploadHandler extends AbstractHandler
             return;
         }
 
-        $this->dispatch(Events::PRE_REMOVE, new Event($obj, $mapping));
+        $preEvent = new Event($obj, $mapping);
+
+        $this->dispatch(Events::PRE_REMOVE, $preEvent);
+
+        if ($preEvent->isCanceled()) {
+            return;
+        }
 
         $this->storage->remove($obj, $mapping);
         $mapping->erase($obj);

--- a/tests/Handler/UploadHandlerTest.php
+++ b/tests/Handler/UploadHandlerTest.php
@@ -192,6 +192,35 @@ final class UploadHandlerTest extends TestCase
         $this->handler->remove($this->object, self::FILE_FIELD);
     }
 
+    public function testRemoveIfEventIsCanceled(): void
+    {
+        $this->expectEvents([Events::PRE_REMOVE]);
+
+        $this->mapping
+            ->expects($this->once())
+            ->method('getFileName')
+            ->with($this->object)
+            ->willReturn('something not null');
+
+        $this->mapping
+            ->expects($this->never())
+            ->method('erase');
+
+        $this->storage
+            ->expects($this->never())
+            ->method('remove');
+
+        $eventListener = function($event) {
+            $event->cancel();
+        };
+
+        $this->dispatcher
+            ->method('dispatch')
+            ->will($this->returnCallback($eventListener));
+
+        $this->handler->remove($this->object, self::FILE_FIELD);
+    }
+
     public function testRemoveWithEmptyObject(): void
     {
         $this->dispatcher


### PR DESCRIPTION
This pull request, adds the possibility to cancel events. This has the advantage to cancel the actual remove request and dispatch a message to make the file removal asynchronously.

Cancellation only works for the `pre_remove` event.

Fixes #1155