### PR TITLE
Support for league/flysystem v2.0 

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterFlysystemRegistryPass.php
+++ b/src/DependencyInjection/Compiler/RegisterFlysystemRegistryPass.php
@@ -2,11 +2,13 @@
 
 namespace Vich\UploaderBundle\DependencyInjection\Compiler;
 
+use League\Flysystem\FilesystemOperator;
 use League\FlysystemBundle\FlysystemBundle;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Vich\UploaderBundle\Storage\FlysystemV2Storage;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
@@ -37,6 +39,10 @@ final class RegisterFlysystemRegistryPass implements CompilerPassInterface
                         $registry[$tag['storage']] = new Reference($serviceId);
                     }
                 }
+            }
+
+            if (\class_exists(FilesystemOperator::class)) {
+                $storageDefinition->setClass(FlysystemV2Storage::class);
             }
 
             $storageDefinition->replaceArgument(1, ServiceLocatorTagPass::register($container, $registry));

--- a/src/Storage/FlysystemV2Storage.php
+++ b/src/Storage/FlysystemV2Storage.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Vich\UploaderBundle\Storage;
+
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\MountManager;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\File\Exception\CannotWriteFileException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+
+/**
+ * @author Daniele Pastori <fullbl@mail.com>
+ */
+class FlysystemV2Storage extends AbstractStorage
+{
+    /**
+     * @var MountManager|ContainerInterface a registry to get FilesystemInterface instances
+     */
+    protected $registry;
+
+    public function __construct(PropertyMappingFactory $factory, $registry)
+    {
+        parent::__construct($factory);
+
+        if (!$registry instanceof MountManager && !$registry instanceof ContainerInterface) {
+            throw new \TypeError(\sprintf('Argument 2 passed to %s::__construct() must be an instance of %s or an instance of %s, %s given.', __CLASS__, MountManager::class, ContainerInterface::class, \is_object($registry) ? \get_class($registry) : \gettype($registry)));
+        }
+
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doUpload(PropertyMapping $mapping, UploadedFile $file, ?string $dir, string $name): void
+    {
+        $fs = $this->getFilesystem($mapping);
+        $path = !empty($dir) ? $dir.'/'.$name : $name;
+
+        $stream = \fopen($file->getRealPath(), 'rb');
+        try {
+            $fs->writeStream($path, $stream, [
+                'mimetype' => $file->getMimeType(),
+            ]);
+        } catch (FilesystemException $e) {
+            throw new CannotWriteFileException($e->getMessage());
+        }
+    }
+
+    protected function doRemove(PropertyMapping $mapping, ?string $dir, string $name): ?bool
+    {
+        $fs = $this->getFilesystem($mapping);
+        $path = !empty($dir) ? $dir.'/'.$name : $name;
+
+        try {
+            $fs->delete($path);
+
+            return true;
+        } catch (FilesystemException $e) {
+            return false;
+        }
+    }
+
+    protected function doResolvePath(PropertyMapping $mapping, ?string $dir, string $name, ?bool $relative = false): string
+    {
+        $path = !empty($dir) ? $dir.'/'.$name : $name;
+
+        if ($relative) {
+            return $path;
+        }
+
+        return $path;
+    }
+
+    public function resolveStream($obj, string $fieldName, ?string $className = null)
+    {
+        $path = $this->resolvePath($obj, $fieldName, $className, true);
+
+        if (empty($path)) {
+            return null;
+        }
+
+        $mapping = $this->factory->fromField($obj, $fieldName, $className);
+        $fs = $this->getFilesystem($mapping);
+
+        try {
+            return $fs->readStream($path);
+        } catch (FilesystemException $e) {
+            return null;
+        }
+    }
+
+    protected function getFilesystem(PropertyMapping $mapping): FilesystemOperator
+    {
+        if ($this->registry instanceof MountManager) {
+            return $this->registry;
+        }
+
+        return $this->registry->get($mapping->getUploadDestination());
+    }
+}

--- a/tests/Storage/FlysystemV2/AbstractFlysystemStorageTest.php
+++ b/tests/Storage/FlysystemV2/AbstractFlysystemStorageTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Storage\FlysystemV2;
+
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\MountManager;
+use League\Flysystem\UnableToDeleteFile;
+use Vich\UploaderBundle\Storage\FlysystemStorage;
+use Vich\UploaderBundle\Storage\StorageInterface;
+use Vich\UploaderBundle\Tests\Storage\StorageTestCase;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+abstract class AbstractFlysystemStorageTest extends StorageTestCase
+{
+    public const FS_KEY = 'filesystemKey';
+
+    /**
+     * @var (MountManager|ContainerInterface)&\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $registry;
+
+    /**
+     * @var Filesystem&\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $filesystem;
+
+    /**
+     * @var FilesystemAdapter&\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $adapter;
+
+    /**
+     * @return mixed
+     */
+    abstract protected function createRegistry(FilesystemOperator $filesystem);
+
+    /**
+     * @requires function MountManager::__construct
+     */
+    public static function setUpBeforeClass(): void
+    {
+    }
+
+    protected function getStorage(): StorageInterface
+    {
+        return new FlysystemStorage($this->factory, $this->registry);
+    }
+
+    protected function setUp(): void
+    {
+        $this->filesystem = $this->createMock(Filesystem::class);
+        $this->adapter = $this->createMock(FilesystemAdapter::class);
+        $this->registry = $this->createRegistry($this->filesystem);
+
+        parent::setUp();
+
+        $this->mapping
+            ->expects($this->any())
+            ->method('getUploadDestination')
+            ->willReturn(self::FS_KEY);
+    }
+
+    public function testUpload(): void
+    {
+        $file = $this->getUploadedFileMock();
+
+        $file
+            ->expects(self::once())
+            ->method('getRealPath')
+            ->willReturn($this->root->url().\DIRECTORY_SEPARATOR.'uploads'.\DIRECTORY_SEPARATOR.'test.txt');
+
+        $file
+            ->expects(self::once())
+            ->method('getClientOriginalName')
+            ->willReturn('originalName.txt');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFile')
+            ->willReturn($file);
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadName')
+            ->with($this->object)
+            ->willReturn('originalName.txt');
+
+        $this->filesystem
+            ->expects(self::once())
+            ->method('putStream')
+            ->with(
+                'originalName.txt',
+                $this->isType('resource'),
+                $this->isType('array')
+            );
+
+        $this->storage->upload($this->object, $this->mapping);
+    }
+
+    public function testRemove(): void
+    {
+        $this->filesystem
+            ->expects(self::once())
+            ->method('delete')
+            ->with('test.txt');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFileName')
+            ->willReturn('test.txt');
+
+        $this->storage->remove($this->object, $this->mapping);
+    }
+
+    public function testRemoveOnNonExistentFile(): void
+    {
+        $this->filesystem
+            ->expects(self::once())
+            ->method('delete')
+            ->with('not_found.txt')
+            ->will($this->throwException(new UnableToDeleteFile('dummy path')));
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFileName')
+            ->willReturn('not_found.txt');
+
+        $this->storage->remove($this->object, $this->mapping);
+    }
+
+    /**
+     * @dataProvider pathProvider
+     */
+    public function testResolvePath(?string $uploadDir, string $expectedPath, bool $relative): void
+    {
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadDir')
+            ->willReturn($uploadDir);
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFileName')
+            ->willReturn('file.txt');
+
+        $this->factory
+            ->expects(self::once())
+            ->method('fromField')
+            ->with($this->object, 'file_field')
+            ->willReturn($this->mapping);
+
+        $this->filesystem
+            ->expects($this->any())
+            ->method('getAdapter')
+            ->willReturn($this->adapter);
+
+        $this->adapter
+            ->expects($this->any())
+            ->method('applyPathPrefix')
+            ->willReturn($uploadDir ? '/absolute/'.$uploadDir.'/file.txt' : '/absolute/file.txt');
+
+        $path = $this->storage->resolvePath($this->object, 'file_field', null, $relative);
+
+        self::assertEquals($expectedPath, $path);
+    }
+
+    public function pathProvider(): array
+    {
+        return [
+            //     dir,   path,                     relative
+            [null,  'file.txt',               true],
+            [null,  '/absolute/file.txt',     false],
+            ['foo', 'foo/file.txt',           true],
+            ['foo', '/absolute/foo/file.txt', false],
+        ];
+    }
+}

--- a/tests/Storage/FlysystemV2/AbstractFlysystemStorageTest.php
+++ b/tests/Storage/FlysystemV2/AbstractFlysystemStorageTest.php
@@ -8,6 +8,7 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\MountManager;
 use League\Flysystem\UnableToDeleteFile;
 use Vich\UploaderBundle\Storage\FlysystemStorage;
+use Vich\UploaderBundle\Storage\FlysystemV2Storage;
 use Vich\UploaderBundle\Storage\StorageInterface;
 use Vich\UploaderBundle\Tests\Storage\StorageTestCase;
 
@@ -48,7 +49,7 @@ abstract class AbstractFlysystemStorageTest extends StorageTestCase
 
     protected function getStorage(): StorageInterface
     {
-        return new FlysystemStorage($this->factory, $this->registry);
+        return new FlysystemV2Storage($this->factory, $this->registry);
     }
 
     protected function setUp(): void

--- a/tests/Storage/FlysystemV2/MountManagerFlysystemStorageTest.php
+++ b/tests/Storage/FlysystemV2/MountManagerFlysystemStorageTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Storage\FlysystemV2;
+
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\MountManager;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+final class MountManagerFlysystemStorageTest extends AbstractFlysystemStorageTest
+{
+    protected function createRegistry(FilesystemOperator $filesystem): MountManager
+    {
+        $mountManager = $this
+            ->getMockBuilder(MountManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mountManager
+            ->method('getFilesystem')
+            ->with(self::FS_KEY)
+            ->willReturn($filesystem);
+
+        return $mountManager;
+    }
+}

--- a/tests/Storage/FlysystemV2/PsrContainerFlysystemStorageTest.php
+++ b/tests/Storage/FlysystemV2/PsrContainerFlysystemStorageTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Storage\FlysystemV2;
+
+use League\Flysystem\FilesystemOperator;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+final class PsrContainerFlysystemStorageTest extends AbstractFlysystemStorageTest
+{
+    protected function createRegistry(FilesystemOperator $filesystem): ContainerInterface
+    {
+        $locator = $this
+            ->getMockBuilder(ContainerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $locator
+            ->method('get')
+            ->with(self::FS_KEY)
+            ->willReturn($filesystem);
+
+        return $locator;
+    }
+}


### PR DESCRIPTION
as in discussion #1177 I'm trying to create another storage, but, so far, I don't know how:

- get the full path in doResolvePath method, since getAdapter function has gone
- make tests work, since two versions of the same library should be needed
