### PR TITLE
Ability to remove file for ReplacingFile

### DIFF
--- a/src/FileAbstraction/ReplacingFile.php
+++ b/src/FileAbstraction/ReplacingFile.php
@@ -13,12 +13,18 @@ use Symfony\Component\HttpFoundation\File\File;
 class ReplacingFile extends File
 {
     protected bool $removeReplacedFile;
+    protected bool $removeReplacedFileOnError;
 
-    public function __construct(string $path, bool $checkPath = true, bool $removeReplacedFile = false)
-    {
+    public function __construct(
+        string $path,
+        bool $checkPath = true,
+        bool $removeReplacedFile = false,
+        bool $removeReplacedFileOnError = false
+    ) {
         parent::__construct($path, $checkPath);
 
         $this->removeReplacedFile = $removeReplacedFile;
+        $this->removeReplacedFileOnError = $removeReplacedFileOnError;
     }
 
     public function getClientOriginalName(): string
@@ -34,6 +40,18 @@ class ReplacingFile extends File
     public function setRemoveReplacedFile(bool $removeReplacedFile): self
     {
         $this->removeReplacedFile = $removeReplacedFile;
+
+        return $this;
+    }
+
+    public function isRemoveReplacedFileOnError(): bool
+    {
+        return $this->removeReplacedFileOnError;
+    }
+
+    public function setRemoveReplacedFileOnError(bool $removeReplacedFileOnError): self
+    {
+        $this->removeReplacedFileOnError = $removeReplacedFileOnError;
 
         return $this;
     }

--- a/src/FileAbstraction/ReplacingFile.php
+++ b/src/FileAbstraction/ReplacingFile.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Vich\UploaderBundle\FileAbstraction;
 
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * This class can be used to signal that the given file should be "uploaded" into the Vich-abstraction
@@ -13,8 +12,29 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 class ReplacingFile extends File
 {
+    protected bool $removeReplacedFile;
+
+    public function __construct(string $path, bool $checkPath = true, bool $removeReplacedFile = false)
+    {
+        parent::__construct($path, $checkPath);
+
+        $this->removeReplacedFile = $removeReplacedFile;
+    }
+
     public function getClientOriginalName(): string
     {
         return $this->getFilename();
+    }
+
+    public function isRemoveReplacedFile(): bool
+    {
+        return $this->removeReplacedFile;
+    }
+
+    public function setRemoveReplacedFile(bool $removeReplacedFile): self
+    {
+        $this->removeReplacedFile = $removeReplacedFile;
+
+        return $this;
     }
 }

--- a/src/FileAbstraction/ReplacingFile.php
+++ b/src/FileAbstraction/ReplacingFile.php
@@ -12,19 +12,13 @@ use Symfony\Component\HttpFoundation\File\File;
  */
 class ReplacingFile extends File
 {
-    protected bool $removeReplacedFile;
-    protected bool $removeReplacedFileOnError;
-
     public function __construct(
         string $path,
         bool $checkPath = true,
-        bool $removeReplacedFile = false,
-        bool $removeReplacedFileOnError = false
+        private bool $removeReplacedFile = false,
+        private bool $removeReplacedFileOnError = false
     ) {
         parent::__construct($path, $checkPath);
-
-        $this->removeReplacedFile = $removeReplacedFile;
-        $this->removeReplacedFileOnError = $removeReplacedFileOnError;
     }
 
     public function getClientOriginalName(): string

--- a/src/FileAbstraction/ReplacingFile.php
+++ b/src/FileAbstraction/ReplacingFile.php
@@ -15,8 +15,8 @@ class ReplacingFile extends File
     public function __construct(
         string $path,
         bool $checkPath = true,
-        private bool $removeReplacedFile = false,
-        private bool $removeReplacedFileOnError = false
+        private readonly bool $removeReplacedFile = false,
+        private readonly bool $removeReplacedFileOnError = false
     ) {
         parent::__construct($path, $checkPath);
     }
@@ -31,22 +31,8 @@ class ReplacingFile extends File
         return $this->removeReplacedFile;
     }
 
-    public function setRemoveReplacedFile(bool $removeReplacedFile): self
-    {
-        $this->removeReplacedFile = $removeReplacedFile;
-
-        return $this;
-    }
-
     public function isRemoveReplacedFileOnError(): bool
     {
         return $this->removeReplacedFileOnError;
-    }
-
-    public function setRemoveReplacedFileOnError(bool $removeReplacedFileOnError): self
-    {
-        $this->removeReplacedFileOnError = $removeReplacedFileOnError;
-
-        return $this;
     }
 }

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -47,6 +47,12 @@ abstract class AbstractStorage implements StorageInterface
         $dir = $mapping->getUploadDir($obj);
 
         $this->doUpload($mapping, $file, $dir, $name);
+
+        if ($file instanceof ReplacingFile
+            && $file->isRemoveReplacedFile()
+        ) {
+            unlink($file->getPathname());
+        }
     }
 
     abstract protected function doRemove(PropertyMapping $mapping, ?string $dir, string $name): ?bool;

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -46,7 +46,17 @@ abstract class AbstractStorage implements StorageInterface
 
         $dir = $mapping->getUploadDir($obj);
 
-        $this->doUpload($mapping, $file, $dir, $name);
+        try {
+            $this->doUpload($mapping, $file, $dir, $name);
+        } catch (\Exception $e) {
+            if ($file instanceof ReplacingFile
+                && $file->isRemoveReplacedFileOnError()
+            ) {
+                unlink($file->getPathname());
+            }
+
+            throw $e;
+        }
 
         if ($file instanceof ReplacingFile
             && $file->isRemoveReplacedFile()


### PR DESCRIPTION
When I download a file from some source and want to add it to an entity, I use ReplacingFile and it creates the file according to the naming rules, but the downloaded file remains as well. I would like to be able to delete the downloaded file if needed.