### PR TITLE
Refactor property mapping creation into a class

### DIFF
--- a/config/factory.xml
+++ b/config/factory.xml
@@ -4,11 +4,17 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="vich_uploader.property_mapping_factory" class="Vich\UploaderBundle\Mapping\PropertyMappingFactory" public="false">
+        <service id="vich_uploader.property_mapping_resolver" class="Vich\UploaderBundle\Mapping\PropertyMappingResolver" public="false">
             <argument type="service" id="service_container" />
-            <argument type="service" id="vich_uploader.metadata_reader" />
             <argument>%vich_uploader.mappings%</argument>
             <argument>%vich_uploader.default_filename_attribute_suffix%</argument>
+        </service>
+
+        <service id="Vich\UploaderBundle\Mapping\PropertyMappingResolverInterface" alias="vich_uploader.property_mapping_resolver" public="false"/>
+
+        <service id="vich_uploader.property_mapping_factory" class="Vich\UploaderBundle\Mapping\PropertyMappingFactory" public="false">
+            <argument type="service" id="vich_uploader.metadata_reader" />
+            <argument type="service" id="vich_uploader.property_mapping_resolver" />
         </service>
 
         <service id="Vich\UploaderBundle\Mapping\PropertyMappingFactory" alias="vich_uploader.property_mapping_factory" public="false"/>

--- a/src/Mapping/PropertyMappingFactory.php
+++ b/src/Mapping/PropertyMappingFactory.php
@@ -3,11 +3,9 @@
 namespace Vich\UploaderBundle\Mapping;
 
 use Doctrine\Persistence\Proxy;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Vich\UploaderBundle\Exception\MappingNotFoundException;
 use Vich\UploaderBundle\Exception\NotUploadableException;
 use Vich\UploaderBundle\Metadata\MetadataReader;
