### PR TITLE
Allow use of array to resolve uri

### DIFF
--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -127,8 +127,8 @@ final class PropertyMapping
      *
      * @internal
      *
-     * @param object $obj      The object or array from which read
-     * @param string $property The property to read
+     * @param object|array $obj      The object or array from which read
+     * @param string       $property The property to read
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -7,6 +7,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
 use Vich\UploaderBundle\Naming\NamerInterface;
+use Vich\UploaderBundle\Util\PropertyPathUtils;
 
 /**
  * PropertyMapping.
@@ -82,13 +83,13 @@ final class PropertyMapping
     /**
      * Gets the fileName property of the given object.
      *
-     * @param object $obj The object
+     * @param object $obj The object or array
      *
      * @return string|null The filename
      *
      * @throws \InvalidArgumentException
      */
-    public function getFileName(object $obj): ?string
+    public function getFileName(object|array $obj): ?string
     {
         return $this->readProperty($obj, 'name');
     }
@@ -126,12 +127,12 @@ final class PropertyMapping
      *
      * @internal
      *
-     * @param object $obj      The object from which read
+     * @param object $obj      The object or array from which read
      * @param string $property The property to read
      *
      * @throws \InvalidArgumentException
      */
-    public function readProperty(object $obj, string $property): mixed
+    public function readProperty(object|array $obj, string $property): mixed
     {
         if (!\array_key_exists($property, $this->propertyPaths)) {
             throw new \InvalidArgumentException(\sprintf('Unknown property %s', $property));
@@ -142,7 +143,7 @@ final class PropertyMapping
             return null;
         }
 
-        $propertyPath = $this->fixPropertyPath($obj, $this->propertyPaths[$property]);
+        $propertyPath = PropertyPathUtils::fixPropertyPath($obj, $this->propertyPaths[$property]);
 
         return $this->getAccessor()->getValue($obj, $propertyPath);
     }
@@ -170,7 +171,7 @@ final class PropertyMapping
             return;
         }
 
-        $propertyPath = $this->fixPropertyPath($obj, $this->propertyPaths[$property]);
+        $propertyPath = PropertyPathUtils::fixPropertyPath($obj, $this->propertyPaths[$property]);
         $this->getAccessor()->setValue($obj, $propertyPath, $value);
     }
 
@@ -319,26 +320,6 @@ final class PropertyMapping
     public function getUriPrefix(): string
     {
         return $this->mapping['uri_prefix'];
-    }
-
-    /**
-     * Fixes a given propertyPath to make it usable both with arrays and
-     * objects.
-     * Ie: if the given object is in fact an array, the property path must
-     * look like [myPath].
-     *
-     * @param object|array $object       The object to inspect
-     * @param string       $propertyPath The property path to fix
-     *
-     * @return string The fixed property path
-     */
-    private function fixPropertyPath($object, string $propertyPath): string
-    {
-        if (!\is_array($object)) {
-            return $propertyPath;
-        }
-
-        return '[' === $propertyPath[0] ? $propertyPath : \sprintf('[%s]', $propertyPath);
     }
 
     private function getAccessor(): PropertyAccessor

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -83,7 +83,7 @@ final class PropertyMapping
     /**
      * Gets the fileName property of the given object.
      *
-     * @param object $obj The object or array
+     * @param object|array $obj The object or array
      *
      * @return string|null The filename
      *

--- a/src/Mapping/PropertyMappingFactory.php
+++ b/src/Mapping/PropertyMappingFactory.php
@@ -90,7 +90,7 @@ final class PropertyMappingFactory
         return $this->resolver->resolve($obj, $field, $mappingData);
     }
 
-    public function fromFirstField(object $obj, ?string $className = null): ?PropertyMapping
+    public function fromFirstField(object|array $obj, ?string $className = null): ?PropertyMapping
     {
         if ($obj instanceof Proxy) {
             $obj->__load();

--- a/src/Naming/CurrentDateTimeDirectoryNamer.php
+++ b/src/Naming/CurrentDateTimeDirectoryNamer.php
@@ -4,6 +4,7 @@ namespace Vich\UploaderBundle\Naming;
 
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Util\PropertyPathUtils;
 
 /**
  * Directory namer wich can create subfolder depends on current datetime.
@@ -38,13 +39,16 @@ final class CurrentDateTimeDirectoryNamer implements DirectoryNamerInterface, Co
         }
     }
 
-    public function directoryName(object $object, PropertyMapping $mapping): string
+    public function directoryName(object|array $object, PropertyMapping $mapping): string
     {
         if (empty($this->dateTimeFormat)) {
             throw new \LogicException('Option "date_time_format" is empty.');
         }
         if (null !== $this->dateTimeProperty) {
-            $dateTime = $this->propertyAccessor->getValue($object, $this->dateTimeProperty)->format('U');
+            $dateTime = $this->propertyAccessor->getValue(
+                $object,
+                PropertyPathUtils::fixPropertyPath($object, $this->dateTimeProperty)
+            )->format('U');
         } else {
             throw new \LogicException('Option "date_time_property" is mandatory.');
         }

--- a/src/Naming/DirectoryNamerInterface.php
+++ b/src/Naming/DirectoryNamerInterface.php
@@ -16,12 +16,12 @@ interface DirectoryNamerInterface
     /**
      * Creates a directory name for the file being uploaded.
      *
-     * @param object          $object  The object the upload is attached to
+     * @param object          $object  The object or array the upload is attached to
      * @param PropertyMapping $mapping The mapping to use to manipulate the given object
      *
      * @return string The directory name
      *
      * @phpstan-param T $object
      */
