### PR TITLE
✅ remove other phpunit deprecations

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
             - name: Require the vendor
-              run: composer require --dev --no-update vincentlanglet/twig-cs-fixer ^2.11
+              run: composer require --dev --no-update vincentlanglet/twig-cs-fixer ^3.1
             - name: Update
               run: composer update --no-interaction --no-progress
             - name: Run
@@ -72,7 +72,7 @@ jobs:
                       with_oneupbundle: false
                       max_deprecations: 5
                     - php: '8.1'
-                      symfony: '6.3.*'
+                      symfony: '6.4.*'
                       dependencies: highest
                       with_imagine: false
                       with_oneupbundle: true
@@ -104,6 +104,8 @@ jobs:
                   php-version: ${{ matrix.php }}
                   extensions: mongodb-stable, pdo_sqlite
             - run: composer require --no-update doctrine/annotations:^1.14
+            - run: |
+                  sed -i 's/"league\/flysystem": "<2.0"/"league\/flysystem": "<2.0",\n"symfony\/http-kernel": "6.4.*,>6.4.8 || 7.1.*,>7.1.1"/' composer.json
             - run: |
                   composer global config --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-interaction --no-progress symfony/flex:^2.2

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/event-dispatcher-contracts": "^3.1",
         "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
-        "symfony/http-kernel": "^5.4 || ^6.0, !=6.4.9 || ^7.0, !=7.1.2",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
         "symfony/mime": "^5.4 || ^6.0 || ^7.0",
         "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
         "symfony/string": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "dg/bypass-finals": "^1.3",
+        "dg/bypass-finals": "^1.8",
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/mongodb-odm": "^2.4",
         "doctrine/orm": "^2.13",

--- a/docker/Dockerfile81
+++ b/docker/Dockerfile81
@@ -38,6 +38,7 @@ WORKDIR /srv/vich-uploader
 COPY . ./
 
 RUN set -eux; \
+    sed -i 's/"league\/flysystem": "<2.0"/"league\/flysystem": "<2.0", "symfony\/http-kernel": "6.4.*,>6.4.8 || 7.1.*,>7.1.1"/' composer.json; \
     composer global config --no-plugins allow-plugins.symfony/flex true; \
     composer global require --no-interaction --no-progress symfony/flex:^2.2; \
     composer config extra.symfony.require "^6.4"; \

--- a/docker/Dockerfile82
+++ b/docker/Dockerfile82
@@ -38,6 +38,7 @@ WORKDIR /srv/vich-uploader
 COPY . ./
 
 RUN set -eux; \
+    sed -i 's/"league\/flysystem": "<2.0"/"league\/flysystem": "<2.0", "symfony\/http-kernel": "6.0.*,>6.4.8 || 7.1.*,>7.1.1"/' composer.json; \
     composer require --no-update doctrine/annotations:^1.14; \
 	composer update --prefer-dist --ignore-platform-reqs; \
 	composer clear-cache

--- a/docker/Dockerfile83
+++ b/docker/Dockerfile83
@@ -38,6 +38,7 @@ WORKDIR /srv/vich-uploader
 COPY . ./
 
 RUN set -eux; \
+    sed -i 's/"league\/flysystem": "<2.0"/"league\/flysystem": "<2.0", "symfony\/http-kernel": "6.0.*,>6.4.8 || 7.1.*,>7.1.1"/' composer.json; \
     composer require --no-update doctrine/annotations:^1.14; \
 	composer update --prefer-dist --ignore-platform-reqs; \
 	composer clear-cache

--- a/tests/Handler/UploadHandlerTest.php
+++ b/tests/Handler/UploadHandlerTest.php
@@ -342,12 +342,10 @@ final class UploadHandlerTest extends TestCase
 
     protected function expectEvents(array $events): void
     {
-        $arguments = \array_map(fn (string $event): array => [$this->validEvent(), $event], $events);
-
         $this->dispatcher
             ->expects(self::exactly(\count($events)))
             ->method('dispatch')
-            ->withConsecutive(...$arguments)
+            ->willReturnCallback(fn (object $event, string $eventName): object => $event)
         ;
     }
 }

--- a/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
+++ b/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
@@ -17,7 +17,7 @@ use Vich\UploaderBundle\Tests\Storage\StorageTestCase;
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-abstract class AbstractFlysystemStorageTest extends StorageTestCase
+abstract class AbstractFlysystemStorageTestCase extends StorageTestCase
 {
     final public const FS_KEY = 'filesystemKey';
 

--- a/tests/Storage/Flysystem/MountManagerFlysystemStorageTest.php
+++ b/tests/Storage/Flysystem/MountManagerFlysystemStorageTest.php
@@ -9,7 +9,7 @@ use League\Flysystem\MountManager;
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-final class MountManagerFlysystemStorageTest extends AbstractFlysystemStorageTest
+final class MountManagerFlysystemStorageTest extends AbstractFlysystemStorageTestCase
 {
     protected function createRegistry(FilesystemOperator $filesystem): MountManager
     {

--- a/tests/Storage/Flysystem/PsrContainerFlysystemStorageTest.php
+++ b/tests/Storage/Flysystem/PsrContainerFlysystemStorageTest.php
@@ -8,7 +8,7 @@ use Psr\Container\ContainerInterface;
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-final class PsrContainerFlysystemStorageTest extends AbstractFlysystemStorageTest
+final class PsrContainerFlysystemStorageTest extends AbstractFlysystemStorageTestCase
 {
     protected function createRegistry(FilesystemOperator $filesystem): ContainerInterface
     {


### PR DESCRIPTION
This PR solves more deprecations of phpunit, so we can try to upgrade phpunit to version 10 (and maybe 11)
Still, the upgrade is likely not possible due to the incompatibility of the symfony bridge.

Moreover, this PR moves the restrictions of the http-kernel versions to test only, so the user can upgrade to more recent versions. In the tests, recent versions cause failures in our kernel-based tests