### PR TITLE
Remove lazy flag from GaufretteStorage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,6 @@
         "doctrine/phpcr-odm": "For integration with Doctrine PHPCR",
         "knplabs/knp-gaufrette-bundle": "For integration with Gaufrette",
         "liip/imagine-bundle": "To generate image thumbnails",
-        "ocramius/proxy-manager": "To use lazy services",
         "league/flysystem-bundle": "For integration with Flysystem",
         "oneup/flysystem-bundle": "For integration with Flysystem",
         "symfony/asset": "To generate better links",

--- a/config/gaufrette.xml
+++ b/config/gaufrette.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="vich_uploader.storage.gaufrette" class="Vich\UploaderBundle\Storage\GaufretteStorage" public="false" lazy="true">
+        <service id="vich_uploader.storage.gaufrette" class="Vich\UploaderBundle\Storage\GaufretteStorage" public="false">
             <argument type="service" id="vich_uploader.property_mapping_factory" />
             <argument type="service" id="knp_gaufrette.filesystem_map" />
             <argument>%knp_gaufrette.stream_wrapper.protocol%</argument>


### PR DESCRIPTION
Classes that are final cannot be marked as lazy.

This service was originally marked as lazy with https://github.com/dustin10/VichUploaderBundle/pull/630, but I cannot reproduce a circular reference with my project after removing the lazy flag.