### PR TITLE
Allow to decorate the UploaderHelper

### DIFF
--- a/src/Templating/Helper/UploaderHelper.php
+++ b/src/Templating/Helper/UploaderHelper.php
@@ -10,7 +10,7 @@ use Vich\UploaderBundle\Storage\StorageInterface;
  * @author Dustin Dobervich <ddobervich@gmail.com>
  * @final
  */
-class UploaderHelper
+class UploaderHelper implements UploaderHelperInterface
 {
     /**
      * @var StorageInterface

--- a/src/Templating/Helper/UploaderHelper.php
+++ b/src/Templating/Helper/UploaderHelper.php
@@ -39,6 +39,15 @@ class UploaderHelper implements UploaderHelperInterface
      */
     public function asset($obj, ?string $fieldName = null, ?string $className = null)
     {
+        if (!\is_object($obj)) {
+            $msg = 'Not passing an object option is deprecated and will be removed in version 2.';
+            @\trigger_error($msg, \E_USER_DEPRECATED);
+        }
+        if (\func_num_args() > 2) {
+            $msg = 'Passing a classname is deprecated and will be removed in version 2.';
+            @\trigger_error($msg, \E_USER_DEPRECATED);
+        }
+
         return $this->storage->resolveUri($obj, $fieldName, $className);
     }
 }

--- a/src/Templating/Helper/UploaderHelperInterface.php
+++ b/src/Templating/Helper/UploaderHelperInterface.php
@@ -8,9 +8,9 @@ interface UploaderHelperInterface
      * Gets the public path for the file associated with the
      * object.
      *
-     * @param object|array $obj       The object
-     * @param string|null  $fieldName The field name
-     * @param string|null  $className The object's class. Mandatory if $obj can't be used to determine it
+     * @param object      $obj       The object
+     * @param string|null $fieldName The field name
+     * @param string|null $className The object's class. Mandatory if $obj can't be used to determine it
      *
      * @return string|null The public asset path or null if file not stored
      */

--- a/src/Templating/Helper/UploaderHelperInterface.php
+++ b/src/Templating/Helper/UploaderHelperInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vich\UploaderBundle\Templating\Helper;
+
+interface UploaderHelperInterface
+{
+    /**
+     * Gets the public path for the file associated with the
+     * object.
+     *
+     * @param object|array $obj       The object
+     * @param string|null  $fieldName The field name
+     * @param string|null  $className The object's class. Mandatory if $obj can't be used to determine it
+     *
+     * @return string|null The public asset path or null if file not stored
+     */
+    public function asset($obj, ?string $fieldName = null, ?string $className = null);
+}

--- a/src/Templating/Helper/UploaderHelperInterface.php
+++ b/src/Templating/Helper/UploaderHelperInterface.php
@@ -5,14 +5,12 @@ namespace Vich\UploaderBundle\Templating\Helper;
 interface UploaderHelperInterface
 {
     /**
-     * Gets the public path for the file associated with the
-     * object.
+     * Gets the public path for the file associated with the object.
      *
      * @param object      $obj       The object
      * @param string|null $fieldName The field name
-     * @param string|null $className The object's class. Mandatory if $obj can't be used to determine it
      *
      * @return string|null The public asset path or null if file not stored
      */
-    public function asset($obj, ?string $fieldName = null, ?string $className = null);
+    public function asset($obj, ?string $fieldName = null);
 }

--- a/src/Twig/Extension/UploaderExtension.php
+++ b/src/Twig/Extension/UploaderExtension.php
@@ -41,6 +41,16 @@ final class UploaderExtension extends AbstractExtension
      */
     public function asset($object, ?string $fieldName = null, ?string $className = null): ?string
     {
+        if (!\is_object($object)) {
+            $msg = 'Not passing an object option is deprecated and will be removed in version 2.';
+            @\trigger_error($msg, \E_USER_DEPRECATED);
+        }
+        if (\func_num_args() > 2) {
+            $msg = 'Passing a classname is deprecated and will be removed in version 2.';
+            @\trigger_error($msg, \E_USER_DEPRECATED);
+        }
+
+        // @phpstan-ignore-next-line
         return $this->helper->asset($object, $fieldName, $className);
     }
 }

