### PR TITLE
If the underlying storage fails, emit an event

### DIFF
--- a/docs/events/events.md
+++ b/docs/events/events.md
@@ -5,14 +5,16 @@ the flux of other code, in this case into the flux of VichUploaderBundle.
 
 The following is a list of events you can listen to:
 
-| Event name | Event constant | Trigger point|
-|------------|----------------|--------------|
-|`vich_uploader.pre_upload`|`Events::PRE_UPLOAD`|before a file upload is handled|
-|`vich_uploader.post_upload`|`Events::POST_UPLOAD`|right after a file upload is handled|
-|`vich_uploader.pre_inject`|`Events::PRE_INJECT`|before a file is injected into an entity|
-|`vich_uploader.post_inject`|`Events::POST_INJECT`|after a file is injected into an entity|
-|`vich_uploader.pre_remove`|`Events::PRE_REMOVE`|before a file is removed|
-|`vich_uploader.post_remove`|`Events::POST_REMOVE`|after a file is removed|
+| Event name                   | Event constant         | Trigger point                            |
+|------------------------------|------------------------|------------------------------------------|
+| `vich_uploader.pre_upload`   | `Events::PRE_UPLOAD`   | before a file upload is handled          |
+| `vich_uploader.post_upload`  | `Events::POST_UPLOAD`  | right after a file upload is handled     |
+| `vich_uploader.pre_inject`   | `Events::PRE_INJECT`   | before a file is injected into an entity |
+| `vich_uploader.post_inject`  | `Events::POST_INJECT`  | after a file is injected into an entity  |
+| `vich_uploader.pre_remove`   | `Events::PRE_REMOVE`   | before a file is removed                 |
+| `vich_uploader.post_remove`  | `Events::POST_REMOVE`  | after a file is removed                  |
+| `vich_uploader.upload_error` | `Events::UPLOAD_ERROR` | If file upload failed.                   |
+| `vich_uploader.remove_error` | `Events::REMOVE_ERROR` | If file remove failed.                   |
 
 The `vich_uploader.pre_remove` event is cancelable, that means that the actual remove request will not take place,
 and you have to take action.
@@ -49,6 +51,44 @@ services:
     AppBundle\EventListener\FooListener:
         tags:
             - { name: kernel.event_listener, event: vich_uploader.pre_upload }
