### PR TITLE
Optionally resolve the uri through flysystem

### DIFF
--- a/config/flysystem.xml
+++ b/config/flysystem.xml
@@ -8,6 +8,7 @@
         <service id="vich_uploader.storage.flysystem" class="Vich\UploaderBundle\Storage\FlysystemStorage" public="false">
             <argument type="service" id="vich_uploader.property_mapping_factory" />
             <argument /><!-- Populated by RegisterFlysystemRegistryPass -->
+            <argument>%vich_uploader.use_flysystem_to_resolve_uri%</argument>
         </service>
         <service id="Vich\UploaderBundle\Storage\FlysystemStorage" alias="vich_uploader.storage.flysystem" public="false"/>
     </services>

--- a/docs/storage/flysystem.md
+++ b/docs/storage/flysystem.md
@@ -57,34 +57,14 @@ vich_uploader:
 ### Issues with adapters public url
 
 If you are using certain adapters like S3, Cloudflare, etc., the generated public URL for assets may be incorrect.
-To resolve this, you can create your own
-[custom storage](https://github.com/dustin10/VichUploaderBundle/blob/master/docs/storage/custom.md)
-by duplicating the existing FlysystemStorage and adding this function:
+To resolve this, you can enable `use_flysystem_to_resolve_uri` in the configuration.
 
-```php
-    public function resolveUri(object|array $obj, ?string $fieldName = null, ?string $className = null): ?string
-    {
-        $path = $this->resolvePath($obj, $fieldName, $className, true);
+This setting makes VichUploaderBundle retrieve the public URL from the configured Flysystem storage.
+If Flysystem cannot generate a public URL, the bundle will fall back to default behaviour.
 
-        if (empty($path)) {
-            return null;
-        }
+**Note:**:
 
-        $mapping = null === $fieldName ?
-            $this->factory->fromFirstField($obj, $className) :
-            $this->factory->fromField($obj, $fieldName, $className);
-        $fs = $this->getFilesystem($mapping);
-
-        try {
-            return $fs->publicUrl($path);
-        } catch (FilesystemException) {
-            return $mapping->getUriPrefix().'/'.$path;
-        }
-    }
-```
-
-Be careful with that; if you have existing implementations,
-it can break them. See [there](https://github.com/dustin10/VichUploaderBundle/pull/1441).
+> Retrieving the public URL is only available when using flysystem version 3.6.0 and up.
 
 ## Integrating with [oneup/flysystem-bundle](https://github.com/1up-lab/OneupFlysystemBundle)
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -57,6 +57,7 @@ final class Configuration implements ConfigurationInterface
                         ->thenInvalid('The storage %s is not supported. Please choose one of '.\implode(', ', $this->supportedStorages).' or provide a service name prefixed with "@".')
                     ->end()
                 ->end()
+                ->booleanNode('use_flysystem_to_resolve_uri')->defaultFalse()->end()
             ->scalarNode('twig')->defaultTrue()->info('twig requires templating')->end()
             ->scalarNode('form')->defaultTrue()->end()
             ->end()

--- a/src/DependencyInjection/VichUploaderExtension.php
+++ b/src/DependencyInjection/VichUploaderExtension.php
@@ -39,6 +39,7 @@ final class VichUploaderExtension extends Extension
         // define a few parameters
         $container->setParameter('vich_uploader.default_filename_attribute_suffix', $config['default_filename_attribute_suffix']);
         $container->setParameter('vich_uploader.mappings', $config['mappings']);
+        $container->setParameter('vich_uploader.use_flysystem_to_resolve_uri', $config['use_flysystem_to_resolve_uri']);
 
         if (\str_starts_with((string) $config['storage'], '@')) {
             $container->setAlias('vich_uploader.storage', \substr((string) $config['storage'], 1));

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -23,9 +23,14 @@ final class FlysystemStorage extends AbstractStorage
     protected MountManager|ContainerInterface $registry;
 
     /**
+     * @var bool use flysystem to resolve the uri
+     */
+    protected bool $useFlysystemToResolveUri;
+
+    /**
      * @param MountManager|ContainerInterface|mixed $registry
      */
-    public function __construct(PropertyMappingFactory $factory, $registry)
+    public function __construct(PropertyMappingFactory $factory, $registry, bool $useFlysystemToResolveUri = false)
     {
         parent::__construct($factory);
 
@@ -34,6 +39,7 @@ final class FlysystemStorage extends AbstractStorage
         }
 
         $this->registry = $registry;
+        $this->useFlysystemToResolveUri = $useFlysystemToResolveUri;
     }
 
     protected function doUpload(PropertyMapping $mapping, File $file, ?string $dir, string $name): void
@@ -74,6 +80,30 @@ final class FlysystemStorage extends AbstractStorage
         }
 
         return $path;
+    }
+
+    public function resolveUri(object|array $obj, ?string $fieldName = null, ?string $className = null): ?string
+    {
+        if (! $this->useFlysystemToResolveUri) {
+            return parent::resolveUri($obj, $fieldName, $className);
+        }
+
+        $path = $this->resolvePath($obj, $fieldName, $className, true);
+
+        if (empty($path)) {
+            return null;
+        }
+
+        $mapping = null === $fieldName ?
+            $this->factory->fromFirstField($obj, $className) :
+            $this->factory->fromField($obj, $fieldName, $className);
+        $fs = $this->getFilesystem($mapping);
+
+        try {
+            return $fs->publicUrl($path);
+        } catch (FilesystemException) {
+            return $mapping->getUriPrefix().'/'.$path;
+        }
     }
 
     public function resolveStream(object|array $obj, ?string $fieldName = null, ?string $className = null)

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -84,7 +84,7 @@ final class FlysystemStorage extends AbstractStorage
 
     public function resolveUri(object|array $obj, ?string $fieldName = null, ?string $className = null): ?string
     {
-        if (! $this->useFlysystemToResolveUri) {
+        if (!$this->useFlysystemToResolveUri) {
             return parent::resolveUri($obj, $fieldName, $className);
         }
 


### PR DESCRIPTION
Based on the work of @sovetski in #1441 the PR will allow you to optionally have FlysystemStorage return the public URL of the filesystem instead. Doing it like this makes the new behaviour become opt-in and it does not require a new major version to release.

To enable simply add a configuration variable:
```diff
vich_uploader:
    db_driver: orm
    metadata:
        type: attribute
    storage: 'flysystem'
+   use_flysystem_to_resolve_uri: true
```