### PR TITLE
Add namer_keep_extension configuration option

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -16,6 +16,7 @@ return (new PhpCsFixer\Config())
         'native_function_invocation' => ['include' => ['@all']],
         'fopen_flags' => ['b_mode' => true],
         'php_unit_mock_short_will_return' => true,
+        'new_with_parentheses' => true,
     ])
     ->setFinder($finder)
 ;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,8 @@
+# Upgrading from v2.8 to v2.9
+
+* New `namer_keep_extension` configuration option to force namers to preserve original file extension.
+* Custom namers using `namer_keep_extension: true` must implement `ConfigurableInterface`.
+
 # Upgrading from v2.7 to v2.8
 
 * Namers are not public anymore. If you uses a custom namer, you can now make it private.

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -15,15 +15,17 @@ vich_uploader:
         type: attribute
     mappings:
         products:
-            uri_prefix: /uploads    # uri prefix to resource
-            upload_destination: ~   # gaufrette storage fs id, required
-            namer: ~                # specify a file namer service for this entity, null default
-            directory_namer: ~      # specify a directory namer service for this entity, null default
-            delete_on_remove: true  # determine whether to delete file upon removal of entity
-            erase_fields: true      # set to false if you have non-nullable fields for mapping
-            delete_on_update: true  # determine wheter to delete the file upon update of entity
-            inject_on_load: false   # determine whether to inject a File instance upon load
-            db_driver: phpcr        # override the default db driver set above. Allow separate driver per mapping
+            uri_prefix: /uploads         # uri prefix to resource
+            upload_destination: ~        # gaufrette storage fs id, required
+            namer: ~                     # specify a file namer service for this entity, null default
+            directory_namer: ~           # specify a directory namer service for this entity, null default
+            delete_on_remove: true       # determine whether to delete file upon removal of entity
+            erase_fields: true           # set to false if you have non-nullable fields for mapping
+            delete_on_update: true       # determine wheter to delete the file upon update of entity
+            inject_on_load: false        # determine whether to inject a File instance upon load
+            namer_keep_extension: false  # force namers to keep original file extension
+                                         # WARNING: Always validate file extensions when set to true to prevent security risks!
+            db_driver: phpcr             # override the default db driver set above. Allow separate driver per mapping
         # ... more mappings
 ```
 

--- a/docs/namers.md
+++ b/docs/namers.md
@@ -86,6 +86,51 @@ vich_uploader:
             namer: Vich\UploaderBundle\Naming\SmartUniqueNamer # or any other namer listed above
 ```
 
+### Extension Handling
+
+By default, namers use smart extension logic that preserves specific file extensions (like `.csv`, `.gpx`, `.xlsb`)
+even when the MIME type suggests a different extension.  
+You can control this behavior with the `namer_keep_extension` option:
+
+``` yaml
+vich_uploader:
+    # ...
+    mappings:
+        products:
+            upload_destination: products_fs
+            namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
+            namer_keep_extension: true  # Always keep the original file extension
+```
+
+**Important**: The `namer_keep_extension` option only works with namers that implement `ConfigurableInterface`.
+If you try to use this option with a custom namer that doesn't implement this interface, you'll get an exception
+with instructions on how to fix it.
+
+#### Behavior Examples
+
+With `namer_keep_extension: false` (default):
+
+* `document.csv` → `unique-name-123.csv` (preserved because csv is in the safe list)
+* `document.xyz` → `unique-name-123.txt` (changed to guessed extension)
+
+With `namer_keep_extension: true`:
+
+* `document.csv` → `unique-name-123.csv` (preserved)
+* `document.xyz` → `unique-name-123.xyz` (preserved)
+
+#### Security Considerations
+
+> [!WARNING]
+> When using `namer_keep_extension: true`, always validate file extensions to prevent security risks.
+> Files with potentially dangerous extensions (like `.php`, `.exe`, `.sh`, `.bat`) could pose security threats
+> if served directly by the web server.
+
+Consider using additional security measures such as:
+
+* Storing uploaded files outside the web root
+* Serving files through a controller that validates permissions
+* Using Content-Security-Policy headers to prevent script execution
+
 ### How-to
 
 * [Create a custom file namer](file_namer/howto/create_a_custom_file_namer.md)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -130,6 +130,7 @@ final class Configuration implements ConfigurationInterface
                             ->scalarNode('erase_fields')->defaultTrue()->end()
                             ->scalarNode('delete_on_update')->defaultTrue()->end()
                             ->scalarNode('inject_on_load')->defaultFalse()->end()
