### PR TITLE
Allow symfony 5.4 symfony/event-dispatcher-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/config": "^5.4 || ^6.0 || ^7.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-        "symfony/event-dispatcher-contracts": "^3.1",
+        "symfony/event-dispatcher-contracts": "^2.2 || ^3.1",
         "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
         "symfony/mime": "^5.4 || ^6.0 || ^7.0",


### PR DESCRIPTION
Symfony 5.4 is not compatible with symfony/event-dispatcher-contracts 3.1 and 2.2 should be allowed.

I do not see any > 2.2 specific features used in VichUploaderBundle