### PR TITLE
Add interfaces for easier testing

### DIFF
--- a/config/factory.xml
+++ b/config/factory.xml
@@ -19,5 +19,6 @@
         </service>
 
         <service id="Vich\UploaderBundle\Mapping\PropertyMappingFactory" alias="vich_uploader.property_mapping_factory" public="false"/>
+        <service id="Vich\UploaderBundle\Mapping\PropertyMappingFactoryInterface" alias="vich_uploader.property_mapping_factory" public="false"/>
     </services>
 </container>

--- a/config/handler.xml
+++ b/config/handler.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="vich_uploader.property_mapping_factory" />
             <argument type="service" id="vich_uploader.storage" />
         </service>
+        <service id="Vich\UploaderBundle\Handler\DownloadHandlerInterface" alias="vich_uploader.download_handler"/>
 
         <!-- global handler -->
         <service id="vich_uploader.upload_handler" class="Vich\UploaderBundle\Handler\UploadHandler" public="true">
@@ -16,6 +17,7 @@
             <argument type="service" id="vich_uploader.file_injector" />
             <argument type="service" id="event_dispatcher" />
         </service>
+        <service id="Vich\UploaderBundle\Handler\UploadHandlerInterface" alias="vich_uploader.upload_handler"/>
 
         <service id="Vich\UploaderBundle\Handler\DownloadHandler" alias="vich_uploader.download_handler" public="false"/>
         <service id="Vich\UploaderBundle\Handler\UploadHandler" alias="vich_uploader.upload_handler" public="false"/>

--- a/src/EventListener/Doctrine/BaseListener.php
+++ b/src/EventListener/Doctrine/BaseListener.php
@@ -3,7 +3,7 @@
 namespace Vich\UploaderBundle\EventListener\Doctrine;
 
 use Vich\UploaderBundle\Adapter\AdapterInterface;
-use Vich\UploaderBundle\Handler\UploadHandler;
+use Vich\UploaderBundle\Handler\UploadHandlerInterface;
 use Vich\UploaderBundle\Metadata\MetadataReader;
 use Vich\UploaderBundle\Util\ClassUtils;
 
@@ -18,7 +18,7 @@ abstract class BaseListener
         protected readonly string $mapping,
         protected readonly AdapterInterface $adapter,
         protected readonly MetadataReader $metadata,
-        protected readonly UploadHandler $handler,
+        protected readonly UploadHandlerInterface $handler,
     ) {
     }
 

--- a/src/Form/Type/VichFileType.php
+++ b/src/Form/Type/VichFileType.php
@@ -14,8 +14,8 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Vich\UploaderBundle\Form\DataTransformer\FileTransformer;
-use Vich\UploaderBundle\Handler\UploadHandler;
-use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Handler\UploadHandlerInterface;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactoryInterface;
 use Vich\UploaderBundle\Storage\StorageInterface;
 
 /**
@@ -29,8 +29,8 @@ class VichFileType extends AbstractType
 
     public function __construct(
         protected readonly StorageInterface $storage,
-        protected readonly UploadHandler $handler,
-        protected readonly PropertyMappingFactory $factory,
+        protected readonly UploadHandlerInterface $handler,
+        protected readonly PropertyMappingFactoryInterface $factory,
         ?PropertyAccessorInterface $propertyAccessor = null
     ) {
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();

--- a/src/Form/Type/VichImageType.php
+++ b/src/Form/Type/VichImageType.php
@@ -8,8 +8,8 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Vich\UploaderBundle\Handler\UploadHandler;
-use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Handler\UploadHandlerInterface;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactoryInterface;
 use Vich\UploaderBundle\Storage\StorageInterface;
 
 /**
@@ -27,8 +27,8 @@ class VichImageType extends VichFileType
 
     public function __construct(
         StorageInterface $storage,
-        UploadHandler $handler,
-        PropertyMappingFactory $factory,
+        UploadHandlerInterface $handler,
+        PropertyMappingFactoryInterface $factory,
         ?PropertyAccessorInterface $propertyAccessor = null,
         private readonly ?CacheManager $cacheManager = null
     ) {

--- a/src/Handler/AbstractHandler.php
+++ b/src/Handler/AbstractHandler.php
@@ -4,7 +4,7 @@ namespace Vich\UploaderBundle\Handler;
 
 use Vich\UploaderBundle\Exception\MappingNotFoundException;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
-use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactoryInterface;
 use Vich\UploaderBundle\Storage\StorageInterface;
 
 /**
@@ -13,7 +13,7 @@ use Vich\UploaderBundle\Storage\StorageInterface;
 abstract class AbstractHandler
 {
     public function __construct(
-        protected readonly PropertyMappingFactory $factory,
+        protected readonly PropertyMappingFactoryInterface $factory,
         protected readonly StorageInterface $storage,
     ) {
     }

--- a/src/Handler/DownloadHandler.php
+++ b/src/Handler/DownloadHandler.php
@@ -10,7 +10,7 @@ use Vich\UploaderBundle\Exception\NoFileFoundException;
 /**
  * @author Kévin Gomez <contact@kevingomez.fr>
  */