+                            ->scalarNode('namer_keep_extension')->defaultFalse()->end()
                             ->scalarNode('db_driver')
                                 ->defaultNull()
                                 ->beforeNormalization()

--- a/src/Mapping/PropertyMappingResolver.php
+++ b/src/Mapping/PropertyMappingResolver.php
@@ -48,11 +48,21 @@ final class PropertyMappingResolver implements PropertyMappingResolverInterface
             $namerConfig = $config['namer'];
             $namer = $this->getNamer($mappingData['mapping'], $namerConfig['service']);
 
-            if (!empty($namerConfig['options'])) {
+            $options = $namerConfig['options'] ?? [];
+
+            // Handle namer_keep_extension option
+            if (isset($config['namer_keep_extension']) && $config['namer_keep_extension']) {
+                if (!$namer instanceof ConfigurableInterface) {
+                    throw new \LogicException(\sprintf('Namer %s does not implement ConfigurableInterface but namer_keep_extension option is set to true in mapping "%s". Either make the namer implement ConfigurableInterface or remove the namer_keep_extension option.', $namerConfig['service'], $mappingData['mapping']));
+                }
+                $options['keep_extension'] = $config['namer_keep_extension'];
+            }
+
+            if (!empty($options)) {
                 if (!$namer instanceof ConfigurableInterface) {
                     throw new \LogicException(\sprintf('Namer %s can not receive options as it does not implement ConfigurableInterface.', $namerConfig['service']));
                 }
-                $namer->configure($namerConfig['options']);
+                $namer->configure($options);
             }
 
             $mapping->setNamer($namer);

--- a/src/Naming/Base64Namer.php
+++ b/src/Naming/Base64Namer.php
@@ -19,16 +19,22 @@ class Base64Namer implements NamerInterface, ConfigurableInterface
     /** @var int Length of the resulting name. 10 can be decoded to a 64-bit integer. */
     protected $length = 10;
 
+    protected bool $keepExtension = false;
+
     /**
      * Injects configuration options.
      *
      * @param array $options Options for this namer. The following options are accepted:
      *                       - length: the length of the resulting name.
+     *                       - keep_extension: whether to keep the original extension or use smart logic
      */
     public function configure(array $options): void
     {
         if (isset($options['length'])) {
             $this->length = $options['length'];
+        }
+        if (isset($options['keep_extension'])) {
+            $this->keepExtension = $options['keep_extension'];
         }
     }
 
@@ -41,7 +47,7 @@ class Base64Namer implements NamerInterface, ConfigurableInterface
             $name .= $this->getRandomChar();
         }
 
-        if ($extension = $this->getExtension($file)) {
+        if ($extension = $this->getExtensionWithOption($file, $this->keepExtension)) {
             $name = "$name.$extension";
         }
 

--- a/src/Naming/HashNamer.php
+++ b/src/Naming/HashNamer.php
@@ -17,17 +17,21 @@ class HashNamer implements NamerInterface, ConfigurableInterface
 
     private ?int $length = null;
 
+    private bool $keepExtension = false;
+
     /**
      * @param array $options Options for this namer. The following options are accepted:
      *                       - algorithm: which hash algorithm to use.
      *                       - length: limit file name length
+     *                       - keep_extension: whether to keep the original extension or use smart logic
      */
     public function configure(array $options): void
     {
-        $options = \array_merge(['algorithm' => $this->algorithm, 'length' => $this->length], $options);
+        $options = \array_merge(['algorithm' => $this->algorithm, 'length' => $this->length, 'keep_extension' => $this->keepExtension], $options);
 
         $this->algorithm = $options['algorithm'];
         $this->length = $options['length'];
+        $this->keepExtension = $options['keep_extension'];
     }
 
     public function name(object|array $object, PropertyMapping $mapping): string
@@ -39,7 +43,7 @@ class HashNamer implements NamerInterface, ConfigurableInterface
             $name = \substr($name, 0, $this->length);
         }
 
