### PR TITLE
Added support for 'ReplacingFile' to 'upload' files not uploaded via HTTP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "league/flysystem-bundle": "^2.0",
         "league/flysystem-memory": "^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "mikey179/vfsstream": "^1.6",
+        "mikey179/vfsstream": "^1.6.8",
         "phpunit/phpunit": "^9.5",
         "symfony/asset": "^4.4 || ^5.0 || ^6.0",
         "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,10 @@ composer require symfony/form
   * [Using the bundled file form type](form/vich_file_type.md)
   * [Using the bundled image form type](form/vich_image_type.md)
 
+### Other usages
+
+  * [Inject files from other sources](other_usages/replacing_file.md)
+
 ### Download-related
 
   * [Serving files with a controller](downloads/serving_files_with_a_controller.md)

--- a/docs/other_usages/replacing_file.md
+++ b/docs/other_usages/replacing_file.md
@@ -1,0 +1,47 @@
+# Inject files from other sources
+
+The bundle provides a way to inject files into entities coming from other sources than [HTTP uploads via forms](../form/vich_file_type.md).
+
+When you have configured your entity like laid out in the [usage page](../usage.md), you can use code like the one below to inject files which are coming from other sources like
+
+- already a file on the server,
+- downloaded with curl/wget or
+- migrate old uploads.
+
+
+## Example
+
+```php
+// ...
+use Acme\DemoBundle\Entity\Product;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Vich\UploaderBundle\FileAbstraction\ReplacingFile;
+
+class MigrationCommand extends Command
+{
+    public function __construct(
+        protected EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+    // ...
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $product = new Product();
+        $product->imageFile = new ReplacingFile('myFile.png');
+        // ...
+
+        $this->em->persist($product);
+        $this->em->flush();
+
+        return Command::SUCCESS;
+    }
+}
+```
+
+## That was it!
+
+Check out the docs for information on how to use the bundle! [Return to the
+index.](../index.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -415,4 +415,6 @@ When you submit and save, the uploaded file will automatically be moved to the
 location you configured and the `imageName` field will be set to the filename of
 the uploaded file.
 
+Alternatively, you can use `ReplacingFile` to [inject files coming from other sources](other_usages/replacing_file.md).
+
 [Return to the index to explore the other possibilities of the bundle.](index.md)

--- a/src/FileAbstraction/ReplacingFile.php
+++ b/src/FileAbstraction/ReplacingFile.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vich\UploaderBundle\FileAbstraction;
+
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+/**
+ * This class can be used to signal that the given file should be "uploaded" into the Vich-abstraction
+ * in cases where it is not possible to construct an `UploadedFile`.
+ */
+class ReplacingFile extends File
+{
+    public function getClientOriginalName(): string
+    {
+        return $this->getFilename();
+    }
+}

--- a/src/Handler/UploadHandler.php
+++ b/src/Handler/UploadHandler.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Vich\UploaderBundle\Event\Event;
 use Vich\UploaderBundle\Event\Events;
+use Vich\UploaderBundle\FileAbstraction\ReplacingFile;
 use Vich\UploaderBundle\Injector\FileInjectorInterface;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
@@ -122,6 +123,6 @@ class UploadHandler extends AbstractHandler
     {
         $file = $mapping->getFile($obj);
 
-        return null !== $file && $file instanceof UploadedFile;
+        return $file instanceof UploadedFile || $file instanceof ReplacingFile;
     }
 }

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -72,7 +72,7 @@ class PropertyMapping
      *
      * @param object $obj The object
      *
