### PR TITLE
Add missing resolveUri method to FlysystemStorage

### DIFF
--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -104,4 +104,24 @@ final class FlysystemStorage extends AbstractStorage
 
         return $this->registry->get($mapping->getUploadDestination());
     }
+
+    public function resolveUri(object|array $obj, ?string $fieldName = null, ?string $className = null): ?string
+	{
+		$path = $this->resolvePath($obj, $fieldName, $className, true);
+
+		if (empty($path)) {
+			return null;
+		}
+
+		$mapping = null === $fieldName ?
+			$this->factory->fromFirstField($obj, $className) :
+			$this->factory->fromField($obj, $fieldName, $className);
+		$fs = $this->getFilesystem($mapping);
+
+		try {
+			return $fs->publicUrl($path);
+		} catch (FilesystemException) {
+			return null;
+		}
+	}
 }

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -121,7 +121,7 @@ final class FlysystemStorage extends AbstractStorage
         try {
             return $fs->publicUrl($path);
         } catch (FilesystemException) {
-            return null;
+            return $mapping->getUriPrefix().'/'.$path;
         }
     }
 }

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -106,22 +106,22 @@ final class FlysystemStorage extends AbstractStorage
     }
 
     public function resolveUri(object|array $obj, ?string $fieldName = null, ?string $className = null): ?string
-	{
-		$path = $this->resolvePath($obj, $fieldName, $className, true);
+    {
+        $path = $this->resolvePath($obj, $fieldName, $className, true);
 
-		if (empty($path)) {
-			return null;
-		}
+        if (empty($path)) {
+            return null;
+        }
 
-		$mapping = null === $fieldName ?
-			$this->factory->fromFirstField($obj, $className) :
-			$this->factory->fromField($obj, $fieldName, $className);
-		$fs = $this->getFilesystem($mapping);
+        $mapping = null === $fieldName ?
+            $this->factory->fromFirstField($obj, $className) :
+            $this->factory->fromField($obj, $fieldName, $className);
+        $fs = $this->getFilesystem($mapping);
 
-		try {
-			return $fs->publicUrl($path);
-		} catch (FilesystemException) {
-			return null;
-		}
-	}
+        try {
+            return $fs->publicUrl($path);
+        } catch (FilesystemException) {
+            return null;
+        }
+    }
 }

--- a/tests/Storage/Flysystem/AbstractFlysystemStorageTest.php
+++ b/tests/Storage/Flysystem/AbstractFlysystemStorageTest.php
@@ -158,4 +158,27 @@ abstract class AbstractFlysystemStorageTest extends StorageTestCase
             ['foo', '/absolute/foo/file.txt', false],
         ];
     }
+
+    public function testResolveUri(): void
+    {
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUriPrefix')
+            ->willReturn('/uploads');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFileName')
+            ->willReturn('file.txt');
+
+        $this->factory
+            ->expects(self::once())
+            ->method('fromField')
+            ->with($this->object, 'file_field')
+            ->willReturn($this->mapping);
+
+        $path = $this->getStorage()->resolveUri($this->object, 'file_field');
+
+        self::assertEquals('/uploads/file.txt', $path);
+    }
 }


### PR DESCRIPTION
It resolves a lot of problems related to Flysystem.

Without this PR, if we are using S3, Cloudflare images or other cloud storage, the public url is not the CDN one but a local url which is incorrect.

For the people who will suggest using `uri_prefix`, as I mentionned here: https://github.com/dustin10/VichUploaderBundle/issues/1434#issuecomment-2041172155
In my case it is impossible to add `uri_prefix` manually, because in Cloudflare, the file name is not at the end, it is something like `https://imagedelivery.net/qsdazd54azd98a4z69d5/image3.jpg/public` the `/public` at the end makes it impossible because it is not just a prefix, we have to do some sprintf etc.

The problem existe since more than 8 years, I think it is time to automatise it with this PR.

I hope that it will be ok for maintainers.

Related:

https://github.com/dustin10/VichUploaderBundle/issues/1418
https://github.com/dustin10/VichUploaderBundle/issues/1434
https://github.com/dustin10/VichUploaderBundle/issues/502
https://github.com/dustin10/VichUploaderBundle/issues/1089
https://github.com/dustin10/VichUploaderBundle/issues/539