-use Vich\UploaderBundle\Naming\ConfigurableInterface;
 use Vich\UploaderBundle\Util\ClassUtils;
 
 /**
@@ -19,12 +17,14 @@ use Vich\UploaderBundle\Util\ClassUtils;
  */
 final class PropertyMappingFactory
 {
-    public function __construct(private readonly ContainerInterface $container, private readonly MetadataReader $metadata, private readonly array $mappings, private readonly ?string $defaultFilenameAttributeSuffix = '_name')
-    {
+    public function __construct(
+        private readonly MetadataReader $metadata,
+        private readonly PropertyMappingResolverInterface $resolver,
+    ) {
     }
 
     /**
-     * Creates an array of PropetyMapping objects which contain the
+     * Creates an array of PropertyMapping objects which contain the
      * configuration for the uploadable fields in the specified
      * object.
      *
@@ -53,7 +53,7 @@ final class PropertyMappingFactory
                 continue;
             }
 
-            $mappings[] = $this->createMapping($obj, $field, $mappingData);
+            $mappings[] = $this->resolver->resolve($obj, $field, $mappingData);
         }
 
         return $mappings;
@@ -87,7 +87,7 @@ final class PropertyMappingFactory
             return null;
         }
 
-        return $this->createMapping($obj, $field, $mappingData);
+        return $this->resolver->resolve($obj, $field, $mappingData);
     }
 
     public function fromFirstField(object $obj, ?string $className = null): ?PropertyMapping
@@ -104,7 +104,7 @@ final class PropertyMappingFactory
             return null;
         }
 
-        return $this->createMapping($obj, \key($mappingData), \reset($mappingData));
+        return $this->resolver->resolve($obj, \key($mappingData), \reset($mappingData));
     }
 
     /**
@@ -119,63 +119,6 @@ final class PropertyMappingFactory
         if (!$this->metadata->isUploadable($class)) {
             throw new NotUploadableException(\sprintf('The class "%s" is not uploadable. If you use attributes to configure VichUploaderBundle, you probably just forgot to add `#[Vich\Uploadable]` on top of your entity. If you don\'t use attributes, check that the configuration files are in the right place. In both cases, clearing the cache can also solve the issue.', $class));
         }
-    }
-
-    /**
-     * Creates the property mapping from the read annotation and configured mapping.
-     *
-     * @param object|array $obj         The object
-     * @param string       $fieldName   The field name
-     * @param array        $mappingData The mapping data
-     *
-     * @return PropertyMapping The property mapping
-     *
-     * @throws \LogicException
-     * @throws MappingNotFoundException
-     */
-    private function createMapping(object|array $obj, string $fieldName, array $mappingData): PropertyMapping
-    {
-        if (!\array_key_exists($mappingData['mapping'], $this->mappings)) {
-            throw MappingNotFoundException::createNotFoundForClassAndField($mappingData['mapping'], $this->getClassName($obj), $fieldName);
-        }
-
-        $config = $this->mappings[$mappingData['mapping']];
-        $fileProperty = $mappingData['propertyName'] ?? $fieldName;
-        $fileNameProperty = empty($mappingData['fileNameProperty']) ? $fileProperty.$this->defaultFilenameAttributeSuffix : $mappingData['fileNameProperty'];
-
-        $mapping = new PropertyMapping($fileProperty, $fileNameProperty, $mappingData);
-        $mapping->setMappingName($mappingData['mapping']);
-        $mapping->setMapping($config);
-
-        if (!empty($config['namer']) && null !== $config['namer']['service']) {
-            $namerConfig = $config['namer'];
-            $namer = $this->container->get($namerConfig['service']);
-
-            if (!empty($namerConfig['options'])) {
-                if (!$namer instanceof ConfigurableInterface) {
-                    throw new \LogicException(\sprintf('Namer %s can not receive options as it does not implement ConfigurableInterface.', $namerConfig['service']));
-                }
-                $namer->configure($namerConfig['options']);
-            }
-
-            $mapping->setNamer($namer);
-        }
-
-        if (!empty($config['directory_namer']) && null !== $config['directory_namer']['service']) {
-            $namerConfig = $config['directory_namer'];
-            $namer = $this->container->get($namerConfig['service']);
-
-            if (!empty($namerConfig['options'])) {
-                if (!$namer instanceof ConfigurableInterface) {
-                    throw new \LogicException(\sprintf('Namer %s can not receive options as it does not implement ConfigurableInterface.', $namerConfig['service']));
-                }
-                $namer->configure($namerConfig['options']);
-            }
-
-            $mapping->setDirectoryNamer($namer);
-        }
-
-        return $mapping;
     }
 
     /**

--- a/src/Mapping/PropertyMappingResolver.php
+++ b/src/Mapping/PropertyMappingResolver.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vich\UploaderBundle\Mapping;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Vich\UploaderBundle\Exception\MappingNotFoundException;
+use Vich\UploaderBundle\Naming\ConfigurableInterface;
+use Vich\UploaderBundle\Util\ClassUtils;
+
+/**
+ * PropertyMappingResolver.
+ *
+ * @author Dustin Dobervich <ddobervich@gmail.com>
+ *
+ * @internal
+ */
+final class PropertyMappingResolver implements PropertyMappingResolverInterface
+{
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly array $mappings,
+        private readonly ?string $defaultFilenameAttributeSuffix = '_name'
+    ) {
+    }
+
+    public function resolve(object|array $obj, string $fieldName, array $mappingData): PropertyMapping
+    {
+        if (!\array_key_exists($mappingData['mapping'], $this->mappings)) {
+            $className = \is_object($obj) ? ClassUtils::getClass($obj) : '[array]';
+            throw MappingNotFoundException::createNotFoundForClassAndField($mappingData['mapping'], $className, $fieldName);
+        }
+
+        $config = $this->mappings[$mappingData['mapping']];
+        $fileProperty = $mappingData['propertyName'] ?? $fieldName;
+        $fileNameProperty = empty($mappingData['fileNameProperty']) ? $fileProperty.$this->defaultFilenameAttributeSuffix : $mappingData['fileNameProperty'];
+
+        $mapping = new PropertyMapping($fileProperty, $fileNameProperty, $mappingData);
+        $mapping->setMappingName($mappingData['mapping']);
+        $mapping->setMapping($config);
+
+        if (!empty($config['namer']) && null !== $config['namer']['service']) {
+            $namerConfig = $config['namer'];
+            $namer = $this->container->get($namerConfig['service']);
+
+            if (!empty($namerConfig['options'])) {
+                if (!$namer instanceof ConfigurableInterface) {
+                    throw new \LogicException(\sprintf('Namer %s can not receive options as it does not implement ConfigurableInterface.', $namerConfig['service']));
+                }
+                $namer->configure($namerConfig['options']);
+            }
+
+            $mapping->setNamer($namer);
+        }
+
+        if (!empty($config['directory_namer']) && null !== $config['directory_namer']['service']) {
+            $namerConfig = $config['directory_namer'];
+            $namer = $this->container->get($namerConfig['service']);
+
+            if (!empty($namerConfig['options'])) {
+                if (!$namer instanceof ConfigurableInterface) {
+                    throw new \LogicException(\sprintf('Namer %s can not receive options as it does not implement ConfigurableInterface.', $namerConfig['service']));
+                }
+                $namer->configure($namerConfig['options']);
+            }
+
+            $mapping->setDirectoryNamer($namer);
+        }
+
+        return $mapping;
+    }
+}

--- a/src/Mapping/PropertyMappingResolverInterface.php
+++ b/src/Mapping/PropertyMappingResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vich\UploaderBundle\Mapping;
+
+use Vich\UploaderBundle\Exception\MappingNotFoundException;
+
+interface PropertyMappingResolverInterface
+{
+    /**
+     * Creates the property mapping from the read annotation and configured mapping.
+     *
+     * @param object|array $obj         The object
+     * @param string       $fieldName   The field name
+     * @param array        $mappingData The mapping data
+     *
+     * @return PropertyMapping The property mapping
+     *
+     * @throws \LogicException
+     * @throws MappingNotFoundException
+     */
+    public function resolve(object|array $obj, string $fieldName, array $mappingData): PropertyMapping;
+}

--- a/tests/Mapping/PropertyMappingFactoryTest.php
+++ b/tests/Mapping/PropertyMappingFactoryTest.php
@@ -6,6 +6,7 @@ use Doctrine\Persistence\Proxy;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Mapping\PropertyMappingResolver;
 use Vich\UploaderBundle\Metadata\MetadataReader;
 use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
 use Vich\UploaderBundle\Naming\NamerInterface;
@@ -42,7 +43,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->method('isUploadable')
             ->willReturn(false);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, []);
