### PR TITLE
Explicit that nullable is a necessity

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,6 +97,7 @@ class Product
     #[Vich\UploadableField(mapping: 'products', fileNameProperty: 'imageName', size: 'imageSize')]
     private ?File $imageFile = null;
 
+    // NOTE: be carefull, this field needs to be nullable.
     #[ORM\Column(nullable: true)]
     private ?string $imageName = null;
 


### PR DESCRIPTION
I just experienced this issue. I didn't thinck that "nullable" was REALLY needed, as i was using my own uploading before and set my field as "uniq". Maybe i wont be the only person experiencing it so… i guess it cost nothing to precise it.

more here : https://stackoverflow.com/questions/75861160/symfony-6-vichuploader-cant-update-delete-file/75902101#75902101