### PR TITLE
Require symfony/contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/config": "^5.4 || ^6.0",
         "symfony/console": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
-        "symfony/event-dispatcher-contracts": "^3.0",
+        "symfony/contracts": "^3.0",
         "symfony/http-foundation": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0",
         "symfony/mime": "^5.4 || ^6.0",


### PR DESCRIPTION
Replaces `symfony/event-dispatcher-contracts` by `symfony/contracts` in package requirements, as both packages cannot coexist in the same project because `contracts` replaces `event-dispatcher-contracts`