### PR TITLE
Fix deprecation warning on 1.x

### DIFF
--- a/src/Twig/Extension/UploaderExtensionRuntime.php
+++ b/src/Twig/Extension/UploaderExtensionRuntime.php
@@ -31,6 +31,10 @@ final class UploaderExtensionRuntime implements RuntimeExtensionInterface
      */
     public function asset($object, ?string $fieldName = null, ?string $className = null): ?string
     {
+        if (null === $className) {
+            return $this->helper->asset($object, $fieldName);
+        }
+
         // @phpstan-ignore-next-line
         return $this->helper->asset($object, $fieldName, $className);
     }


### PR DESCRIPTION
Symfony will trigger a deprecation warning even when calling `vich_uploader_asset` with a single parameter because UploaderExtensionRuntime::asset passes always 3 parameters.