-final class DownloadHandler extends AbstractHandler
+final class DownloadHandler extends AbstractHandler implements DownloadHandlerInterface
 {
     /**
      * Create a response object that will trigger the download of a file.

--- a/src/Handler/DownloadHandlerInterface.php
+++ b/src/Handler/DownloadHandlerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vich\UploaderBundle\Handler;
+
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+interface DownloadHandlerInterface
+{
+    public function downloadObject(object|array $object, string $field, ?string $className = null, string|bool|null $fileName = null, bool $forceDownload = true): StreamedResponse;
+}

--- a/src/Handler/UploadHandler.php
+++ b/src/Handler/UploadHandler.php
@@ -18,7 +18,7 @@ use Vich\UploaderBundle\Storage\StorageInterface;
  *
  * @author Kévin Gomez <contact@kevingomez.fr>
  */
-final class UploadHandler extends AbstractHandler
+final class UploadHandler extends AbstractHandler implements UploadHandlerInterface
 {
     public function __construct(
         PropertyMappingFactory $factory,

--- a/src/Handler/UploadHandlerInterface.php
+++ b/src/Handler/UploadHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vich\UploaderBundle\Handler;
+
+interface UploadHandlerInterface
+{
+    public function upload(object $obj, string $fieldName): void;
+
+    public function inject(object $obj, string $fieldName): void;
+
+    public function clean(object $obj, string $fieldName): void;
+
+    public function remove(object $obj, string $fieldName): void;
+}

--- a/src/Mapping/PropertyMappingFactory.php
+++ b/src/Mapping/PropertyMappingFactory.php
@@ -15,7 +15,7 @@ use Vich\UploaderBundle\Util\ClassUtils;
  *
  * @internal
  */
-final class PropertyMappingFactory
+final class PropertyMappingFactory implements PropertyMappingFactoryInterface
 {
     public function __construct(
         private readonly MetadataReader $metadata,

--- a/src/Mapping/PropertyMappingFactoryInterface.php
+++ b/src/Mapping/PropertyMappingFactoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vich\UploaderBundle\Mapping;
+
+interface PropertyMappingFactoryInterface
+{
+    public function fromObject(object|array $obj, ?string $className = null, ?string $mappingName = null): array;
+
+    public function fromField(object|array $obj, string $field, ?string $className = null): ?PropertyMapping;
+
+    public function fromFirstField(object|array $obj, ?string $className = null): ?PropertyMapping;
+}

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Vich\UploaderBundle\Exception\MappingNotFoundException;
 use Vich\UploaderBundle\FileAbstraction\ReplacingFile;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
-use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactoryInterface;
 
 /**
  * FileSystemStorage.
@@ -16,7 +16,7 @@ use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
  */
 abstract class AbstractStorage implements StorageInterface
 {
-    public function __construct(protected readonly PropertyMappingFactory $factory)
+    public function __construct(protected readonly PropertyMappingFactoryInterface $factory)
     {
     }
 

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -10,7 +10,7 @@ use Symfony\Component\ErrorHandler\Error\UndefinedMethodError;
 use Symfony\Component\HttpFoundation\File\Exception\CannotWriteFileException;
 use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
-use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactoryInterface;
 
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
@@ -31,7 +31,7 @@ final class FlysystemStorage extends AbstractStorage
     /**
      * @param MountManager|ContainerInterface|mixed $registry
      */
-    public function __construct(PropertyMappingFactory $factory, mixed $registry, bool $useFlysystemToResolveUri = false)
+    public function __construct(PropertyMappingFactoryInterface $factory, mixed $registry, bool $useFlysystemToResolveUri = false)
     {
         parent::__construct($factory);
 

--- a/src/Storage/GaufretteStorage.php
+++ b/src/Storage/GaufretteStorage.php
@@ -7,7 +7,7 @@ use Gaufrette\FilesystemInterface;
 use Gaufrette\FilesystemMapInterface;
 use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
-use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactoryInterface;
 
 /**
  * GaufretteStorage.
@@ -19,11 +19,11 @@ final class GaufretteStorage extends AbstractStorage
     /**
      * Constructs a new instance of FileSystemStorage.
      *
-     * @param PropertyMappingFactory $factory       The factory
-     * @param FilesystemMapInterface $filesystemMap Gaufrette filesystem factory
-     * @param string                 $protocol      Gaufrette stream wrapper protocol
+     * @param PropertyMappingFactoryInterface $factory       The factory
+     * @param FilesystemMapInterface          $filesystemMap Gaufrette filesystem factory
+     * @param string                          $protocol      Gaufrette stream wrapper protocol
      */
-    public function __construct(PropertyMappingFactory $factory, protected FilesystemMapInterface $filesystemMap, protected string $protocol = 'gaufrette')
+    public function __construct(PropertyMappingFactoryInterface $factory, protected FilesystemMapInterface $filesystemMap, protected string $protocol = 'gaufrette')
     {
         parent::__construct($factory);
     }


### PR DESCRIPTION
The DB Finals bypass is not 100% reliable. Providing interfaces instead allows for mocking without additional complex hooks modifying the PHP environment.

This adds interfaces and default service aliases so there are no changes required. 