### PR TITLE
Refactor: Make VichImageType class extensible by removing 'final'

### DIFF
--- a/src/Form/Type/VichImageType.php
+++ b/src/Form/Type/VichImageType.php
@@ -44,7 +44,7 @@ class VichImageType extends VichFileType
             'imagine_pattern' => null,
             'storage_resolve_method' => self::STORAGE_RESOLVE_URI,
             'attr' => [
-                'accept' => 'image/png,image/jpeg,image/gif,image/webp',
+                'accept' => 'image/*',
             ],
         ]);
 

--- a/src/Form/Type/VichImageType.php
+++ b/src/Form/Type/VichImageType.php
@@ -17,7 +17,7 @@ use Vich\UploaderBundle\Storage\StorageInterface;
  * @author Konstantin Myakshin <koc-dp@yandex.ru>
  * @author Massimiliano Arione <max.arione@gmail.com>
  */
-final class VichImageType extends VichFileType
+class VichImageType extends VichFileType
 {
     public const STORAGE_RESOLVE_URI = 0;
 

--- a/src/Form/Type/VichImageType.php
+++ b/src/Form/Type/VichImageType.php
@@ -43,6 +43,9 @@ class VichImageType extends VichFileType
             'image_uri' => true,
             'imagine_pattern' => null,
             'storage_resolve_method' => self::STORAGE_RESOLVE_URI,
+            'attr' => [
+                'accept' => 'image/png,image/jpeg,image/gif,image/webp',
+            ],
         ]);
 
         $resolver->setAllowedValues(


### PR DESCRIPTION
This commit updates the VichImageType class by removing the 'final' keyword, thereby allowing for extension of the class. This modification maintains consistency with Symfony's practice of non-final form types, enabling developers to extend this form type to add custom functionality or modifications as needed.