### PR TITLE
Improve public uri

### DIFF
--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -97,7 +97,12 @@ final class FlysystemStorage extends AbstractStorage
         $fs = $this->getFilesystem($mapping);
 
         try {
-            return $fs->publicUrl($path);
+            return $fs->publicUrl($path, [
+                'object' => $obj,
+                'fieldName' => $fieldName,
+                'className' => $className,
+                'mapping' => $mapping,
+            ]);
         } catch (FilesystemException|UndefinedMethodError) {
             return $mapping->getUriPrefix().'/'.$path;
         }

--- a/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
+++ b/tests/Storage/Flysystem/AbstractFlysystemStorageTestCase.php
@@ -190,7 +190,12 @@ abstract class AbstractFlysystemStorageTestCase extends StorageTestCase
         $this->filesystem
             ->expects(self::once())
             ->method('publicUrl')
-            ->with('file.txt')
+            ->with('file.txt', [
+                'object' => $this->object,
+                'fieldName' => 'file_field',
+                'className' => null,
+                'mapping' => $this->mapping,
+            ])
             ->willReturn('example.com/file.txt');
 
         $this->mapping


### PR DESCRIPTION
This PR needs #1486 before to be merged.

When using publicUri with flysystem, it could be necessary to have more context (the object, mapping and fieldName) to generate a public uri