-        if ($extension = $this->getExtension($file)) {
+        if ($extension = $this->getExtensionWithOption($file, $this->keepExtension)) {
             $name = \sprintf('%s.%s', $name, $extension);
         }
 

--- a/src/Naming/OrignameNamer.php
+++ b/src/Naming/OrignameNamer.php
@@ -20,13 +20,17 @@ final class OrignameNamer implements NamerInterface, ConfigurableInterface
     {
     }
 
+    private bool $keepExtension = false;
+
     /**
      * @param array $options Options for this namer. The following options are accepted:
      *                       - transliterate: whether the filename should be transliterated or not
+     *                       - keep_extension: whether to keep the original extension or use smart logic
      */
     public function configure(array $options): void
     {
         $this->transliterate = isset($options['transliterate']) ? (bool) $options['transliterate'] : $this->transliterate;
+        $this->keepExtension = isset($options['keep_extension']) ? (bool) $options['keep_extension'] : $this->keepExtension;
     }
 
     public function name(object|array $object, PropertyMapping $mapping): string
@@ -39,7 +43,7 @@ final class OrignameNamer implements NamerInterface, ConfigurableInterface
             $name = $this->transliterator->transliterate($name);
         }
 
-        $extension = $this->getExtension($file);
+        $extension = $this->getExtensionWithOption($file, $this->keepExtension);
 
         if (\is_string($extension) && '' !== $extension && !\str_ends_with($name, ".$extension")) {
             $name .= ".$extension";

--- a/src/Naming/Polyfill/FileExtensionTrait.php
+++ b/src/Naming/Polyfill/FileExtensionTrait.php
@@ -20,8 +20,34 @@ trait FileExtensionTrait
      */
     private function getExtension(File $file): ?string
     {
+        return $this->getExtensionWithOption($file, false);
+    }
+
+    /**
+     * Gets the original extension from the file name without any guessing.
+     */
+    private function getOriginalExtension(File $file): ?string
+    {
         if (!$file instanceof UploadedFile && !$file instanceof ReplacingFile) {
             throw new \InvalidArgumentException('Unexpected type for $file: '.$file::class);
+        }
+
+        $originalExtension = \pathinfo($file->getClientOriginalName(), \PATHINFO_EXTENSION);
+
+        return '' !== $originalExtension ? $originalExtension : null;
+    }
+
+    /**
+     * Gets the extension with option to keep original or use smart logic.
+     */
+    private function getExtensionWithOption(File $file, bool $keepOriginal): ?string
+    {
+        if (!$file instanceof UploadedFile && !$file instanceof ReplacingFile) {
+            throw new \InvalidArgumentException('Unexpected type for $file: '.$file::class);
+        }
+
+        if ($keepOriginal) {
+            return $this->getOriginalExtension($file);
         }
 
         if ('' !== ($extension = $file->guessExtension())) {

--- a/src/Naming/PropertyNamer.php
+++ b/src/Naming/PropertyNamer.php
@@ -19,6 +19,8 @@ final class PropertyNamer implements NamerInterface, ConfigurableInterface
 
     private bool $transliterate = false;
 
+    private bool $keepExtension = false;
+
     public function __construct(private readonly Transliterator $transliterator)
     {
     }
@@ -27,6 +29,7 @@ final class PropertyNamer implements NamerInterface, ConfigurableInterface
      * @param array $options Options for this namer. The following options are accepted:
      *                       - property: path to the property used to name the file. Can be either an attribute or a method.
      *                       - transliterate: whether the filename should be transliterated or not
+     *                       - keep_extension: whether to keep the original extension or use smart logic
      *
      * @throws \InvalidArgumentException
      */
@@ -38,6 +41,7 @@ final class PropertyNamer implements NamerInterface, ConfigurableInterface
 
         $this->propertyPath = $options['property'];
         $this->transliterate = isset($options['transliterate']) ? (bool) $options['transliterate'] : $this->transliterate;
+        $this->keepExtension = isset($options['keep_extension']) ? (bool) $options['keep_extension'] : $this->keepExtension;
     }
 
     public function name(object|array $object, PropertyMapping $mapping): string
@@ -63,7 +67,7 @@ final class PropertyNamer implements NamerInterface, ConfigurableInterface
         }
 
         // append the file extension if there is one
-        if ($extension = $this->getExtension($file)) {
+        if ($extension = $this->getExtensionWithOption($file, $this->keepExtension)) {
             $name = \sprintf('%s.%s', $name, $extension);
         }
 

--- a/src/Naming/SlugNamer.php
+++ b/src/Naming/SlugNamer.php
@@ -10,19 +10,26 @@ use Vich\UploaderBundle\Util\Transliterator;
  *
  * @author Massimiliano Arione <garakkio@gmail.com>
  */
-final class SlugNamer implements NamerInterface
+final class SlugNamer implements NamerInterface, ConfigurableInterface
 {
     use Polyfill\FileExtensionTrait;
 
+    private bool $keepExtension = false;
+
     public function __construct(private readonly Transliterator $transliterator, private readonly object $service, private readonly string $method)
     {
+    }
+
+    public function configure(array $options): void
+    {
+        $this->keepExtension = isset($options['keep_extension']) ? (bool) $options['keep_extension'] : $this->keepExtension;
     }
 
     public function name(object|array $object, PropertyMapping $mapping): string
     {
         $file = $mapping->getFile($object);
         $originalName = $file->getClientOriginalName();
-        $extension = $this->getExtension($file);
+        $extension = $this->getExtensionWithOption($file, $this->keepExtension);
         $basename = \substr(\pathinfo($originalName, \PATHINFO_FILENAME), 0, 240);
         $basename = \strtolower($this->transliterator->transliterate($basename));
         $slug = \is_string($extension) && '' !== $extension

--- a/src/Naming/SmartUniqueNamer.php
+++ b/src/Naming/SmartUniqueNamer.php
@@ -11,12 +11,19 @@ use Vich\UploaderBundle\Util\Transliterator;
  *
  * @author Massimiliano Arione <garakkio@gmail.com>
  */
-final class SmartUniqueNamer implements NamerInterface
+final class SmartUniqueNamer implements NamerInterface, ConfigurableInterface
 {
     use Polyfill\FileExtensionTrait;
 
+    private bool $keepExtension = false;
+
     public function __construct(private readonly Transliterator $transliterator)
     {
+    }
+
+    public function configure(array $options): void
+    {
+        $this->keepExtension = isset($options['keep_extension']) ? (bool) $options['keep_extension'] : $this->keepExtension;
     }
 
     public function name(object|array $object, PropertyMapping $mapping): string
@@ -24,7 +31,7 @@ final class SmartUniqueNamer implements NamerInterface
         $file = $mapping->getFile($object);
         $originalName = $file->getClientOriginalName();
         $originalName = $this->transliterator->transliterate($originalName);
-        $originalExtension = $this->getExtension($file);
+        $originalExtension = $this->getExtensionWithOption($file, $this->keepExtension);
         $originalBasename = \pathinfo($originalName, \PATHINFO_FILENAME);
         $uniqId = \str_replace('.', '', \uniqid('-', true));
         $uniqExtension = \is_string($originalExtension) && '' !== $originalExtension

--- a/src/Naming/UniqidNamer.php
+++ b/src/Naming/UniqidNamer.php
@@ -7,15 +7,22 @@ use Vich\UploaderBundle\Mapping\PropertyMapping;
 /**
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-final class UniqidNamer implements NamerInterface
+final class UniqidNamer implements NamerInterface, ConfigurableInterface
 {
     use Polyfill\FileExtensionTrait;
+
+    private bool $keepExtension = false;
+
+    public function configure(array $options): void
+    {
+        $this->keepExtension = isset($options['keep_extension']) ? (bool) $options['keep_extension'] : $this->keepExtension;
+    }
 
     public function name(object|array $object, PropertyMapping $mapping): string
     {
         $file = $mapping->getFile($object);
         $name = \str_replace('.', '', \uniqid('', true));
-        $extension = $this->getExtension($file);
+        $extension = $this->getExtensionWithOption($file, $this->keepExtension);
 
         if (\is_string($extension) && '' !== $extension) {
             $name = \sprintf('%s.%s', $name, $extension);

--- a/tests/DependencyInjection/VichUploaderExtensionTest.php
+++ b/tests/DependencyInjection/VichUploaderExtensionTest.php
@@ -88,6 +88,7 @@ class VichUploaderExtensionTest extends AbstractExtensionTestCase
 
         // the default db_driver is copied into the mapping
         $mappings['foo']['db_driver'] = 'orm';
+        $mappings['foo']['namer_keep_extension'] = false;
 
         $this->assertContainerBuilderHasParameter('vich_uploader.mappings', $mappings);
     }
@@ -106,6 +107,7 @@ class VichUploaderExtensionTest extends AbstractExtensionTestCase
                     'erase_fields' => true,
                     'delete_on_update' => true,
                     'inject_on_load' => true,
+                    'namer_keep_extension' => false,
                     'db_driver' => 'orm',
                 ],
             ],
@@ -147,7 +149,7 @@ class VichUploaderExtensionTest extends AbstractExtensionTestCase
 
         $twigExtension->load([[
             'strict_variables' => true,
-            'exception_controller' => null, // TODO remove after bumping symfony/twig-bundle to ^5.0
+            // 'exception_controller' => null, // TODO remove after bumping symfony/twig-bundle to ^5.0
             'form_themes' => ['@Ololo/trololo.html.twig'],
         ]], $this->container);
         $vichUploaderExtension->load([$this->getMinimalConfiguration()], $this->container);

--- a/tests/Fixtures/App/app/config/config.yml
+++ b/tests/Fixtures/App/app/config/config.yml
@@ -20,7 +20,7 @@ framework:
 twig:
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
-    exception_controller: null
+#    exception_controller: null
 
 # Doctrine Configuration
 doctrine:

--- a/tests/Mapping/PropertyMappingResolverNonConfigurableTest.php
+++ b/tests/Mapping/PropertyMappingResolverNonConfigurableTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Mapping;
+
+use PHPUnit\Framework\TestCase;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Mapping\PropertyMappingResolver;
+use Vich\UploaderBundle\Naming\NamerInterface;
+
+final class PropertyMappingResolverNonConfigurableTest extends TestCase
+{
+    public function testNonConfigurableNamerWithKeepExtensionThrowsException(): void
+    {
+        $nonConfigurableNamer = new class() implements NamerInterface {
+            public function name(object|array $object, PropertyMapping $mapping): string
+            {
+                return 'non_configurable_name.txt';
+            }
+        };
+
+        $resolver = new PropertyMappingResolver(
+            ['non_configurable_namer' => $nonConfigurableNamer],
+            [],
+            [
+                'test_mapping' => [
+                    'upload_destination' => '/tmp',
+                    'uri_prefix' => '/',
+                    'namer' => ['service' => 'non_configurable_namer', 'options' => []],
+                    'directory_namer' => ['service' => null, 'options' => null],
+                    'delete_on_remove' => true,
+                    'erase_fields' => true,
+                    'delete_on_update' => true,
+                    'inject_on_load' => false,
+                    'namer_keep_extension' => true, // <-- This should throw an exception
+                    'db_driver' => 'orm',
+                ],
+            ]
+        );
+
+        $object = new \stdClass();
+        $mappingData = [
+            'mapping' => 'test_mapping',
+            'propertyName' => 'file',
+        ];
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Namer non_configurable_namer does not implement ConfigurableInterface but namer_keep_extension option is set to true in mapping "test_mapping"');
+
+        $resolver->resolve($object, 'file', $mappingData);
+    }
+
+    public function testNonConfigurableNamerWithKeepExtensionFalseWorksNormally(): void
+    {
+        $nonConfigurableNamer = new class() implements NamerInterface {
+            public function name(object|array $object, PropertyMapping $mapping): string
+            {
+                return 'non_configurable_name.txt';
+            }
+        };
+
+        $resolver = new PropertyMappingResolver(
+            ['non_configurable_namer' => $nonConfigurableNamer],
+            [],
+            [
+                'test_mapping' => [
+                    'upload_destination' => '/tmp',
+                    'uri_prefix' => '/',
+                    'namer' => ['service' => 'non_configurable_namer', 'options' => []],
+                    'directory_namer' => ['service' => null, 'options' => null],
+                    'delete_on_remove' => true,
+                    'erase_fields' => true,
+                    'delete_on_update' => true,
+                    'inject_on_load' => false,
+                    'namer_keep_extension' => false, // <-- This should work fine
+                    'db_driver' => 'orm',
+                ],
+            ]
+        );
+
+        $object = new \stdClass();
+        $mappingData = [
+            'mapping' => 'test_mapping',
+            'propertyName' => 'file',
+        ];
+
+        $mapping = $resolver->resolve($object, 'file', $mappingData);
+
+        self::assertInstanceOf(PropertyMapping::class, $mapping);
+        self::assertTrue($mapping->hasNamer());
+    }
+}

--- a/tests/Naming/Fixtures/SimpleNamer.php
+++ b/tests/Naming/Fixtures/SimpleNamer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Naming\Fixtures;
+
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Naming\NamerInterface;
+
+/**
+ * Simple namer that doesn't implement ConfigurableInterface.
+ * This simulates what most custom namers in user applications look like.
+ */
+class SimpleNamer implements NamerInterface
+{
+    use \Vich\UploaderBundle\Naming\Polyfill\FileExtensionTrait;
+
+    public function name(object|array $object, PropertyMapping $mapping): string
+    {
+        $file = $mapping->getFile($object);
+        $originalName = $file->getClientOriginalName();
+        $basename = \pathinfo($originalName, \PATHINFO_FILENAME);
+        $extension = $this->getExtension($file);
+
+        return 'simple_'.$basename.($extension ? '.'.$extension : '');
+    }
+}

--- a/tests/Naming/NonConfigurableNamerTest.php
+++ b/tests/Naming/NonConfigurableNamerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Naming;
+
+use Vich\UploaderBundle\Tests\Naming\Fixtures\SimpleNamer;
+use Vich\UploaderBundle\Tests\TestCase;
+
+final class NonConfigurableNamerTest extends TestCase
+{
+    public function testNonConfigurableNamerIgnoresKeepExtensionOption(): void
+    {
+        $namer = new SimpleNamer();
+        $file = $this->getUploadedFileMock();
+        $file
+            ->method('getClientOriginalName')
+            ->willReturn('test.xyz')
+        ;
+        $file
+            ->method('guessExtension')
+            ->willReturn('txt')
+        ;
+
+        $entity = new \stdClass();
+        $mapping = $this->getPropertyMappingMock();
+        $mapping->expects(self::once())
+            ->method('getFile')
+            ->with($entity)
+            ->willReturn($file)
+        ;
+
+        $result = $namer->name($entity, $mapping);
+
+        self::assertEquals('simple_test.txt', $result);
+    }
+}


### PR DESCRIPTION
Adds the `namer_keep_extension` configuration option as [suggested in #1479](https://github.com/dustin10/VichUploaderBundle/issues/1479#issuecomment-2538046709) to control file extension handling behavior in namers.

When `true`, namers preserve the original file extension; when `false` (default), they use smart extension logic. Only namers implementing `ConfigurableInterface` support this option.

This provides users flexibility while maintaining the CWE-434 security improvements from #1468 as the default behavior.

Are you comfortable including this feature given it allows users to opt back into preserving original file extensions?