### PR TITLE
Docs: Fix DownloadHandler link

### DIFF
--- a/docs/downloads/serving_files_with_a_controller.md
+++ b/docs/downloads/serving_files_with_a_controller.md
@@ -6,7 +6,7 @@ used to **check that the user has the rights** to download the file, to **serve 
 file under a different name** that the one saved in the database, to **force the
 download of the file** instead of opening it in the same browser tab, …
 
-For all these reasons, the bundle provides a [`DownloadHandler`](https://github.com/dustin10/VichUploaderBundle/blob/master/Handler/DownloadHandler.php)
+For all these reasons, the bundle provides a [`DownloadHandler`](https://github.com/dustin10/VichUploaderBundle/blob/master/src/Handler/DownloadHandler.php)
 that can be used in your controllers.
 
 ## Usage


### PR DESCRIPTION
Fix a missing folder in the link to the DownloadHandler file on the Serving files with a controller README.