### PR TITLE
Check metadata type when adding annotation/attribute mapping drivers

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterMappingDriversPass.php
+++ b/src/DependencyInjection/Compiler/RegisterMappingDriversPass.php
@@ -18,7 +18,9 @@ final class RegisterMappingDriversPass implements CompilerPassInterface
             new Reference('vich_uploader.metadata_driver.xml'),
         ];
 
-        if ($container->has('annotation_reader')) {
+        $metaDataType = $container->getParameter('vich_uploader.metadata_type');
+
+        if ('attribute' === $metaDataType || ('annotation' === $metaDataType && $container->has('annotation_reader'))) {
             $managers = [];
             if ($container->hasDefinition('doctrine_mongodb')) {
                 $managers[] = new Reference('doctrine_mongodb');

--- a/src/DependencyInjection/VichUploaderExtension.php
+++ b/src/DependencyInjection/VichUploaderExtension.php
@@ -38,6 +38,7 @@ final class VichUploaderExtension extends Extension
         // define a few parameters
         $container->setParameter('vich_uploader.default_filename_attribute_suffix', $config['default_filename_attribute_suffix']);
         $container->setParameter('vich_uploader.mappings', $config['mappings']);
+        $container->setParameter('vich_uploader.metadata_type', $config['metadata']['type']);
 
         if (\str_starts_with((string) $config['storage'], '@')) {
             $container->setAlias('vich_uploader.storage', \substr((string) $config['storage'], 1));


### PR DESCRIPTION
Fixes #1344

The `annotation_reader` service is _not_ required for attributes to be read, but if the `doctrine/annotations` package isn't present the service does not exist meaning attribute metadata is not read.

This PR resolves this issue by adding the meta data type config as a parameter and modifying the check for the existence of the service so it short-circuits if the meta data type is `attribute`.