### PR TITLE
Implement getAllClassNames in AnnotationDriver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-simplexml": "*",
+        "doctrine/persistence": "^1.3 || ^2 || ^3",
         "jms/metadata": "^1.7 || ^2.4",
         "symfony/config": "^4.4 || ^5.0 || ^6.0",
         "symfony/console": "^4.4 || ^5.0 || ^6.0",

--- a/config/mapping.xml
+++ b/config/mapping.xml
@@ -16,7 +16,8 @@
 
         <!-- drivers -->
         <service id="vich_uploader.metadata_driver.annotation" class="Vich\UploaderBundle\Metadata\Driver\AnnotationDriver" public="false">
-            <argument type="service" id="vich_uploader.metadata.reader" />
+            <argument key="$reader" type="service" id="vich_uploader.metadata.reader" />
+            <argument key="$managerRegistry" type="service" id="doctrine" />
         </service>
 
         <service id="vich_uploader.metadata_driver.xml" class="Vich\UploaderBundle\Metadata\Driver\XmlDriver" public="false">

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,7 +24,4 @@ Searches for uploadable classes.
 php bin/console vich:mapping:list-classes
 ```
 
-> **NOTE** Only classes configured using XML or YAML are displayed.
-
-
 [Return to the index](index.md)

--- a/src/Command/MappingDebugClassCommand.php
+++ b/src/Command/MappingDebugClassCommand.php
@@ -3,6 +3,8 @@
 namespace Vich\UploaderBundle\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -51,5 +53,12 @@ class MappingDebugClassCommand extends Command
         }
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('fqcn')) {
+            $suggestions->suggestValues($this->metadataReader->getUploadableClasses());
+        }
     }
 }

--- a/src/Command/MappingListClassesCommand.php
+++ b/src/Command/MappingListClassesCommand.php
@@ -42,7 +42,6 @@ class MappingListClassesCommand extends Command
         }
 
         $output->writeln(\sprintf('Found <comment>%d</comment> classes.', \count($uploadableClasses)));
-        $output->writeln('<info>NOTE:</info> Only classes configured using XML or YAML are displayed.');
 
         return 0;
     }

--- a/tests/Command/MappingDebugClassCommandTest.php
+++ b/tests/Command/MappingDebugClassCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Command;
 
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Vich\TestBundle\Entity\Image;
 use Vich\UploaderBundle\Command\MappingDebugClassCommand;
 use Vich\UploaderBundle\Metadata\MetadataReader;
@@ -24,5 +25,31 @@ final class MappingDebugClassCommandTest extends AbstractCommandTestCase
         $command = new MappingDebugClassCommand($reader);
         $output = $this->executeCommand('vich:mapping:debug-class', $command, ['fqcn' => Image::class]);
         self::assertStringContainsString('Introspecting class', $output);
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions): void
+    {
+        if (!class_exists(CommandCompletionTester::class)) {
+            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+        }
+
+        $reader = $this->createMock(MetadataReader::class);
+        $reader->expects(self::once())->method('getUploadableClasses')->willReturn([Image::class]);
+        $tester = new CommandCompletionTester(new MappingDebugClassCommand($reader));
+
+        $this->assertEqualsCanonicalizing($expectedSuggestions, $tester->complete($input));
+    }
+
+    public function provideCompletionSuggestions(): \Generator
+    {
+        yield 'fqcn' => [
+            [''],
+            [
+                Image::class,
+            ],
+        ];
     }
 }

--- a/tests/Kernel/FilesystemAppKernel.php
+++ b/tests/Kernel/FilesystemAppKernel.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Kernel;
 
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -18,7 +19,7 @@ class FilesystemAppKernel extends Kernel
 
     public function registerBundles(): array
     {
-        return [new FrameworkBundle(), new VichUploaderBundle()];
+        return [new FrameworkBundle(), new DoctrineBundle(), new VichUploaderBundle()];
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
@@ -30,6 +31,14 @@ class FilesystemAppKernel extends Kernel
                     'resource' => 'kernel::loadRoutes',
                     'type' => 'service',
                     'utf8' => false,
+                ],
+            ]);
+
+            $container->loadFromExtension('doctrine', [
+                'dbal' => [
+                    'driver' => 'pdo_sqlite',
+                    'memory' => true,
+                    'charset' => 'UTF8',
                 ],
             ]);
 

--- a/tests/Kernel/FlysystemOfficialAppKernel.php
+++ b/tests/Kernel/FlysystemOfficialAppKernel.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Kernel;
 
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use League\FlysystemBundle\FlysystemBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -18,7 +19,7 @@ class FlysystemOfficialAppKernel extends Kernel
 
     public function registerBundles(): array
     {
-        return [new FrameworkBundle(), new FlysystemBundle(), new VichUploaderBundle()];
+        return [new FrameworkBundle(), new DoctrineBundle(), new FlysystemBundle(), new VichUploaderBundle()];
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
@@ -30,6 +31,14 @@ class FlysystemOfficialAppKernel extends Kernel
                     'resource' => 'kernel::loadRoutes',
                     'type' => 'service',
                     'utf8' => false,
+                ],
+            ]);
+
+            $container->loadFromExtension('doctrine', [
+                'dbal' => [
+                    'driver' => 'pdo_sqlite',
+                    'memory' => true,
+                    'charset' => 'UTF8',
                 ],
             ]);
 

--- a/tests/Kernel/FlysystemOneUpAppKernel.php
+++ b/tests/Kernel/FlysystemOneUpAppKernel.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Kernel;
 
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Oneup\FlysystemBundle\OneupFlysystemBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -19,7 +20,7 @@ class FlysystemOneUpAppKernel extends Kernel
     public function registerBundles(): array
     {
         if (\class_exists(OneupFlysystemBundle::class)) {
-            return [new FrameworkBundle(), new OneupFlysystemBundle(), new VichUploaderBundle()];
+            return [new FrameworkBundle(), new DoctrineBundle(), new OneupFlysystemBundle(), new VichUploaderBundle()];
         }
 
         return [new FrameworkBundle(), new VichUploaderBundle()];
@@ -34,6 +35,14 @@ class FlysystemOneUpAppKernel extends Kernel
                     'resource' => 'kernel::loadRoutes',
                     'type' => 'service',
                     'utf8' => false,
+                ],
+            ]);
+
+            $container->loadFromExtension('doctrine', [
+                'dbal' => [
+                    'driver' => 'pdo_sqlite',
+                    'memory' => true,
+                    'charset' => 'UTF8',
                 ],
             ]);
 

--- a/tests/Kernel/SimpleAppKernel.php
+++ b/tests/Kernel/SimpleAppKernel.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Kernel;
 
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -17,7 +18,7 @@ class SimpleAppKernel extends Kernel
 
     public function registerBundles(): array
     {
-        return [new FrameworkBundle(), new VichUploaderBundle()];
+        return [new FrameworkBundle(), new DoctrineBundle(), new VichUploaderBundle()];
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
@@ -29,6 +30,14 @@ class SimpleAppKernel extends Kernel
                     'resource' => 'kernel::loadRoutes',
                     'type' => 'service',
                     'utf8' => false,
+                ],
+            ]);
+
+            $container->loadFromExtension('doctrine', [
+                'dbal' => [
+                    'driver' => 'pdo_sqlite',
+                    'memory' => true,
+                    'charset' => 'UTF8',
                 ],
             ]);
 


### PR DESCRIPTION
Make getAllClassNames in AnnotationDriver return a list of Doctrine managed entities that are annotated with `@Vich\Uploadable` by injecting `Doctrine\Persistence\ManagerRegistry` (Service ID `doctrine` in a Symfony app), making `vich:mapping:list-classes` discover that entities.

Also provides autocompletion for `vich:mapping:debug-class` (fix #1232)

[![asciicast](https://asciinema.org/a/510200.svg)](https://asciinema.org/a/510200)