-    public function directoryName(object $object, PropertyMapping $mapping): string;
+    public function directoryName(object|array $object, PropertyMapping $mapping): string;
 }

--- a/src/Naming/DirectoryNamerInterface.php
+++ b/src/Naming/DirectoryNamerInterface.php
@@ -16,7 +16,7 @@ interface DirectoryNamerInterface
     /**
      * Creates a directory name for the file being uploaded.
      *
-     * @param object          $object  The object or array the upload is attached to
+     * @param object|array    $object  The object or array the upload is attached to
      * @param PropertyMapping $mapping The mapping to use to manipulate the given object
      *
      * @return string The directory name

--- a/src/Naming/PropertyDirectoryNamer.php
+++ b/src/Naming/PropertyDirectoryNamer.php
@@ -44,7 +44,7 @@ final class PropertyDirectoryNamer implements DirectoryNamerInterface, Configura
         $this->transliterate = isset($options['transliterate']) ? (bool) $options['transliterate'] : $this->transliterate;
     }
 
-    public function directoryName(object $object, PropertyMapping $mapping): string
+    public function directoryName(object|array $object, PropertyMapping $mapping): string
     {
         if (empty($this->propertyPath)) {
             throw new \LogicException('The property to use can not be determined. Did you call the configure() method?');

--- a/src/Naming/SubdirDirectoryNamer.php
+++ b/src/Naming/SubdirDirectoryNamer.php
@@ -30,7 +30,7 @@ final class SubdirDirectoryNamer implements DirectoryNamerInterface, Configurabl
         $this->dirs = $options['dirs'];
     }
 
-    public function directoryName(object $object, PropertyMapping $mapping): string
+    public function directoryName(object|array $object, PropertyMapping $mapping): string
     {
         $fileName = $mapping->getFilename($object);
 

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -115,7 +115,7 @@ abstract class AbstractStorage implements StorageInterface
      * @throws \RuntimeException
      * @throws \Vich\UploaderBundle\Exception\NotUploadableException
      */
-    protected function getFilename(object $obj, ?string $fieldName = null, ?string $className = null): array
+    protected function getFilename(object|array $obj, ?string $fieldName = null, ?string $className = null): array
     {
         $mapping = null === $fieldName ?
             $this->factory->fromFirstField($obj, $className) :

--- a/src/Templating/Helper/UploaderHelper.php
+++ b/src/Templating/Helper/UploaderHelper.php
@@ -24,9 +24,9 @@ final class UploaderHelper implements UploaderHelperInterface
      * Gets the public path for the file associated with the
      * object.
      *
-     * @param object      $obj       The object or array
-     * @param string|null $fieldName The field name
-     * @param string|null $className The class name with the uploadable field. Mandatory if $obj is an array
+     * @param object|array $obj       The object or array
+     * @param string|null  $fieldName The field name
+     * @param string|null  $className The class name with the uploadable field. Mandatory if $obj is an array
      *
      * @return string|null The public asset path or null if file not stored
      */

--- a/src/Templating/Helper/UploaderHelper.php
+++ b/src/Templating/Helper/UploaderHelper.php
@@ -24,13 +24,14 @@ final class UploaderHelper implements UploaderHelperInterface
      * Gets the public path for the file associated with the
      * object.
      *
-     * @param object      $obj       The object
+     * @param object      $obj       The object or array
      * @param string|null $fieldName The field name
+     * @param string|null $className The class name with the uploadable field. Mandatory if $obj is an array
      *
      * @return string|null The public asset path or null if file not stored
      */
-    public function asset(object $obj, ?string $fieldName = null): ?string
+    public function asset(object|array $obj, ?string $fieldName = null, ?string $className = null): ?string
     {
-        return $this->storage->resolveUri($obj, $fieldName);
+        return $this->storage->resolveUri($obj, $fieldName, $className);
     }
 }

