### PR TITLE
Support multiple extensions for MIME types in FileExtensionTrait

### DIFF
--- a/src/Naming/Polyfill/FileExtensionTrait.php
+++ b/src/Naming/Polyfill/FileExtensionTrait.php
@@ -10,9 +10,9 @@ trait FileExtensionTrait
 {
     // extensions safe to keep
     private static array $keep = [
-        'txt' => 'csv',
-        'xml' => 'gpx',
-        'xlsx' => 'xlsb',
+        'txt' => ['csv', 'srt', 'vtt'],
+        'xml' => ['gpx', 'kml'],
+        'xlsx' => ['xlsb'],
     ];
 
     /**
@@ -27,7 +27,7 @@ trait FileExtensionTrait
         if ('' !== ($extension = $file->guessExtension())) {
             if (isset(self::$keep[$extension])) {
                 $originalExtension = \pathinfo($file->getClientOriginalName(), \PATHINFO_EXTENSION);
-                if (self::$keep[$extension] === $originalExtension) {
+                if (\in_array($originalExtension, self::$keep[$extension], true)) {
                     return $originalExtension;
                 }
             }

--- a/tests/Naming/SmartUniqidNamerTest.php
+++ b/tests/Naming/SmartUniqidNamerTest.php
@@ -26,7 +26,10 @@ final class SmartUniqidNamerTest extends TestCase
             'dot in filename' => ['filename has . spaces (2).jpg', 'jpg', '/filename-has-spaces-2-[[:xdigit:]]{22}\.jpg/'],
             'file with no extension with null mimetype' => ['lala', null, '/lala-[[:xdigit:]]{22}$/'],
             'csv retains extension even if guessed as txt' => ['lala.csv', 'txt', '/lala-[[:xdigit:]]{22}\.csv/'],
+            'srt retains extension even if guessed as txt' => ['lala.srt', 'txt', '/lala-[[:xdigit:]]{22}\.srt/'],
+            'vtt retains extension even if guessed as txt' => ['lala.vtt', 'txt', '/lala-[[:xdigit:]]{22}\.vtt/'],
             'gpx retains extension even if guessed as xml' => ['baz.gpx', 'xml', '/^baz-[[:xdigit:]]{22}\.gpx$/'],
+            'kml retains extension even if guessed as xml' => ['baz.kml', 'xml', '/^baz-[[:xdigit:]]{22}\.kml$/'],
             'xlsb retains extension even if guessed as xlsx' => ['lala.xlsb', 'xlsx', '/lala-[[:xdigit:]]{22}\.xlsb/'],
         ];
     }


### PR DESCRIPTION
Refactored the extension mapping to use arrays instead of single values, allowing multiple file extensions to share the same MIME type. Added support for srt/vtt subtitle files and kml geospatial data.