### PR TITLE
Remove ext-mongo polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "alcaeus/mongo-php-adapter": "^1.2",
         "dg/bypass-finals": "^1.3",
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/mongodb-odm": "^2.4",


### PR DESCRIPTION
With Doctrine MongoDB ODM 1.x no longer being supported, this library no longer relies on the deprecated `ext-mongo` extension, so we no longer need to install the polyfill for it.