--- a/src/Templating/Helper/UploaderHelperInterface.php
+++ b/src/Templating/Helper/UploaderHelperInterface.php
@@ -7,9 +7,9 @@ interface UploaderHelperInterface
     /**
      * Gets the public path for the file associated with the object.
      *
-     * @param object      $obj       The object or array
-     * @param string|null $fieldName The field name
-     * @param string|null $className The class name with the uploadable field. Mandatory if $obj is an array
+     * @param object|array $obj       The object or array
+     * @param string|null  $fieldName The field name
+     * @param string|null  $className The class name with the uploadable field. Mandatory if $obj is an array
      *
      * @return string|null The public asset path or null if file not stored
      */

--- a/src/Templating/Helper/UploaderHelperInterface.php
+++ b/src/Templating/Helper/UploaderHelperInterface.php
@@ -7,10 +7,11 @@ interface UploaderHelperInterface
     /**
      * Gets the public path for the file associated with the object.
      *
-     * @param object      $obj       The object
+     * @param object      $obj       The object or array
      * @param string|null $fieldName The field name
+     * @param string|null $className The class name with the uploadable field. Mandatory if $obj is an array
      *
      * @return string|null The public asset path or null if file not stored
      */
-    public function asset(object $obj, ?string $fieldName = null): ?string;
+    public function asset(object|array $obj, ?string $fieldName = null, ?string $className = null): ?string;
 }

--- a/src/Twig/Extension/UploaderExtensionRuntime.php
+++ b/src/Twig/Extension/UploaderExtensionRuntime.php
@@ -17,9 +17,9 @@ final class UploaderExtensionRuntime implements RuntimeExtensionInterface
     /**
      * Gets the public path for the file associated with the uploadable object.
      *
-     * @param object      $object    The object or array
-     * @param string|null $fieldName The field name
-     * @param string|null $className The class name with the uploadable field. Mandatory if $object is an array
+     * @param object|array $object    The object or array
+     * @param string|null  $fieldName The field name
+     * @param string|null  $className The class name with the uploadable field. Mandatory if $object is an array
      *
      * @return string|null The public path or null if file not stored
      */

--- a/src/Twig/Extension/UploaderExtensionRuntime.php
+++ b/src/Twig/Extension/UploaderExtensionRuntime.php
@@ -17,13 +17,14 @@ final class UploaderExtensionRuntime implements RuntimeExtensionInterface
     /**
      * Gets the public path for the file associated with the uploadable object.
      *
-     * @param object      $object    The object
+     * @param object      $object    The object or array
      * @param string|null $fieldName The field name
+     * @param string|null $className The class name with the uploadable field. Mandatory if $object is an array
      *
      * @return string|null The public path or null if file not stored
      */
-    public function asset(object $object, ?string $fieldName = null): ?string
+    public function asset(object|array $object, ?string $fieldName = null, ?string $className = null): ?string
     {
-        return $this->helper->asset($object, $fieldName);
+        return $this->helper->asset($object, $fieldName, $className);
     }
 }

--- a/src/Util/PropertyPathUtils.php
+++ b/src/Util/PropertyPathUtils.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vich\UploaderBundle\Util;
+
+abstract class PropertyPathUtils
+{
+    /**
+     * Fixes a given propertyPath to make it usable both with arrays and
+     * objects.
+     * Ie: if the given object is in fact an array, the property path must
+     * look like [myPath].
+     *
+     * @param object|array $object       The object to inspect
+     * @param string       $propertyPath The property path to fix
+     *
+     * @return string The fixed property path
+     */
+    public static function fixPropertyPath(object|array $object, string $propertyPath): string
+    {
+        if (!\is_array($object)) {
+            return $propertyPath;
+        }
+
+        return '[' === $propertyPath[0] ? $propertyPath : \sprintf('[%s]', $propertyPath);
+    }
+}

--- a/src/Util/PropertyPathUtils.php
+++ b/src/Util/PropertyPathUtils.php
@@ -2,8 +2,12 @@
 
 namespace Vich\UploaderBundle\Util;
 
-abstract class PropertyPathUtils
+final class PropertyPathUtils
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Fixes a given propertyPath to make it usable both with arrays and
      * objects.


### PR DESCRIPTION
Closes #1361.

This PR (re)allows the use of an array instead of an object to resolve a file path. I also went ahead and reintroduced this feature for the twig filter.

I moved the `fixPropertyPath` function to a utils file since it was also needed in the `directoryName` function because of the date property contained in the array. 