### PR TITLE
Rework Doctrine mapping to XML to fix issue with SF 5.4

### DIFF
--- a/config/doctrine/File.orm.xml
+++ b/config/doctrine/File.orm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- A copy of this file is necessary in src/Resources/config/doctrine for SF <5.4 compatibility. If this file is updated the copy needs to be updated too -->
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                   https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <embeddable name="Vich\UploaderBundle\Entity\File">
+        <field name="name" nullable="true"/>
+        <field name="originalName" column="original_name" nullable="true"/>
+        <field name="mimeType" column="mime_type" nullable="true"/>
+        <field name="size" type="integer" nullable="true"/>
+        <field name="dimensions" type="simple_array" nullable="true"/>
+    </embeddable>
+</doctrine-mapping>

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -2,44 +2,29 @@
 
 namespace Vich\UploaderBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Embeddable
- */
 class File
 {
     /**
-     * @ORM\Column(name="name", nullable=true)
-     *
      * @var string
      */
     protected $name;
 
     /**
-     * @ORM\Column(name="original_name", nullable=true)
-     *
      * @var string
      */
     protected $originalName;
 
     /**
-     * @ORM\Column(name="mime_type", nullable=true)
-     *
      * @var string
      */
     protected $mimeType;
 
     /**
-     * @ORM\Column(name="size", type="integer", nullable=true)
-     *
      * @var int
      */
     protected $size;
 
     /**
-     * @ORM\Column(name="dimensions", type="simple_array", nullable=true)
-     *
      * @var array<int, int>
      */
     protected $dimensions;

--- a/src/Resources/config/doctrine/File.orm.xml
+++ b/src/Resources/config/doctrine/File.orm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- Copy of the file in config/doctrine, if update is done there this should be updated too -->
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                   https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <embeddable name="Vich\UploaderBundle\Entity\File">
+        <field name="name" nullable="true"/>
+        <field name="originalName" column="original_name" nullable="true"/>
+        <field name="mimeType" column="mime_type" nullable="true"/>
+        <field name="size" type="integer" nullable="true"/>
+        <field name="dimensions" type="simple_array" nullable="true"/>
+    </embeddable>
+</doctrine-mapping>


### PR DESCRIPTION
Different approach to #1243, change the configuration to XML (as suggested in https://symfony.com/doc/current/bundles/best_practices.html#doctrine-entities-documents).
Symlink in `src/Resources/config/doctrine` is needed for backwards compatibility, as the bundle path detection is fixed in Symfony 5.4.