### PR TITLE
Allow creating directory subfolders by giving the path in the config

### DIFF
--- a/config/namer.xml
+++ b/config/namer.xml
@@ -22,6 +22,7 @@
         <service id="Vich\UploaderBundle\Naming\CurrentDateTimeDirectoryNamer" public="true">
             <argument type="service" id="property_accessor" on-invalid="null"/>
         </service>
+        <service id="Vich\UploaderBundle\Naming\ConfigurableDirectoryNamer" public="true"/>
         <service id="Vich\UploaderBundle\Naming\SmartUniqueNamer" public="true">
             <argument type="service" id="Vich\UploaderBundle\Util\Transliterator"/>
         </service>
@@ -34,6 +35,7 @@
         <service id="vich_uploader.directory_namer_subdir" alias="Vich\UploaderBundle\Naming\SubdirDirectoryNamer" public="true"/>
         <service id="vich_uploader.namer_directory_property" alias="Vich\UploaderBundle\Naming\PropertyDirectoryNamer" public="true"/>
         <service id="vich_uploader.namer_directory_current_date_time" alias="Vich\UploaderBundle\Naming\CurrentDateTimeDirectoryNamer" public="true"/>
+        <service id="vich_uploader.namer_directory_configurable" alias="Vich\UploaderBundle\Naming\ConfigurableDirectoryNamer" public="true"/>
         <service id="vich_uploader.namer_smart_unique" alias="Vich\UploaderBundle\Naming\SmartUniqueNamer" public="true"/>
         <service id="Vich\UploaderBundle\Util\Transliterator" public="false">
             <argument type="service" id="slugger"/>

--- a/docs/namers.md
+++ b/docs/namers.md
@@ -110,6 +110,7 @@ At the moment there are several available namers:
 * `Vich\UploaderBundle\Naming\SubdirDirectoryNamer`
 * `Vich\UploaderBundle\Naming\PropertyDirectoryNamer`
 * `Vich\UploaderBundle\Naming\CurrentDateTimeDirectoryNamer`
+* `Vich\UploaderBundle\Naming\ConfigurableDirectoryNamer`
 
 **SubdirDirectoryNamer** creates subdirs depending on the file name, i.e. `abcdef.jpg` will be
 stored in a folder `ab`. It is also possible to configure how many chars use per directory name and
@@ -179,6 +180,23 @@ vich_uploader:
                 options:
                     date_time_format: 'Y/d/m' # will create directory "2018/23/09" for current date "2018-09-23"
                     date_time_property: uploadTimestamp # see above example
+```
+
+**ConfigurableDirectoryNamer** creates subdirs which path is given in the directory namer's options.
+
+To use it, you just have to specify the service for the `directory_namer`
+configuration option of your mapping, and **must** set the option `directory_path`:
+
+``` yaml
+vich_uploader:
+    # ...
+    mappings:
+        products:
+            upload_destination: products
+            directory_namer:
+                service: vich_uploader.namer_directory_configurable
+                options:
+                    directory_path: 'folder/subfolder/subsubfolder'
 ```
 
 If no directory namer is configured for a mapping, the bundle will simply use

--- a/src/Naming/ConfigurableDirectoryNamer.php
+++ b/src/Naming/ConfigurableDirectoryNamer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
+/**
+ * Directory namer which can create subfolder which path is given in the directory namer's options.
+ */
+class ConfigurableDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface
+{
+    /** @var string */
+    private $directoryPath = '';
+
+    /**
+     * @param array $options Options for this namer. The following options are accepted:
+     *                       - directory_path: the path of the folders to create
+     */
+    public function configure(array $options): void
+    {
+        if (!isset($options['directory_path'])) {
+            throw new \InvalidArgumentException('Option "directory_path" is missing.');
+        }
+
+        $this->directoryPath = $options['directory_path'];
+    }
+
+    public function directoryName($object, PropertyMapping $mapping): string
+    {
+        return $this->directoryPath;
+    }
+}

--- a/tests/Naming/ConfigurableDirectoryNamerTest.php
+++ b/tests/Naming/ConfigurableDirectoryNamerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Naming;
+
+use Vich\UploaderBundle\Naming\ConfigurableDirectoryNamer;
+use Vich\UploaderBundle\Tests\DummyEntity;
+use Vich\UploaderBundle\Tests\TestCase;
+
+final class ConfigurableDirectoryNamerTest extends TestCase
+{
+    public function testNameReturnsTheRightName(): void
+    {
+        $entity = new DummyEntity();
+        $entity->setFileName('file name');
+        $mapping = $this->getPropertyMappingMock();
+
+        $namer = new ConfigurableDirectoryNamer();
+        $namer->configure(['directory_path' => 'folder/subfolder/subsubfolder']);
+
+        self::assertSame('folder/subfolder/subsubfolder', $namer->directoryName($entity, $mapping));
+    }
+
+    public function testConfigurationFailsIfTheDirectoryPathIsntSpecified(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Option "directory_path" is missing.');
+
+        $namer = new ConfigurableDirectoryNamer();
+
+        $namer->configure(['incorrect' => 'options']);
+    }
+}


### PR DESCRIPTION
---
name: ⚙ Improvement
about: Allowing to set the image subfolders directly from the yaml configuration (without having to rely on property accessor)
---

### Improvement

|    Q        |   A
|------------ | ------
| New Feature | yes
| RFC         | no
| BC Break    | no

#### Summary

This pr is a proposal to add a new directory namer, which allow to configure the image subfolders directly from the yaml configuration.

This would allow to use multiple vich mapping on the same storage, without 
- having to duplicate the storage configuration for each mapping
- be forced to use the PropertyDirectoryNamer, which add a method solely for this purpose

For example, it would allow to do the following: 
```
vich_uploader:
    # ...

    storage: flysystem

    mappings:
        logo:
            uri_prefix: '%app.uploads.uri_prefix%'
            upload_destination: storage.uploads.cdn
            directory_namer:
                service: vich.namer_directory_configurable
                options:
                    directory_path: custom/logos
            namer:
                service: Vich\UploaderBundle\Naming\SmartUniqueNamer

        map:
            uri_prefix: '%app.uploads.uri_prefix%'
            upload_destination: storage.uploads.cdn
            directory_namer:
                service: vich.namer_directory_configurable
                options:
                    directory_path: custom/maps
            namer:
                service: Vich\UploaderBundle\Naming\SmartUniqueNamer

flysystem:
    storages:
        storage.uploads.cdn:
            adapter: 'gcloud'
            visibility: !php/const League\Flysystem\GoogleCloudStorage\PortableVisibilityHandler::NO_PREDEFINED_VISIBILITY
            options:
                client: 'app.uploads_cdn.gcloud_client_service'
                bucket: '%uploads.cdn.gcp.storage.bucket_name%'
                prefix: '%uploads.cdn.gcp.storage.path_prefix%'

```

This would also take care of #1377
