### PR TITLE
Fix the aligment of the icon in the symfony profiler

### DIFF
--- a/templates/Collector/icon.svg
+++ b/templates/Collector/icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-cloud-upload" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon-tabler-cloud-upload" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
     <path stroke="none" d="M0 0h24v24H0z" fill="none" />
     <path d="M7 18a4.6 4.4 0 0 1 0 -9a5 4.5 0 0 1 11 2h1a3.5 3.5 0 0 1 0 7h-1" />
     <path d="M9 15l3 -3l3 3" />


### PR DESCRIPTION
This was bothering me :P 

![not_aligned](https://github.com/dustin10/VichUploaderBundle/assets/516028/76a08429-459b-4bf9-9487-c2c0743ad478)

Like symfony's own icons the svg itself should not have the `icon` and `icon-tabler` classes as these are applied in the template (https://github.com/symfony/symfony/tree/7.1/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon).