### PR TITLE
fix Symfony 5.4 deprecation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Vich\\\\UploaderBundle\\\\Adapter\\\\AdapterInterface\\:\\:recomputeChangeSet\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Vich\\\\UploaderBundle\\\\Adapter\\\\AdapterInterface\\:\\:recomputeChangeSet\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Adapter/AdapterInterface.php
 
@@ -31,7 +31,7 @@ parameters:
 			path: src/DependencyInjection/Configuration.php
 
 		-
-			message: "#^Method Vich\\\\UploaderBundle\\\\Event\\\\Event\\:\\:__construct\\(\\) has parameter \\$object with no typehint specified\\.$#"
+			message: "#^Method Vich\\\\UploaderBundle\\\\Event\\\\Event\\:\\:__construct\\(\\) has parameter \\$object with no type specified\\.$#"
 			count: 1
 			path: src/Event/Event.php
 
@@ -41,22 +41,22 @@ parameters:
 			path: src/EventListener/Doctrine/CleanListener.php
 
 		-
-			message: "#^Method Vich\\\\UploaderBundle\\\\Handler\\\\UploadHandler\\:\\:clean\\(\\) has parameter \\$obj with no typehint specified\\.$#"
+			message: "#^Method Vich\\\\UploaderBundle\\\\Handler\\\\UploadHandler\\:\\:clean\\(\\) has parameter \\$obj with no type specified\\.$#"
 			count: 1
 			path: src/Handler/UploadHandler.php
 
 		-
-			message: "#^Method Vich\\\\UploaderBundle\\\\Handler\\\\UploadHandler\\:\\:inject\\(\\) has parameter \\$obj with no typehint specified\\.$#"
+			message: "#^Method Vich\\\\UploaderBundle\\\\Handler\\\\UploadHandler\\:\\:inject\\(\\) has parameter \\$obj with no type specified\\.$#"
 			count: 1
 			path: src/Handler/UploadHandler.php
 
 		-
-			message: "#^Method Vich\\\\UploaderBundle\\\\Handler\\\\UploadHandler\\:\\:remove\\(\\) has parameter \\$obj with no typehint specified\\.$#"
+			message: "#^Method Vich\\\\UploaderBundle\\\\Handler\\\\UploadHandler\\:\\:remove\\(\\) has parameter \\$obj with no type specified\\.$#"
 			count: 1
 			path: src/Handler/UploadHandler.php
 
 		-
-			message: "#^Method Vich\\\\UploaderBundle\\\\Naming\\\\ConfigurableInterface\\:\\:configure\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Vich\\\\UploaderBundle\\\\Naming\\\\ConfigurableInterface\\:\\:configure\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Naming/ConfigurableInterface.php
 

--- a/src/Form/DataTransformer/FileTransformer.php
+++ b/src/Form/DataTransformer/FileTransformer.php
@@ -3,12 +3,18 @@
 namespace Vich\UploaderBundle\Form\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * @final
  */
 class FileTransformer implements DataTransformerInterface
 {
+    /**
+     * @param UploadedFile $file
+     *
+     * @return array<string, UploadedFile>
+     */
     public function transform($file): array
     {
         return [
@@ -16,6 +22,11 @@ class FileTransformer implements DataTransformerInterface
         ];
     }
 
+    /**
+     * @param array<string, UploadedFile> $data
+     *
+     * @return UploadedFile
+     */
     public function reverseTransform($data)
     {
         return $data['file'];


### PR DESCRIPTION
This will fix the following deprecation:
>method "Symfony\Component\Form\DataTransformerInterface::reverseTransform()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Vich\UploaderBundle\Form\DataTransformer\FileTransformer" now to avoid errors or add an explicit @return annotation to suppress this message.