### PR TITLE
Fix for uploading file on Azure Blob

### DIFF
--- a/src/Storage/GaufretteStorage.php
+++ b/src/Storage/GaufretteStorage.php
@@ -46,12 +46,12 @@ class GaufretteStorage extends AbstractStorage
     {
         $filesystem = $this->getFilesystem($mapping);
         $path = !empty($dir) ? $dir.'/'.$name : $name;
+        
+        $filesystem->write($path, \file_get_contents($file->getPathname()), true);
 
         if ($filesystem->getAdapter() instanceof MetadataSupporter) {
             $filesystem->getAdapter()->setMetadata($path, ['contentType' => $file->getMimeType()]);
         }
-
-        $filesystem->write($path, \file_get_contents($file->getPathname()), true);
     }
 
     protected function doRemove(PropertyMapping $mapping, ?string $dir, string $name): ?bool

--- a/src/Storage/GaufretteStorage.php
+++ b/src/Storage/GaufretteStorage.php
@@ -46,7 +46,7 @@ class GaufretteStorage extends AbstractStorage
     {
         $filesystem = $this->getFilesystem($mapping);
         $path = !empty($dir) ? $dir.'/'.$name : $name;
-        
+
         $filesystem->write($path, \file_get_contents($file->getPathname()), true);
 
         if ($filesystem->getAdapter() instanceof MetadataSupporter) {


### PR DESCRIPTION
Should resolve issue when uploading file with AzureBlobStorage adpater.

Error message displayed: 
`Failed to set metadata for blob "$path" in container "$container": The specified container does not exist. (ContainerNotFound).`

Resolves issue #708 