### PR TITLE
Fix command and Symfony deprecations

### DIFF
--- a/src/Command/MappingDebugClassCommand.php
+++ b/src/Command/MappingDebugClassCommand.php
@@ -15,8 +15,6 @@ use Vich\UploaderBundle\Metadata\MetadataReader;
  */
 class MappingDebugClassCommand extends Command
 {
-    protected static $defaultName = 'vich:mapping:debug-class';
-
     /** @var MetadataReader */
     private $metadataReader;
 

--- a/src/Command/MappingDebugCommand.php
+++ b/src/Command/MappingDebugCommand.php
@@ -15,8 +15,6 @@ use Vich\UploaderBundle\Exception\MappingNotFoundException;
  */
 class MappingDebugCommand extends Command
 {
-    protected static $defaultName = 'vich:mapping:debug';
-
     /** @var array */
     private $mappings;
 

--- a/src/Command/MappingListClassesCommand.php
+++ b/src/Command/MappingListClassesCommand.php
@@ -12,8 +12,6 @@ use Vich\UploaderBundle\Metadata\MetadataReader;
  */
 class MappingListClassesCommand extends Command
 {
-    protected static $defaultName = 'vich:mapping:list-classes';
-
     /** @var MetadataReader */
     private $metadataReader;
 

--- a/tests/Kernel/FilesystemAppKernel.php
+++ b/tests/Kernel/FilesystemAppKernel.php
@@ -26,6 +26,7 @@ class FilesystemAppKernel extends Kernel
     {
         $loader->load(static function (ContainerBuilder $container): void {
             $container->loadFromExtension('framework', [
+                'http_method_override' => true,
                 'secret' => '$ecret',
                 'router' => [
                     'resource' => 'kernel::loadRoutes',

--- a/tests/Kernel/FlysystemOfficialAppKernel.php
+++ b/tests/Kernel/FlysystemOfficialAppKernel.php
@@ -26,6 +26,7 @@ class FlysystemOfficialAppKernel extends Kernel
     {
         $loader->load(static function (ContainerBuilder $container): void {
             $container->loadFromExtension('framework', [
+                'http_method_override' => true,
                 'secret' => '$ecret',
                 'router' => [
                     'resource' => 'kernel::loadRoutes',

--- a/tests/Kernel/FlysystemOneUpAppKernel.php
+++ b/tests/Kernel/FlysystemOneUpAppKernel.php
@@ -30,6 +30,7 @@ class FlysystemOneUpAppKernel extends Kernel
     {
         $loader->load(static function (ContainerBuilder $container): void {
             $container->loadFromExtension('framework', [
+                'http_method_override' => true,
                 'secret' => '$ecret',
                 'router' => [
                     'resource' => 'kernel::loadRoutes',

--- a/tests/Kernel/SimpleAppKernel.php
+++ b/tests/Kernel/SimpleAppKernel.php
@@ -25,6 +25,7 @@ class SimpleAppKernel extends Kernel
     {
         $loader->load(static function (ContainerBuilder $container): void {
             $container->loadFromExtension('framework', [
+                'http_method_override' => true,
                 'secret' => '$ecret',
                 'router' => [
                     'resource' => 'kernel::loadRoutes',


### PR DESCRIPTION
Backporting some of the v2.0 changes into 1.x branch:
- removing `$defaultName` from Command classes
- setting `framework.http_method_override` in tests