### PR TITLE
[Commands] Fix Symfony 6.1 deprecations

### DIFF
--- a/src/Command/MappingDebugClassCommand.php
+++ b/src/Command/MappingDebugClassCommand.php
@@ -17,11 +17,6 @@ final class MappingDebugClassCommand extends Command
         parent::__construct();
     }
 
-    public static function getDefaultName(): string
-    {
-        return 'vich:mapping:debug-class';
-    }
-
     protected function configure(): void
     {
         $this

--- a/src/Command/MappingDebugClassCommand.php
+++ b/src/Command/MappingDebugClassCommand.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -10,6 +11,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Vich\UploaderBundle\Metadata\MetadataReader;
 
+#[AsCommand(
+    name: 'vich:mapping:debug-class',
+    description: 'Debug a class.'
+)]
 final class MappingDebugClassCommand extends Command
 {
     public function __construct(private readonly MetadataReader $metadataReader)
@@ -20,8 +25,6 @@ final class MappingDebugClassCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('vich:mapping:debug-class')
-            ->setDescription('Debug a class.')
             ->addArgument('fqcn', InputArgument::REQUIRED, 'The FQCN of the class to debug.')
         ;
     }

--- a/src/Command/MappingDebugCommand.php
+++ b/src/Command/MappingDebugCommand.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -10,6 +11,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Vich\UploaderBundle\Exception\MappingNotFoundException;
 
+#[AsCommand(
+    name: 'vich:mapping:debug',
+    description: 'Debug a mapping.'
+)]
 final class MappingDebugCommand extends Command
 {
     public function __construct(private readonly array $mappings)
@@ -20,8 +25,6 @@ final class MappingDebugCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('vich:mapping:debug')
-            ->setDescription('Debug a mapping.')
             ->addArgument('mapping', InputArgument::REQUIRED, 'The mapping to debug.')
         ;
     }

--- a/src/Command/MappingDebugCommand.php
+++ b/src/Command/MappingDebugCommand.php
@@ -17,11 +17,6 @@ final class MappingDebugCommand extends Command
         parent::__construct();
     }
 
-    public static function getDefaultName(): string
-    {
-        return 'vich:mapping:debug';
-    }
-
     protected function configure(): void
     {
         $this

--- a/src/Command/MappingListClassesCommand.php
+++ b/src/Command/MappingListClassesCommand.php
@@ -2,24 +2,21 @@
 
 namespace Vich\UploaderBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Vich\UploaderBundle\Metadata\MetadataReader;
 
+#[AsCommand(
+    name: 'vich:mapping:list-classes',
+    description: 'Searches for uploadable classes'
+)]
 final class MappingListClassesCommand extends Command
 {
     public function __construct(private readonly MetadataReader $metadataReader)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('vich:mapping:list-classes')
-            ->setDescription('Searches for uploadable classes.')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/MappingListClassesCommand.php
+++ b/src/Command/MappingListClassesCommand.php
@@ -14,11 +14,6 @@ final class MappingListClassesCommand extends Command
         parent::__construct();
     }
 
-    public static function getDefaultName(): string
-    {
-        return 'vich:mapping:list-classes';
-    }
-
     protected function configure(): void
     {
         $this


### PR DESCRIPTION
The `$defaultName` property in commands has been [deprecated](https://github.com/symfony/symfony/commit/ca3458c8781eafd9ff40bac50a254334e526dc10) in Symfony 6.1

Commands in Symfony 6 should use the `AsCommand` attribute instead.

Tests command OK.