### PR TITLE
Remove internal annotation from bundle class

### DIFF
--- a/src/VichUploaderBundle.php
+++ b/src/VichUploaderBundle.php
@@ -10,8 +10,6 @@ use Vich\UploaderBundle\DependencyInjection\Compiler\RegisterSluggerPass;
 
 /**
  * @author Dustin Dobervich <ddobervich@gmail.com>
- *
- * @internal
  */
 final class VichUploaderBundle extends Bundle
 {


### PR DESCRIPTION
As per the discussion in #1214 with @garak, the `@internal` annotation on `Vich\UploaderBundle\VichUploaderBundle` causes a strike-through to appear in the class name in `config/bundles.php` within PhpStorm and possibly other IDEs.

![149996469-fe9a19fa-6097-47db-bb45-d42aae919c8f](https://user-images.githubusercontent.com/6660584/150102685-dbb227fd-3e61-46e7-b801-dc0589f0263c.png)


This makes it look like the developer has done something wrong.

This PR simply removes the annotation from this class.