+```
+
+## Error events
+
+The `UPLOAD_ERROR` event happens when writing a file fails, and before an exception is thrown.
+
+If an error occurs while removing a file, then the `REMOVE_ERROR` event gets fired. Failures in removing
+files do not trigger any exceptions unless you choose to throw an error in the event handler for the `REMOVE_ERROR`
+event.
+
+You can use the event to throw an error when the error occurs:
+
+```php
+<?php
+
+namespace App\EventListener;
+
+use Vich\UploaderBundle\Event\ErrorEvent;use Vich\UploaderBundle\Event\Event;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Vich\UploaderBundle\Event\Events;
+
+class RemoveErrorEventListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(){
+            return [
+            Events::REMOVE_ERROR => 'onUploadError',
+        ]       
+    }
+    public function onUploadError(ErrorEvent $errorEvent)
+    {
+        $object = $event->getObject();
+        $mapping = $event->getMapping();
+        $exception = $errorEvent->getThrowable();
+        
+        throw $exception;
+    }
+
+}
 ```
 
 [Return to the index](../index.md)

--- a/src/Event/ErrorEvent.php
+++ b/src/Event/ErrorEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Vich\UploaderBundle\Event;
+
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
+class ErrorEvent extends Event
+{
+    private \Throwable $throwable;
+
+    public function __construct(object $object, PropertyMapping $mapping, \Throwable $throwable)
+    {
+        parent::__construct($object, $mapping);
+        $this->throwable = $throwable;
+    }
+
+    public function getThrowable(): \Throwable
+    {
+        return $this->throwable;
+    }
+}

--- a/src/Event/Events.php
+++ b/src/Event/Events.php
@@ -54,4 +54,14 @@ final class Events
      * @Event("Vich\UploaderBundle\Event\Event")
      */
     public const POST_REMOVE = 'vich_uploader.post_remove';
+
+    /**
+     * Triggered if writing to storage fails.
+     */
+    public const UPLOAD_ERROR = 'vich_uploader.upload_error';
+
+    /**
+     * Triggered if removing the file from storage fails.
+     */
+    public const REMOVE_ERROR = 'vich_uploader.remove_error';
 }

--- a/src/Storage/FileSystemStorage.php
+++ b/src/Storage/FileSystemStorage.php
@@ -41,11 +41,19 @@ final class FileSystemStorage extends AbstractStorage
     {
         $file = $this->doResolvePath($mapping, $dir, $name);
 
-        return \file_exists($file) && \unlink($file);
+        if (!\file_exists($file) || !unlink($file)) {
+            throw new \Exception('Cannot remove file '.$file);
+        }
+
+        return true;
     }
 
-    protected function doResolvePath(PropertyMapping $mapping, ?string $dir, string $name, ?bool $relative = false): string
-    {
+    protected function doResolvePath(
+        PropertyMapping $mapping,
+        ?string $dir,
+        string $name,
+        ?bool $relative = false
+    ): string {
         $path = !empty($dir) ? $dir.\DIRECTORY_SEPARATOR.$name : $name;
 
         if ($relative) {

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -56,13 +56,9 @@ final class FlysystemStorage extends AbstractStorage
         $fs = $this->getFilesystem($mapping);
         $path = !empty($dir) ? $dir.'/'.$name : $name;
 
-        try {
-            $fs->delete($path);
+        $fs->delete($path);
 
-            return true;
-        } catch (FilesystemException) {
-            return false;
-        }
+        return true;
     }
 
     protected function doResolvePath(PropertyMapping $mapping, ?string $dir, string $name, ?bool $relative = false): string

--- a/src/Storage/GaufretteStorage.php
+++ b/src/Storage/GaufretteStorage.php
@@ -3,7 +3,6 @@
 namespace Vich\UploaderBundle\Storage;
 
 use Gaufrette\Adapter\MetadataSupporter;
-use Gaufrette\Exception\FileNotFound;
 use Gaufrette\FilesystemInterface;
 use Gaufrette\FilesystemMapInterface;
 use Symfony\Component\HttpFoundation\File\File;
@@ -46,11 +45,7 @@ final class GaufretteStorage extends AbstractStorage
         $filesystem = $this->getFilesystem($mapping);
         $path = !empty($dir) ? $dir.'/'.$name : $name;
 
-        try {
-            return $filesystem->delete($path);
-        } catch (FileNotFound) {
-            return false;
-        }
+        return $filesystem->delete($path);
     }
 
     protected function doResolvePath(PropertyMapping $mapping, ?string $dir, string $name, ?bool $relative = false): string

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -23,6 +23,8 @@ interface StorageInterface
      *
      * @param object          $obj     The object
      * @param PropertyMapping $mapping The mapping representing the field to remove
+     *
+     * @throw \Exception      Throws an exception
      */
     public function remove(object $obj, PropertyMapping $mapping): ?bool;
 

--- a/tests/Storage/FileSystemStorageTest.php
+++ b/tests/Storage/FileSystemStorageTest.php
@@ -42,6 +42,8 @@ final class FileSystemStorageTest extends StorageTestCase
      */
     public function testRemoveSkipsNonExistingFile(): void
     {
+        $this->expectException(\Exception::class);
+
         $this->mapping
             ->expects(self::once())
             ->method('getUploadDir')

--- a/tests/Storage/GaufretteStorageTest.php
+++ b/tests/Storage/GaufretteStorageTest.php
@@ -172,6 +172,8 @@ class GaufretteStorageTest extends StorageTestCase
      */
     public function testRemoveNotFoundFile(): void
     {
+        // the exception is caught in the UploadHandler.
+        $this->expectException(FileNotFound::class);
         $this->mapping
             ->method('getUploadDestination')
             ->willReturn('filesystemKey');


### PR DESCRIPTION
If the underlying storage fails, we emit an event that can be handled as the user wants.

The behaviour is to throw exceptions on write but not on remove as this seems to be the semantics as they are in the library prior to this change.

It seems to me that the error behavior of remove operations is a bit uneven. If a write fails in the native filesystem it seems to me that that will trigger some kind of error.

Anyhow, I think this keeps BC but introduces an event.

Ref #1449