### PR TITLE
Fixes issue #1316

### DIFF
--- a/src/Storage/FileSystemStorage.php
+++ b/src/Storage/FileSystemStorage.php
@@ -17,6 +17,15 @@ final class FileSystemStorage extends AbstractStorage
     {
         $uploadDir = $mapping->getUploadDestination().\DIRECTORY_SEPARATOR.$dir;
 
+        if (!\file_exists($uploadDir)) {
+            if (!\mkdir($uploadDir, recursive: true)) {
+                throw new \Exception('Could not create directory "'.$uploadDir.'"');
+            }
+        }
+        if (!\is_dir($uploadDir)) {
+            throw new \Exception('Tried to move file to directory "'.$uploadDir.'" but it is a file');
+        }
+
         if ($file instanceof UploadedFile) {
             return $file->move($uploadDir, $name);
         }

--- a/tests/Storage/FileSystemStorageTest.php
+++ b/tests/Storage/FileSystemStorageTest.php
@@ -264,11 +264,13 @@ final class FileSystemStorageTest extends StorageTestCase
      */
     public function testUploadedFileIsCorrectlyMoved(string $uploadDir, string $dir, string $expectedDir): void
     {
+        $uploadDir = $this->root->url().\DIRECTORY_SEPARATOR.$uploadDir;
+        $expectedDir = $this->root->url().\DIRECTORY_SEPARATOR.$expectedDir;
         $file = $this->getUploadedFileMock();
 
         $file
             ->method('getClientOriginalName')
-            ->willReturn('filename.txt');
+            ->willReturn('test.txt');
 
         $this->mapping
             ->expects(self::once())
@@ -285,7 +287,7 @@ final class FileSystemStorageTest extends StorageTestCase
             ->expects(self::once())
             ->method('getUploadName')
             ->with($this->object)
-            ->willReturn('filename.txt');
+            ->willReturn('test.txt');
 
         $this->mapping
             ->expects(self::once())
@@ -296,7 +298,7 @@ final class FileSystemStorageTest extends StorageTestCase
         $file
             ->expects(self::once())
             ->method('move')
-            ->with($expectedDir, 'filename.txt');
+            ->with($expectedDir, 'test.txt');
 
         $this->storage->upload($this->object, $this->mapping);
     }
@@ -309,7 +311,7 @@ final class FileSystemStorageTest extends StorageTestCase
         $file = $this->getReplacingFileMock();
         $file
             ->method('getClientOriginalName')
-            ->willReturn('filename.txt');
+            ->willReturn('test.txt');
         $file
             ->method('getPathname')
             ->willReturn($this->getValidUploadDir().'/test.txt');
@@ -348,7 +350,7 @@ final class FileSystemStorageTest extends StorageTestCase
         $file = $this->getReplacingFileMock();
         $file
             ->method('getClientOriginalName')
-            ->willReturn('filename.txt');
+            ->willReturn('test.txt');
         $file
             ->method('getPathname')
             ->willReturn($this->getValidUploadDir().'/test.txt');
@@ -383,20 +385,20 @@ final class FileSystemStorageTest extends StorageTestCase
     {
         return [
             // upload dir, dir, expected dir
-            [
-                '/root_dir',
+            'zero subdirectories' => [
+                '/storage/vich_uploader_bundle',
                 '',
-                '/root_dir/',
+                '/storage/vich_uploader_bundle/',
             ],
-            [
-                '/root_dir',
+            'one subdirectory' => [
+                '/storage/vich_uploader_bundle',
                 'dir_1',
-                '/root_dir/dir_1',
+                '/storage/vich_uploader_bundle/dir_1',
             ],
-            [
-                '/root_dir',
+            'two subdirectories' => [
+                '/storage/vich_uploader_bundle',
                 'dir_1/dir_2',
-                '/root_dir/dir_1/dir_2',
+                '/storage/vich_uploader_bundle/dir_1/dir_2',
             ],
         ];
     }

--- a/tests/Storage/FileSystemStorageTest.php
+++ b/tests/Storage/FileSystemStorageTest.php
@@ -307,7 +307,6 @@ final class FileSystemStorageTest extends StorageTestCase
     public function testReplacingFileIsCorrectlyUploaded(): void
     {
         $file = $this->getReplacingFileMock();
-
         $file
             ->method('getClientOriginalName')
             ->willReturn('filename.txt');
@@ -337,6 +336,45 @@ final class FileSystemStorageTest extends StorageTestCase
             ->method('getUploadDir')
             ->with($this->object)
             ->willReturn('vich_uploader_bundle');
+
+        $this->storage->upload($this->object, $this->mapping);
+    }
+
+    /**
+     * @group upload
+     */
+    public function testReplacingFileWithDirectoryNamerIsCorrectlyUploaded(): void
+    {
+        $file = $this->getReplacingFileMock();
+        $file
+            ->method('getClientOriginalName')
+            ->willReturn('filename.txt');
+        $file
+            ->method('getPathname')
+            ->willReturn($this->getValidUploadDir().'/test.txt');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFile')
+            ->with($this->object)
+            ->willReturn($file);
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadDestination')
+            ->willReturn($this->root->url().\DIRECTORY_SEPARATOR.'storage');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadName')
+            ->with($this->object)
+            ->willReturn('test.txt');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadDir')
+            ->with($this->object)
+            ->willReturn('vich_uploader_bundle/directoryNamer/1/');
 
         $this->storage->upload($this->object, $this->mapping);
     }


### PR DESCRIPTION
I guess the `FileSystemStorage` just lacked functionality for `DirectoryNamerInterface`/subdirectories. Don't know how this issue has not come up earlier...