### PR TITLE
#1308 Handle empty dimensions array case

### DIFF
--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -87,7 +87,7 @@ class File
      */
     public function getWidth(): ?int
     {
-        return null !== $this->dimensions ? $this->dimensions[0] : null;
+        return isset($this->dimensions[0]) ? $this->dimensions[0] : null;
     }
 
     /**
@@ -98,7 +98,7 @@ class File
      */
     public function getHeight(): ?int
     {
-        return null !== $this->dimensions ? $this->dimensions[1] : null;
+        return isset($this->dimensions[1]) ? $this->dimensions[1] : null;
     }
 
     /**

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -87,7 +87,7 @@ class File
      */
     public function getWidth(): ?int
     {
-        return isset($this->dimensions[0]) ? $this->dimensions[0] : null;
+        return $this->dimensions[0] ?? null;
     }
 
     /**
@@ -98,7 +98,7 @@ class File
      */
     public function getHeight(): ?int
     {
-        return isset($this->dimensions[1]) ? $this->dimensions[1] : null;
+        return $this->dimensions[1] ?? null;
     }
 
     /**


### PR DESCRIPTION
When normalizing the File the `getWidth` and `getHeight` are called and while the dimension for null files is returned as an empty array the original check is not enough to handle this case.