### PR TITLE
Enable error bunbbling in the embebbed file field

### DIFF
--- a/src/Form/Type/VichFileType.php
+++ b/src/Form/Type/VichFileType.php
@@ -61,6 +61,7 @@ class VichFileType extends AbstractType
             'label' => $options['label'],
             'attr' => $options['attr'],
             'translation_domain' => $options['translation_domain'],
+            'error_bubbling' => true,
         ]);
 
         $builder->addModelTransformer(new FileTransformer());


### PR DESCRIPTION
Without the `error_bubbling` in the embedded file field, any error from the field doesn't get displayed in the form.

In my case, I get a size limit that is hidden by VichUploader in the form but the field is marked as invalid by Symfony Form component.

I'm using the Symfony backed Bootstrap theme and i also got the same behavior without any theme.

Note: The error appear when the file size is greater than `upload_max_filesize`.

![image](https://user-images.githubusercontent.com/4648342/230141738-f54c309b-53fe-426a-9b79-bacbfe7c7ac7.png)
![image](https://user-images.githubusercontent.com/4648342/230142200-d395c998-5b20-4596-8308-725aa444d478.png)

About my environment:
- Symfony 5.4.18
- PHP 8.1.17
- vich/uploader-bundle 2.1.1