### PR TITLE
Fix Collector toolbar spacing

### DIFF
--- a/templates/Collector/mapping_collector.html.twig
+++ b/templates/Collector/mapping_collector.html.twig
@@ -8,7 +8,7 @@
 
     {% set text %}
         <div class="sf-toolbar-info-piece">
-            <strong>Mappings</strong>
+            <b>Mappings</b>
             <span class="sf-toolbar-status sf-toolbar-status-grey">{{ collector.mappingsCount }}</span>
         </div>
     {% endset %}


### PR DESCRIPTION
This tiny change fixes the padding and style in the debug toolbar.

Before:
![image](https://user-images.githubusercontent.com/1985514/130067603-ecbbc423-d3ae-4aba-82c0-218b21050002.png)

After:
![image](https://user-images.githubusercontent.com/1985514/130067663-6b6a2b7e-5a99-4c3b-a85d-32b1ad3efc84.png)

This is because profiler styles are explicitly looking for `<b>` there and not `<strong>`: https://github.com/symfony/web-profiler-bundle/blob/95fb24b09551688a09cffac95a2ddbb907833f07/Resources/views/Profiler/toolbar.css.twig#L177