### PR TITLE
Fix remove listener if property namer is used

### DIFF
--- a/src/EventListener/Doctrine/RemoveListener.php
+++ b/src/EventListener/Doctrine/RemoveListener.php
@@ -43,7 +43,7 @@ class RemoveListener extends BaseListener
             if ($object instanceof Proxy) {
                 $object->__load();
             }
-            $this->entities[] = $object;
+            $this->entities[] = clone $object;
         }
     }
 
@@ -54,5 +54,6 @@ class RemoveListener extends BaseListener
                 $this->handler->remove($object, $field);
             }
         }
+        $this->entities = [];
     }
 }


### PR DESCRIPTION
When the `PropertyDirectoryNamer` is used with the `id` of the entity
the remove listener throws an exception because it runs after the removal
and the id is no longer available at that time. This PR fixes the issue.
