### PR TITLE
XSD schema for XML mapping

### DIFF
--- a/docs/mapping/xml.md
+++ b/docs/mapping/xml.md
@@ -6,7 +6,8 @@ format and comes with the following syntax to declare your uploadable fields:
 ```xml
 <!-- config/vich_uploader/Entity.Product.xml -->
 <!-- Attributes "mapping", "name" and "filename_property" are required -->
-<vich_uploader class="Acme\DemoBundle\Entity\Product">
+<vich_uploader xmlns="https://vich-uploader-bundle/schema/"
+               class="Acme\DemoBundle\Entity\Product">
     <field mapping="products" name="imageFile" filename_property="imageName"
            size="imageSize" dimensions="imageDimensions" mime_type="imageMimeType" original_name="imageOriginalName" />
 </vich_uploader>

--- a/vich_uploader.xsd
+++ b/vich_uploader.xsd
@@ -1,0 +1,32 @@
+<xs:schema
+        attributeFormDefault="unqualified"
+        elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="https://vich-uploader-bundle/schema/"
+>
+    <xs:element name="vich_uploader">
+        <xs:complexType>
+
+            <xs:sequence>
+
+                <xs:element name="field">
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:string">
+                                <xs:attribute type="xs:string" name="name" use="required"/>
+                                <xs:attribute type="xs:string" name="mapping" use="required"/>
+                                <xs:attribute type="xs:string" name="filename_property" use="required"/>
+                                <xs:attribute type="xs:string" name="size"/>
+                                <xs:attribute type="xs:string" name="dimensions"/>
+                                <xs:attribute type="xs:string" name="mime_type"/>
+                                <xs:attribute type="xs:string" name="original_name"/>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+
+            <xs:attribute type="xs:string" name="class" use="required"/>
+
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
Provides an XSD schema so that creating XML mapping is easier, since IDE can use it for autocompletion

### Improvement

|    Q        |   A
|------------ | ------
| New Feature | yes
| RFC         | yes
| BC Break    | no

#### Summary

Creating an XML document without an associated XSD schema is error prone. With the provided XSD schema, IDEs can provide autocompletion, and XML files can be validated.
