### PR TITLE
Fix exception handling in FlysystemStorage

### DIFF
--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -12,7 +12,6 @@ use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
 
-
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  * @author Titouan Galopin <galopintitouan@gmail.com>

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -98,7 +98,7 @@ final class FlysystemStorage extends AbstractStorage
 
         try {
             return $fs->publicUrl($path);
-        } catch (FilesystemException | UndefinedMethodError) {
+        } catch (FilesystemException|UndefinedMethodError) {
             return $mapping->getUriPrefix().'/'.$path;
         }
     }

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -7,9 +7,11 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\MountManager;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\File\Exception\CannotWriteFileException;
+use Symfony\Component\ErrorHandler\Error\UndefinedMethodError;
 use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+
 
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
@@ -97,7 +99,7 @@ final class FlysystemStorage extends AbstractStorage
 
         try {
             return $fs->publicUrl($path);
-        } catch (FilesystemException) {
+        } catch (FilesystemException | UndefinedMethodError) {
             return $mapping->getUriPrefix().'/'.$path;
         }
     }

--- a/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
+++ b/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
@@ -220,7 +220,7 @@ abstract class AbstractFlysystemStorageTestCase extends StorageTestCase
             ->expects(self::once())
             ->method('publicUrl')
             ->with('file.txt')
-            ->will($this->throwException(new UndefinedMethodError('Undefined method'), new Error('An error occurred')));
+            ->will($this->throwException(new UndefinedMethodError('Undefined method', new Error('An error occurred'))));
 
         $this->mapping
             ->expects(self::once())

--- a/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
+++ b/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
@@ -12,6 +12,7 @@ use Psr\Container\ContainerInterface;
 use Vich\UploaderBundle\Storage\FlysystemStorage;
 use Vich\UploaderBundle\Storage\StorageInterface;
 use Vich\UploaderBundle\Tests\Storage\StorageTestCase;
+use Symfony\Component\ErrorHandler\Error\UndefinedMethodError;
 
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
@@ -208,5 +209,36 @@ abstract class AbstractFlysystemStorageTestCase extends StorageTestCase
         $path = $this->getStorage()->resolveUri($this->object, 'file_field');
 
         self::assertEquals('example.com/file.txt', $path);
+    }
+
+    public function testResolveUriHandlesUndefinedMethodError(): void
+    {
+        $this->useFlysystemToResolveUri = true;
+
+        $this->filesystem
+            ->expects(self::once())
+            ->method('publicUrl')
+            ->with('file.txt')
+            ->will($this->throwException(new UndefinedMethodError('Undefined method')));
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFileName')
+            ->willReturn('file.txt');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUriPrefix')
+            ->willReturn('/uploads');
+
+        $this->factory
+            ->expects(self::exactly(2))
+            ->method('fromField')
+            ->with($this->object, 'file_field')
+            ->willReturn($this->mapping);
+
+        $path = $this->getStorage()->resolveUri($this->object, 'file_field');
+
+        self::assertEquals('/uploads/file.txt', $path);
     }
 }

--- a/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
+++ b/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Vich\UploaderBundle\Tests\Storage\Flysystem;
 
+use Error;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemOperator;
@@ -219,7 +220,7 @@ abstract class AbstractFlysystemStorageTestCase extends StorageTestCase
             ->expects(self::once())
             ->method('publicUrl')
             ->with('file.txt')
-            ->will($this->throwException(new UndefinedMethodError('Undefined method')));
+            ->will($this->throwException(new UndefinedMethodError('Undefined method'), new Error('An error occurred')));
 
         $this->mapping
             ->expects(self::once())


### PR DESCRIPTION
Related to #1445

Add handling for UndefinedMethodError exception in FlysystemStorage.

* Catch both `FilesystemException` and `UndefinedMethodError` exceptions in the `publicUrl` method of `src/Storage/FlysystemStorage.php`.
* Add a test case in `tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php` to check for `UndefinedMethodError` exception handling in the `resolveUri` method.
* Ensure the test case covers both exceptions to maintain compatibility with different Flysystem versions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dustin10/VichUploaderBundle/issues/1445?shareId=23df5f4d-8611-4598-bf4d-508b46f3196e).