--- a/src/Twig/Extension/UploaderExtension.php
+++ b/src/Twig/Extension/UploaderExtension.php
@@ -4,7 +4,7 @@ namespace Vich\UploaderBundle\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelperInterface;
 
 /**
  * UploaderExtension.
@@ -14,11 +14,11 @@ use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
 final class UploaderExtension extends AbstractExtension
 {
     /**
-     * @var UploaderHelper
+     * @var UploaderHelperInterface
      */
     private $helper;
 
-    public function __construct(UploaderHelper $helper)
+    public function __construct(UploaderHelperInterface $helper)
     {
         $this->helper = $helper;
     }

--- a/src/Twig/Extension/UploaderExtension.php
+++ b/src/Twig/Extension/UploaderExtension.php
@@ -4,6 +4,7 @@ namespace Vich\UploaderBundle\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
 use Vich\UploaderBundle\Templating\Helper\UploaderHelperInterface;
 
 /**
@@ -41,13 +42,15 @@ final class UploaderExtension extends AbstractExtension
      */
     public function asset($object, ?string $fieldName = null, ?string $className = null): ?string
     {
-        if (!\is_object($object)) {
-            $msg = 'Not passing an object option is deprecated and will be removed in version 2.';
-            @\trigger_error($msg, \E_USER_DEPRECATED);
-        }
-        if (\func_num_args() > 2) {
-            $msg = 'Passing a classname is deprecated and will be removed in version 2.';
-            @\trigger_error($msg, \E_USER_DEPRECATED);
+        if (!$this->helper instanceof UploaderHelper) {
+            if (!\is_object($object)) {
+                $msg = 'Not passing an object option is deprecated and will be removed in version 2.';
+                @\trigger_error($msg, \E_USER_DEPRECATED);
+            }
+            if (\func_num_args() > 2) {
+                $msg = 'Passing a classname is deprecated and will be removed in version 2.';
+                @\trigger_error($msg, \E_USER_DEPRECATED);
+            }
         }
 
         // @phpstan-ignore-next-line

--- a/tests/Functional/WebTestCase.php
+++ b/tests/Functional/WebTestCase.php
@@ -52,11 +52,6 @@ abstract class WebTestCase extends BaseWebTestCase
             $om = $registry->getEntityManager();
         }
 
-        $cacheDriver = $om->getMetadataFactory()->getCacheDriver();
-        if (null !== $cacheDriver) {
-            $cacheDriver->deleteAll();
-        }
-
         $connection = $om->getConnection();
         $params = $connection->getParams();
         $name = isset($params['path']) ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);

--- a/tests/Templating/Helper/UploadHelperTest.php
+++ b/tests/Templating/Helper/UploadHelperTest.php
@@ -41,8 +41,8 @@ final class UploadHelperTest extends TestCase
         $this->storage
             ->expects(self::once())
             ->method('resolveUri')
-            ->with($obj, 'file', 'ClassName');
+            ->with($obj, 'file');
 
-        $this->helper->asset($obj, 'file', 'ClassName');
+        $this->helper->asset($obj, 'file');
     }
 }

--- a/tests/Twig/Extension/UploaderExtensionTest.php
+++ b/tests/Twig/Extension/UploaderExtensionTest.php
@@ -44,8 +44,8 @@ final class UploaderExtensionTest extends TestCase
         $this->helper
             ->expects(self::once())
             ->method('asset')
-            ->with($obj, 'file', 'ClassName');
+            ->with($obj, 'file');
 
-        $this->extension->asset($obj, 'file', 'ClassName');
+        $this->extension->asset($obj, 'file');
     }
 }


### PR DESCRIPTION
Hi @garak. 

I recently tried the 1.19 version and got an issue.

Since the UploaderHelper is/will be final, I cannot extends it.
But since this class is required (and not an interface) in the construct of the UploaderExtension, I cannot use decoration either.

This PR solve this issue. 