-     * @return \Symfony\Component\HttpFoundation\File\UploadedFile|null The file
+     * @return \Symfony\Component\HttpFoundation\File\UploadedFile|\Vich\UploaderBundle\FileAbstraction\ReplacingFile|null The file
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -368,7 +368,7 @@ class PropertyMapping
 
     protected function getAccessor(): PropertyAccessor
     {
-        //TODO: reuse original property accessor from forms
+        // TODO: reuse original property accessor from forms
         if (null !== $this->accessor) {
             return $this->accessor;
         }

--- a/src/Naming/OrignameNamer.php
+++ b/src/Naming/OrignameNamer.php
@@ -3,6 +3,7 @@
 namespace Vich\UploaderBundle\Naming;
 
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Vich\UploaderBundle\FileAbstraction\ReplacingFile;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Util\Transliterator;
 
@@ -40,7 +41,7 @@ class OrignameNamer implements NamerInterface, ConfigurableInterface
 
     public function name($object, PropertyMapping $mapping): string
     {
-        /* @var $file UploadedFile */
+        /* @var $file UploadedFile|ReplacingFile */
         $file = $mapping->getFile($object);
         $name = $file->getClientOriginalName();
 

--- a/src/Naming/Polyfill/FileExtensionTrait.php
+++ b/src/Naming/Polyfill/FileExtensionTrait.php
@@ -2,15 +2,20 @@
 
 namespace Vich\UploaderBundle\Naming\Polyfill;
 
+use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Vich\UploaderBundle\FileAbstraction\ReplacingFile;
 
 trait FileExtensionTrait
 {
     /**
      * Guess the extension of the given file.
      */
-    private function getExtension(UploadedFile $file): ?string
+    private function getExtension(File $file): ?string
     {
+        if (!$file instanceof UploadedFile && !$file instanceof ReplacingFile) {
+            throw new \InvalidArgumentException('Unexpected type for $file: '.get_class($file));
+        }
         $originalName = $file->getClientOriginalName();
 
         if ('' !== ($extension = \pathinfo($originalName, \PATHINFO_EXTENSION))) {

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -2,8 +2,10 @@
 
 namespace Vich\UploaderBundle\Storage;
 
+use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Vich\UploaderBundle\Exception\MappingNotFoundException;
+use Vich\UploaderBundle\FileAbstraction\ReplacingFile;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 
@@ -27,13 +29,12 @@ abstract class AbstractStorage implements StorageInterface
     /**
      * @return mixed
      */
-    abstract protected function doUpload(PropertyMapping $mapping, UploadedFile $file, ?string $dir, string $name);
+    abstract protected function doUpload(PropertyMapping $mapping, File $file, ?string $dir, string $name);
 
     public function upload($obj, PropertyMapping $mapping): void
     {
         $file = $mapping->getFile($obj);
-
-        if (null === $file || !($file instanceof UploadedFile)) {
+        if (!$file instanceof UploadedFile && !$file instanceof ReplacingFile) {
             throw new \LogicException('No uploadable file found');
         }
 

--- a/src/Storage/FileSystemStorage.php
+++ b/src/Storage/FileSystemStorage.php
@@ -14,11 +14,20 @@ use Vich\UploaderBundle\Mapping\PropertyMapping;
  */
 class FileSystemStorage extends AbstractStorage
 {
-    protected function doUpload(PropertyMapping $mapping, UploadedFile $file, ?string $dir, string $name): ?File
+    protected function doUpload(PropertyMapping $mapping, File $file, ?string $dir, string $name): ?File
     {
         $uploadDir = $mapping->getUploadDestination().\DIRECTORY_SEPARATOR.$dir;
 
-        return $file->move($uploadDir, $name);
+        if ($file instanceof UploadedFile) {
+            return $file->move($uploadDir, $name);
+        } else {
+            $targetPathname = $uploadDir.\DIRECTORY_SEPARATOR.$name;
+            if (!\copy($file->getPathname(), $targetPathname)) {
+                throw new \Exception('Could not copy file');
+            }
+
+            return new File($targetPathname);
+        }
     }
 
     protected function doRemove(PropertyMapping $mapping, ?string $dir, string $name): ?bool

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -7,7 +7,7 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\MountManager;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\File\Exception\CannotWriteFileException;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 
@@ -37,7 +37,7 @@ class FlysystemStorage extends AbstractStorage
         $this->registry = $registry;
     }
 
-    protected function doUpload(PropertyMapping $mapping, UploadedFile $file, ?string $dir, string $name): void
+    protected function doUpload(PropertyMapping $mapping, File $file, ?string $dir, string $name): void
     {
         $fs = $this->getFilesystem($mapping);
         $path = !empty($dir) ? $dir.'/'.$name : $name;

--- a/src/Storage/GaufretteStorage.php
+++ b/src/Storage/GaufretteStorage.php
@@ -6,7 +6,7 @@ use Gaufrette\Adapter\MetadataSupporter;
 use Gaufrette\Exception\FileNotFound;
 use Gaufrette\FilesystemInterface;
 use Gaufrette\FilesystemMapInterface;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 
@@ -43,7 +43,7 @@ class GaufretteStorage extends AbstractStorage
         $this->protocol = $protocol;
     }
 
-    protected function doUpload(PropertyMapping $mapping, UploadedFile $file, ?string $dir, string $name): void
+    protected function doUpload(PropertyMapping $mapping, File $file, ?string $dir, string $name): void
     {
         $filesystem = $this->getFilesystem($mapping);
         $path = !empty($dir) ? $dir.'/'.$name : $name;

--- a/tests/Storage/FileSystemStorageTest.php
+++ b/tests/Storage/FileSystemStorageTest.php
@@ -301,6 +301,46 @@ final class FileSystemStorageTest extends StorageTestCase
         $this->storage->upload($this->object, $this->mapping);
     }
 
+    /**
+     * @group upload
+     */
+    public function testReplacingFileIsCorrectlyUploaded(): void
+    {
+        $file = $this->getReplacingFileMock();
+
+        $file
+            ->method('getClientOriginalName')
+            ->willReturn('filename.txt');
+        $file
+            ->method('getPathname')
+            ->willReturn($this->getValidUploadDir().'/test.txt');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFile')
+            ->with($this->object)
+            ->willReturn($file);
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadDestination')
+            ->willReturn($this->root->url().\DIRECTORY_SEPARATOR.'storage');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadName')
+            ->with($this->object)
+            ->willReturn('test.txt');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadDir')
+            ->with($this->object)
+            ->willReturn('vich_uploader_bundle');
+
+        $this->storage->upload($this->object, $this->mapping);
+    }
+
     public function filenameWithDirectoriesDataProvider(): array
     {
         return [

--- a/tests/Storage/StorageTestCase.php
+++ b/tests/Storage/StorageTestCase.php
@@ -68,6 +68,9 @@ abstract class StorageTestCase extends TestCase
             'uploads' => [
                 'test.txt' => 'some content',
             ],
+            'storage' => [
+                'vich_uploader_bundle' => [],
+            ],
         ]);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Vich\UploaderBundle\Tests;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\String\Slugger\AsciiSlugger;
+use Vich\UploaderBundle\FileAbstraction\ReplacingFile;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 use Vich\UploaderBundle\Util\Transliterator;
@@ -18,6 +19,16 @@ class TestCase extends BaseTestCase
     {
         return $this->getMockBuilder(UploadedFile::class)
             ->setConstructorArgs(['lala', 'lala', $mimeType = null, $error = 9, $test = true])
+            ->getMock();
+    }
+
+    /**
+     * @return ReplacingFile&\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getReplacingFileMock(): ReplacingFile
+    {
+        return $this->getMockBuilder(ReplacingFile::class)
+            ->setConstructorArgs(['lala', false])
             ->getMock();
     }
 


### PR DESCRIPTION
This fixes #1296.

I removed most of the dependencies of files in `/src/Storage` on `UploadedFile` because it makes no sense in my opinion.

Going beyond this PR I even think that [this](https://github.com/dustin10/VichUploaderBundle/blob/6b8ac89b54ee8340e3fc108927b2c20226118436/src/Storage/FileSystemStorage.php#L21) should be replaced with a copy call, because all other concrete implementations of `Storage` indeed only copy and do not remove the original. In practice this might not be relevant though.

The new class `ReplacingFile` provides a method `getClientOriginalName` to be somewhat compatible with `UploadedFile`.  I changed all other occurrences of `UploadedFile` to alternatively expect an `ReplacingFile`. If language level would be PHP 8.1., this could be a union type in all occurrences, but I guess this is not possible at the moment.

I just used it this way, and it works. I did not run the test-suite though (and did not write a test), because "make tests" just throws an error:
```
make tests
make vichuploader-image
docker build -t dustin10/vichuploader_php74 -f ./docker/Dockerfile74 .
make[1]: docker: No such file or directory
make[1]: *** [vichuploader-image] Error 1
make: *** [tests] Error 2
```