+        $resolver = new PropertyMappingResolver($this->container, []);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $factory->fromObject(new DummyEntity());
     }
 
@@ -81,7 +83,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->with($expectedClassName)
             ->willReturn($expectedFields);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, $mappings);
+        $resolver = new PropertyMappingResolver($this->container, $mappings);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $mappings = $factory->fromObject($object, $givenClassName);
 
         self::assertCount(1, $mappings);
@@ -111,7 +114,8 @@ class PropertyMappingFactoryTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, []);
+        $resolver = new PropertyMappingResolver($this->container, []);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $factory->fromObject([]);
     }
 
@@ -146,7 +150,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->with(DummyEntity::class)
             ->willReturn($expectedFields);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, $mappings);
+        $resolver = new PropertyMappingResolver($this->container, $mappings);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $mappings = $factory->fromObject($obj);
 
         self::assertCount(1, $mappings);
@@ -202,7 +207,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->with(DummyEntity::class)
             ->willReturn($expectedFields);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, $mappings);
+        $resolver = new PropertyMappingResolver($this->container, $mappings);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $mappings = $factory->fromObject(new DummyEntity(), null, 'other_mapping');
 
         self::assertCount(1, $mappings);
@@ -241,7 +247,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->with(DummyEntity::class)
             ->willReturn($expectedFields);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, $mappings);
+        $resolver = new PropertyMappingResolver($this->container, $mappings);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $factory->fromObject(new DummyEntity());
     }
 
@@ -278,7 +285,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->with($expectedClassName, 'file')
             ->willReturn($expectedFields);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, $mappings);
+        $resolver = new PropertyMappingResolver($this->container, $mappings);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $mapping = $factory->fromField($object, 'file', $className);
 
         self::assertEquals('dummy_file', $mapping->getMappingName());
@@ -315,7 +323,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->with(DummyEntity::class)
             ->willReturn(null);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, []);
+        $resolver = new PropertyMappingResolver($this->container, []);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $mapping = $factory->fromField(new DummyEntity(), 'oops');
 
         self::assertNull($mapping);
@@ -342,7 +351,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->with(DummyEntity::class)
             ->willReturn(['mapping' => 'dummy_file', 'propertyName' => 'file']);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, $mappings, '_suffix');
+        $resolver = new PropertyMappingResolver($this->container, $mappings, '_suffix');
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $mapping = $factory->fromField(new DummyEntity(), 'file');
 
         self::assertEquals('file_suffix', $mapping->getFileNamePropertyName());
@@ -380,7 +390,8 @@ class PropertyMappingFactoryTest extends TestCase
             ->with(DummyEntity::class)
             ->willReturn(['file' => ['mapping' => 'dummy_file', 'propertyName' => 'file', 'fileNameProperty' => 'fileName']]);
 
-        $factory = new PropertyMappingFactory($this->container, $this->metadata, $mappings);
+        $resolver = new PropertyMappingResolver($this->container, $mappings);
+        $factory = new PropertyMappingFactory($this->metadata, $resolver);
         $mappings = $factory->fromObject(new DummyEntity());
 
         self::assertCount(1, $mappings);


### PR DESCRIPTION
This refactors parts of the property mapping factory into a resolver to allow for decoration via an interface.

Refs #1317