### PR TITLE
require doctrine/annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^8.1",
         "ext-simplexml": "*",
+        "doctrine/annotations": "*",
         "doctrine/persistence": "^3",
         "jms/metadata": "^2.4",
         "symfony/config": "^5.4 || ^6.0",


### PR DESCRIPTION
Hi. After too long and unnecessary debug session on why nothing works when using attribute/annotation metadata in this bundle configuration just to realize that it is required to have doctrine/annotations in order to get this bundle work properly and not silently failing (or rather just outright skipping necessary configuration) I belive this composer requirement is a must have.  
I can't decide on version restriction here as my project have 1.14 installed, and other requirement prevent me to test if it works with 2.0 as well here.  

I did see other issues and comments regarding this issue but I think that this strict requirement is needed until more proper way of dealing with this issue is found.