### PR TITLE
urlencode filename in resolve uri

### DIFF
--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -92,7 +92,7 @@ abstract class AbstractStorage implements StorageInterface
         }
 
         $dir = $mapping->getUploadDir($obj);
-        $path = !empty($dir) ? $dir.'/'.$filename : $filename;
+        $path = !empty($dir) ? $dir.'/'.urlencode($filename) : urlencode($filename);
 
         return $mapping->getUriPrefix().'/'.$path;
     }


### PR DESCRIPTION
Filenames with non URL friendly chars break links

For example:
filename = 'training-C#-overview.pdf'
will create link as:
https://example.com/path/prefix/training-C#-overview.pdf
instead of:
https://example.com/path/prefix/training-C%23-overview.pdf

URL encoding should prevent browsers from interpreting this char.