### PR TITLE
Add cleanup command to remove orphaned uploaded files

### DIFF
--- a/config/command.xml
+++ b/config/command.xml
@@ -21,6 +21,15 @@
             <tag name="console.command" command="vich:mapping:list-classes" />
         </service>
 
+        <service id="vich_uploader.command.cleanup" class="Vich\UploaderBundle\Command\CleanupCommand" public="false">
+            <argument type="service" id="vich_uploader.storage" />
+            <argument type="service" id="vich_uploader.property_mapping_factory" />
+            <argument type="service" id="vich_uploader.metadata_reader" />
+            <argument>[]</argument><!-- manager registries, filled by compiler pass -->
+            <argument>%vich_uploader.mappings%</argument>
+            <tag name="console.command" command="vich:cleanup" />
+        </service>
+
     </services>
 
 </container>

--- a/docs/command/cleanup.md
+++ b/docs/command/cleanup.md
@@ -1,0 +1,80 @@
+# Cleanup Command
+
+Removes orphaned files from storage that are no longer referenced in the database.
+
+This command is useful when files have been deleted from the database (e.g., through
+foreign key cascades or direct database operations) but the physical files remain in
+storage.
+
+## ⚠️ Safety & Limitations
+
+**BEFORE RUNNING THIS COMMAND:**
+
+- **ALWAYS BACKUP YOUR STORAGE—**file deletions are permanent and cannot be rolled
+  back. There is no undo.
+- **TEST WITH `--dry-run` FIRST** - always preview what will be deleted before running
+  the actual clean-up.
+
+**Built-in safety:**
+
+- Files younger than `--min-age` (default: 60 minutes) are never deleted to prevent race
+  conditions with concurrent uploads
+- Interactive mode requires explicit "yes" confirmation before deleting
+
+**Limitations:**
+
+- Requires repositories that support `createQueryBuilder()`. Custom repositories without
+  this method will be skipped with a warning
+- For remote storage backends (S3, Azure, etc.), file timestamps may not be available
+  and `--min-age` protection may not work correctly
+- Scripts and CI/CD must explicitly use `--force` or `--dry-run` (interactive mode is
+  not available in non-interactive environments)
+
+## Basic usage
+
+```bash
+# Preview what would be deleted
+php bin/console vich:cleanup --dry-run
+
+# Interactive mode (asks for confirmation)
+php bin/console vich:cleanup
+
+# Non-interactive mode for scripts/CI-CD
+php bin/console vich:cleanup --force
+```
+
+## Options
+
+- `--dry-run`: Preview which files would be deleted without actually deleting them
+- `--force`: Skip confirmation prompt (required for non-interactive execution)
+- `--mapping=MAPPING` (`-m`): Process only a specific mapping instead of all mappings
+- `--batch-size=SIZE` (`-b`): Number of entities to process per batch (default: 1000,
+  max: 10000)
+- `--min-age=MINUTES`: Minimum age in minutes for files to be considered orphaned
+  (default: 60 minutes)
+- `--verbose` (`-v`): Show detailed progress information including list of all orphaned
+  files
+
+## Common examples
+
+```bash
+# Preview cleanup for a specific mapping
+php bin/console vich:cleanup --mapping=product_image --dry-run
+
+# Run cleanup for a specific mapping
+php bin/console vich:cleanup --mapping=product_image --force
+
+# Extra safety: only delete files older than 2 hours
+php bin/console vich:cleanup --min-age=120 --force
+
+# Verbose output with file details
+php bin/console vich:cleanup --dry-run -v
+
+# Memory-constrained environments
+php bin/console vich:cleanup --batch-size=500 --force
+
+# Immediate cleanup (USE WITH CAUTION - may delete files being uploaded)
+php bin/console vich:cleanup --min-age=0 --force
+```
+
+[Return to commands overview](../commands.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,7 +2,7 @@
 
 ## Debug class
 
-Show entity file mapping metadata for class.
+Show entity file mapping metadata for a class.
 
 ```bash
 php bin/console vich:mapping:debug-class App\\Entity\\Foo
@@ -23,5 +23,16 @@ Searches for uploadable classes.
 ```bash
 php bin/console vich:mapping:list-classes
 ```
+
+## Cleanup orphaned files
+
+Removes orphaned files from storage that are no longer referenced in the database.
+
+```bash
+php bin/console vich:cleanup --dry-run
+```
+
+For detailed documentation, options, examples, and safety considerations, see the
+[cleanup command documentation](command/cleanup.md).
 
 [Return to the index](index.md)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,3 +96,9 @@ parameters:
 			count: 4
 			path: tests/TestCase.php
 
+		-
+			message: '#^Return type of call to method PHPUnit\\Framework\\TestCase\:\:createMock\(\) contains unresolvable type\.$#'
+			identifier: method.unresolvableReturnType
+			count: 17
+			path: tests/Command/CleanupCommandTest.php
+

--- a/src/Command/CleanupCommand.php
+++ b/src/Command/CleanupCommand.php
@@ -1,0 +1,400 @@
+<?php
+
+namespace Vich\UploaderBundle\Command;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Metadata\MetadataReader;
+use Vich\UploaderBundle\Storage\StorageInterface;
+
+#[AsCommand(name: 'vich:cleanup', description: 'Remove orphaned files from storage')]
+final class CleanupCommand extends Command
+{
+    public const DEFAULT_MIN_AGE_MINUTES = 60;
+    public const DEFAULT_BATCH_SIZE = 1000;
+    public const MAX_BATCH_SIZE = 10000;
+
+    /**
+     * @param ManagerRegistry[] $managerRegistries
+     */
+    public function __construct(
+        private readonly StorageInterface $storage,
+        private readonly PropertyMappingFactory $mappingFactory,
+        private readonly MetadataReader $metadataReader,
+        private readonly array $managerRegistries,
+        private readonly array $mappings
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show what would be deleted without actually deleting')
+            ->addOption('batch-size', 'b', InputOption::VALUE_REQUIRED, 'Batch size for processing entities', self::DEFAULT_BATCH_SIZE)
+            ->addOption('mapping', 'm', InputOption::VALUE_REQUIRED, 'Process only specific mapping')
+            ->addOption('min-age', null, InputOption::VALUE_REQUIRED, 'Minimum age in minutes for files to be considered orphaned (prevents race conditions)', self::DEFAULT_MIN_AGE_MINUTES)
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force deletion without confirmation (required for non-interactive execution)')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = $input->getOption('dry-run');
+        $batchSize = (int) $input->getOption('batch-size');
+        $requestedMapping = $input->getOption('mapping');
+        $minAgeMinutes = (int) $input->getOption('min-age');
+        $force = $input->getOption('force');
+
+        // Validate batch size
+        if ($batchSize < 1 || $batchSize > self::MAX_BATCH_SIZE) {
+            $io->error(\sprintf('Batch size must be between 1 and %d, got: %d', self::MAX_BATCH_SIZE, $batchSize));
+
+            return self::FAILURE;
+        }
+
+        // Validate min-age
+        if ($minAgeMinutes < 0) {
+            $io->error(\sprintf('Minimum age must be non-negative, got: %d minutes', $minAgeMinutes));
+
+            return self::FAILURE;
+        }
+
+        // Calculate cutoff timestamp for file age
+        $cutoffTimestamp = \time() - ($minAgeMinutes * 60);
+
+        if ($dryRun) {
+            $io->note('Running in dry-run mode. No files will be deleted.');
+        } elseif (!$force && $input->isInteractive()) {
+            $io->warning('This command will permanently delete orphaned files from storage.');
+            $io->note(\sprintf('Files must be older than %d minutes to be considered orphaned.', $minAgeMinutes));
+
+            if (!$io->confirm('Do you want to continue?', false)) {
+                $io->info('Operation cancelled.');
+
+                return self::SUCCESS;
+            }
+        } elseif (!$force) {
+            $io->error('The --force flag is required for non-interactive deletion. Use --dry-run to preview files that would be deleted.');
+
+            return self::FAILURE;
+        }
+
+        // Validate mapping if specified
+        if ($requestedMapping && !isset($this->mappings[$requestedMapping])) {
+            $io->error(\sprintf('Mapping "%s" does not exist.', $requestedMapping));
+
+            return self::FAILURE;
+        }
+
+        // Get all uploadable classes
+        $uploadableClasses = $this->metadataReader->getUploadableClasses();
+
+        if (empty($uploadableClasses)) {
+            $io->warning('No uploadable classes found.');
+
+            return self::SUCCESS;
+        }
+
+        $io->info(\sprintf('Found %d uploadable class(es).', \count($uploadableClasses)));
+
+        // Process each mapping
+        $mappingsToProcess = $requestedMapping ? [$requestedMapping] : \array_keys($this->mappings);
+
+        $totalDeleted = 0;
+
+        foreach ($mappingsToProcess as $mappingName) {
+            $io->section(\sprintf('Processing mapping: %s', $mappingName));
+
+            $deleted = $this->processMapping($mappingName, $uploadableClasses, $batchSize, $dryRun, $cutoffTimestamp, $input, $io);
+            $totalDeleted += $deleted;
+
+            $io->success(\sprintf(
+                'Processed mapping "%s": %d orphaned file(s) %s.',
+                $mappingName,
+                $deleted,
+                $dryRun ? 'found' : 'deleted'
+            ));
+        }
+
+        $io->success(\sprintf(
+            'Total: %d orphaned file(s) %s.',
+            $totalDeleted,
+            $dryRun ? 'found' : 'deleted'
+        ));
+
+        return self::SUCCESS;
+    }
+
+    private function processMapping(
+        string $mappingName,
+        array $uploadableClasses,
+        int $batchSize,
+        bool $dryRun,
+        int $cutoffTimestamp,
+        InputInterface $input,
+        SymfonyStyle $io
+    ): int {
+        // Collect all file paths referenced in the database
+        $referencedFiles = [];
+
+        foreach ($uploadableClasses as $className) {
+            $fields = $this->metadataReader->getUploadableFields($className, $mappingName);
+
+            if (empty($fields)) {
+                continue;
+            }
+
+            $io->text(\sprintf('Scanning entities: %s', $className));
+
+            // Get all objects for this class
+            $objectManager = $this->getManagerForClass($className);
+
+            if (null === $objectManager) {
+                $io->warning(\sprintf('No object manager found for class "%s". Skipping.', $className));
+                continue;
+            }
+
+            /** @var class-string $className */
+            $repository = $objectManager->getRepository($className);
+
+            // Check if repository has createQueryBuilder method
+            if (!\method_exists($repository, 'createQueryBuilder')) {
+                $io->warning(\sprintf('Repository for class "%s" does not support query builder. Skipping.', $className));
+                continue;
+            }
+
+            $qb = $repository->createQueryBuilder('e');
+
+            // Get total count
+            $totalCount = (int) (clone $qb)
+                ->select('COUNT(e)')
+                ->getQuery()
+                ->getSingleScalarResult();
+
+            if (0 === $totalCount) {
+                $io->text('No entities found.');
+                continue;
+            }
+
+            // Only show the progress bar in interactive mode
+            $progressBar = null;
+            if ($input->isInteractive()) {
+                $progressBar = new ProgressBar($io, $totalCount);
+                $progressBar->setFormat('verbose');
+                $progressBar->start();
+            } else {
+                $io->text(\sprintf('Processing %d entities...', $totalCount));
+            }
+
+            // Process in batches
+            $offset = 0;
+
+            while ($offset < $totalCount) {
+                $entities = $qb
+                    ->setFirstResult($offset)
+                    ->setMaxResults($batchSize)
+                    ->getQuery()
+                    ->getResult();
+
+                foreach ($entities as $entity) {
+                    foreach ($fields as $fieldName => $field) {
+                        \assert(\is_string($fieldName));
+                        $mapping = $this->mappingFactory->fromField($entity, $fieldName);
+
+                        if (null === $mapping || $mapping->getMappingName() !== $mappingName) {
+                            continue;
+                        }
+
+                        $fileName = $mapping->getFileName($entity);
+
+                        if (!empty($fileName)) {
+                            // Get the relative path
+                            $uploadDir = $mapping->getUploadDir($entity);
+                            $relativePath = (\is_string($uploadDir) && '' !== $uploadDir)
+                                ? $uploadDir.'/'.$fileName
+                                : $fileName;
+
+                            // Normalise path separators
+                            $relativePath = \str_replace('\\', '/', $relativePath);
+
+                            $referencedFiles[$relativePath] = true;
+                        }
+                    }
+
+                    if (null !== $progressBar) {
+                        $progressBar->advance();
+                    }
+                }
+
+                // Clear object manager to free memory
+                /* @var \Doctrine\Persistence\ObjectManager $objectManager */
+                $objectManager->clear();
+
+                $offset += $batchSize;
+            }
+
+            if (null !== $progressBar) {
+                $progressBar->finish();
+                $io->newLine(2);
+            } else {
+                $io->text('Entity scanning completed.');
+            }
+        }
+
+        $io->text(\sprintf('Found %d referenced file(s) in database.', \count($referencedFiles)));
+
+        // Get a sample mapping to list files
+        $sampleClassName = null;
+        $sampleField = null;
+
+        foreach ($uploadableClasses as $className) {
+            $fields = $this->metadataReader->getUploadableFields($className, $mappingName);
+
+            if (!empty($fields)) {
+                $sampleClassName = $className;
+                $sampleField = \array_key_first($fields);
+                break;
+            }
+        }
+
+        if (null === $sampleClassName || null === $sampleField) {
+            $io->warning('Could not find any uploadable field for this mapping.');
+
+            return 0;
+        }
+
+        // Create a fake object to get the mapping
+        try {
+            $reflectionClass = new \ReflectionClass($sampleClassName);
+            $sampleObject = $reflectionClass->newInstanceWithoutConstructor();
+            \assert(\is_string($sampleField));
+            $mapping = $this->mappingFactory->fromField($sampleObject, $sampleField);
+        } catch (\Exception $e) {
+            $io->error(\sprintf('Could not create instance of class "%s": %s', $sampleClassName, $e->getMessage()));
+
+            return 0;
+        }
+
+        if (null === $mapping) {
+            $io->error('Could not create mapping for sample field.');
+
+            return 0;
+        }
+
+        // List all files in storage
+        $io->text('Scanning storage for files...');
+
+        $storageFiles = [];
+        $fileCount = 0;
+        $skippedCount = 0;
+
+        foreach ($this->storage->listFiles($mapping) as $storedFile) {
+            // Apply min-age filtering if timestamp is available
+            // Skip files that are too young (lastModifiedAt > cutoffTimestamp means more recent)
+            if (null !== $storedFile->lastModifiedAt && $storedFile->lastModifiedAt > $cutoffTimestamp) {
+                // File is too young, skip it
+                ++$skippedCount;
+                continue;
+            }
+
+            $storageFiles[$storedFile->path] = true;
+            ++$fileCount;
+
+            // Show progress every 1000 files
+            if (0 === $fileCount % 1000) {
+                if ($io->isVerbose()) {
+                    $io->text(\sprintf('Scanned %d files...', $fileCount));
+                }
+            }
+        }
+
+        if ($skippedCount > 0) {
+            $io->text(\sprintf('Skipped %d file(s) younger than cutoff age.', $skippedCount));
+        }
+
+        $io->text(\sprintf('Found %d file(s) in storage (matching age criteria).', $fileCount));
+
+        // Find orphaned files
+        $orphanedFiles = \array_diff_key($storageFiles, $referencedFiles);
+
+        $io->text(\sprintf('Found %d orphaned file(s).', \count($orphanedFiles)));
+
+        if (empty($orphanedFiles)) {
+            return 0;
+        }
+
+        // Delete orphaned files
+        $deleted = 0;
+
+        if ($io->isVerbose()) {
+            $io->text('Orphaned files:');
+        }
+
+        foreach (\array_keys($orphanedFiles) as $orphanedFile) {
+            if ($io->isVerbose()) {
+                $io->text(\sprintf('  - %s', $orphanedFile));
+            }
+
+            if (!$dryRun) {
+                try {
+                    // Parse directory and filename from path
+                    $lastSlashPos = \strrpos($orphanedFile, '/');
+
+                    if (false !== $lastSlashPos) {
+                        $dir = \substr($orphanedFile, 0, $lastSlashPos);
+                        $fileName = \substr($orphanedFile, $lastSlashPos + 1);
+                    } else {
+                        $dir = '';
+                        $fileName = $orphanedFile;
+                    }
+
+                    // Create a temporary object to use for deletion
+                    // Try to use the constructor if it has no required parameters, otherwise skip it
+                    $constructor = $reflectionClass->getConstructor();
+                    if (null === $constructor || 0 === $constructor->getNumberOfRequiredParameters()) {
+                        $tempObject = $reflectionClass->newInstance();
+                    } else {
+                        $tempObject = $reflectionClass->newInstanceWithoutConstructor();
+                    }
+                    $mapping->setFileName($tempObject, $fileName);
+
+                    // Pass directory explicitly to bypass DirectoryNamer
+                    // This works even when directory namers are configured, since the directory
+                    // is already known from the file path on disk
+                    $this->storage->remove($tempObject, $mapping, $dir);
+                    ++$deleted;
+                } catch (\Exception $e) {
+                    $io->error(\sprintf('Failed to delete file "%s": %s', $orphanedFile, $e->getMessage()));
+                }
+            } else {
+                ++$deleted;
+            }
+        }
+
+        return $deleted;
+    }
+
+    private function getManagerForClass(string $className): ?ObjectManager
+    {
+        foreach ($this->managerRegistries as $managerRegistry) {
+            foreach ($managerRegistry->getManagers() as $manager) {
+                /** @var class-string $className */
+                if (!$manager->getMetadataFactory()->isTransient($className)) {
+                    return $manager;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/DependencyInjection/Compiler/RegisterCleanupCommandPass.php
+++ b/src/DependencyInjection/Compiler/RegisterCleanupCommandPass.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Vich\UploaderBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @internal
+ */
+final class RegisterCleanupCommandPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('vich_uploader.command.cleanup')) {
+            return;
+        }
+
+        $managers = [];
+        if ($container->hasDefinition('doctrine_mongodb')) {
+            $managers[] = new Reference('doctrine_mongodb');
+        }
+        if ($container->hasDefinition('doctrine')) {
+            $managers[] = new Reference('doctrine');
+        }
+        if ($container->hasDefinition('doctrine_phpcr')) {
+            $managers[] = new Reference('doctrine_phpcr');
+        }
+
+        if (\count($managers) > 0) {
+            $container->getDefinition('vich_uploader.command.cleanup')
+                ->replaceArgument(3, $managers);
+        }
+    }
+}

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -68,7 +68,7 @@ abstract class AbstractStorage implements StorageInterface
 
     abstract protected function doRemove(PropertyMapping $mapping, ?string $dir, string $name): ?bool;
 
-    public function remove(object $obj, PropertyMapping $mapping): ?bool
+    public function remove(object $obj, PropertyMapping $mapping, ?string $dir = null): ?bool
     {
         $name = $mapping->getFileName($obj);
 
@@ -76,6 +76,13 @@ abstract class AbstractStorage implements StorageInterface
             return false;
         }
 
+        // If $dir is provided explicitly, use it directly (bypasses getUploadDir and DirectoryNamer)
+        // This is useful for cleanup operations where the entity no longer exists in the database
+        if (null !== $dir) {
+            return $this->doRemove($mapping, $dir, $name);
+        }
+
+        // Default behavior: calculate directory from object using DirectoryNamer if configured
         return $this->doRemove($mapping, $mapping->getUploadDir($obj), $name);
     }
 

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -23,10 +23,11 @@ interface StorageInterface
      *
      * @param object          $obj     The object
      * @param PropertyMapping $mapping The mapping representing the field to remove
+     * @param string|null     $dir     Optional directory path to use instead of calling getUploadDir()
      *
      * @throw \Exception      Throws an exception
      */
-    public function remove(object $obj, PropertyMapping $mapping): ?bool;
+    public function remove(object $obj, PropertyMapping $mapping, ?string $dir = null): ?bool;
 
     /**
      * Resolves the path for a file based on the specified object
@@ -64,4 +65,19 @@ interface StorageInterface
      * @return resource|null The resolved resource or null if file not stored
      */
     public function resolveStream(object|array $obj, ?string $fieldName = null, ?string $className = null);
+
+    /**
+     * Lists all files in the storage for a given mapping.
+     *
+     * Implementations MUST return an empty iterable if the root directory/storage
+     * for the mapping does not exist or cannot be read. Do not throw for missing roots.
+     *
+     * The modification time, when available, MUST be a Unix timestamp in seconds (UTC).
+     * If it cannot be determined, it MUST be null.
+     *
+     * @param PropertyMapping $mapping The mapping to list files for
+     *
+     * @return iterable<StoredFile> StoredFile objects with path and optional modification time (?int seconds)
+     */
+    public function listFiles(PropertyMapping $mapping): iterable;
 }

--- a/src/Storage/StoredFile.php
+++ b/src/Storage/StoredFile.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Vich\UploaderBundle\Storage;
+
+/**
+ * Value object representing a file in storage.
+ */
+final class StoredFile
+{
+    /**
+     * @param string   $path           File path relative to mapping root
+     * @param int|null $lastModifiedAt Unix timestamp of the last modification, or null if unavailable
+     */
+    public function __construct(
+        public string $path,
+        public ?int $lastModifiedAt = null
+    ) {
+    }
+}

--- a/src/VichUploaderBundle.php
+++ b/src/VichUploaderBundle.php
@@ -4,6 +4,7 @@ namespace Vich\UploaderBundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Vich\UploaderBundle\DependencyInjection\Compiler\RegisterCleanupCommandPass;
 use Vich\UploaderBundle\DependencyInjection\Compiler\RegisterFlysystemRegistryPass;
 use Vich\UploaderBundle\DependencyInjection\Compiler\RegisterMappingDriversPass;
 use Vich\UploaderBundle\DependencyInjection\Compiler\RegisterSluggerPass;
@@ -20,6 +21,7 @@ final class VichUploaderBundle extends Bundle
         $container->addCompilerPass(new RegisterMappingDriversPass());
         $container->addCompilerPass(new RegisterFlysystemRegistryPass());
         $container->addCompilerPass(new RegisterSluggerPass());
+        $container->addCompilerPass(new RegisterCleanupCommandPass());
     }
 
     public function getPath(): string

--- a/tests/Command/CleanupCommandTest.php
+++ b/tests/Command/CleanupCommandTest.php
@@ -1,0 +1,720 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Command;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use Vich\UploaderBundle\Command\CleanupCommand;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
+use Vich\UploaderBundle\Storage\StorageInterface;
+
+final class CleanupCommandTest extends AbstractCommandTestCase
+{
+    public function testCommandWithNoUploadableClasses(): void
+    {
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn([]);
+
+        $storage = $this->createMock(StorageInterface::class);
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [],
+            []
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--force' => true]);
+
+        self::assertStringContainsString('No uploadable classes found', $output);
+    }
+
+    public function testCommandWithInvalidMapping(): void
+    {
+        $reader = $this->mockMetadataReader();
+        $storage = $this->createMock(StorageInterface::class);
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [],
+            ['valid_mapping' => []]
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--mapping' => 'invalid_mapping', '--force' => true]);
+
+        self::assertStringContainsString('Mapping "invalid_mapping" does not exist', $output);
+    }
+
+    public function testDryRunMode(): void
+    {
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn([]);
+
+        $storage = $this->createMock(StorageInterface::class);
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [],
+            []
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--dry-run' => true]);
+
+        self::assertStringContainsString('Running in dry-run mode', $output);
+        self::assertStringContainsString('No files will be deleted', $output);
+    }
+
+    public function testCommandWithSpecificMapping(): void
+    {
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn(['App\\Entity\\Product']);
+
+        // getUploadableFields is called twice: once for processing and once for finding sample field
+        $reader->expects(self::exactly(2))
+            ->method('getUploadableFields')
+            ->with('App\\Entity\\Product', 'product_image')
+            ->willReturn([]);
+
+        $storage = $this->createMock(StorageInterface::class);
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [],
+            ['product_image' => ['upload_destination' => '/tmp']]
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--mapping' => 'product_image', '--force' => true]);
+
+        self::assertStringContainsString('Processing mapping: product_image', $output);
+    }
+
+    public function testCommandWithNoObjectManager(): void
+    {
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn(['App\\Entity\\Product']);
+
+        // getUploadableFields is called twice: once for processing and once for finding sample field
+        $reader->expects(self::exactly(2))
+            ->method('getUploadableFields')
+            ->with('App\\Entity\\Product', 'test_mapping')
+            ->willReturn([
+                'image' => [
+                    'mapping' => 'test_mapping',
+                    'propertyName' => 'image',
+                    'fileNameProperty' => 'imageName',
+                ],
+            ]);
+
+        $storage = $this->createMock(StorageInterface::class);
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        // Create an empty manager registry (no managers)
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->expects(self::once())
+            ->method('getManagers')
+            ->willReturn([]);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [$managerRegistry],
+            ['test_mapping' => ['upload_destination' => '/tmp']]
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--force' => true]);
+
+        self::assertStringContainsString('No object manager found for class "App\\Entity\\Product"', $output);
+    }
+
+    public function testCommandWithRepositoryWithoutQueryBuilder(): void
+    {
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn(['App\\Entity\\Product']);
+
+        // getUploadableFields is called twice: once for processing and once for finding sample field
+        $reader->expects(self::exactly(2))
+            ->method('getUploadableFields')
+            ->with('App\\Entity\\Product', 'test_mapping')
+            ->willReturn([
+                'image' => [
+                    'mapping' => 'test_mapping',
+                    'propertyName' => 'image',
+                    'fileNameProperty' => 'imageName',
+                ],
+            ]);
+
+        $storage = $this->createMock(StorageInterface::class);
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        // Create a repository without createQueryBuilder method
+        $repository = $this->createMock(ObjectRepository::class);
+
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $metadataFactory->expects(self::once())
+            ->method('isTransient')
+            ->with('App\\Entity\\Product')
+            ->willReturn(false);
+
+        $objectManager = $this->createMock(ObjectManager::class);
+        $objectManager->expects(self::once())
+            ->method('getMetadataFactory')
+            ->willReturn($metadataFactory);
+        $objectManager->expects(self::once())
+            ->method('getRepository')
+            ->with('App\\Entity\\Product')
+            ->willReturn($repository);
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->expects(self::once())
+            ->method('getManagers')
+            ->willReturn([$objectManager]);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [$managerRegistry],
+            ['test_mapping' => ['upload_destination' => '/tmp']]
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--force' => true]);
+
+        self::assertStringContainsString('support query', $output);
+        self::assertStringContainsString('Skipping', $output);
+        // After skipping the repository, the command tries to create a sample instance which fails
+        self::assertStringContainsString('Could not create instance', $output);
+    }
+
+    public function testCommandWithCustomBatchSize(): void
+    {
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn([]);
+
+        $storage = $this->createMock(StorageInterface::class);
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [],
+            []
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--batch-size' => '500', '--force' => true]);
+
+        self::assertStringNotContainsString('error', \strtolower($output));
+    }
+
+    public function testCommandDetectsOrphanedFiles(): void
+    {
+        // This test verifies the scenario where storage has MORE files than referenced in database
+        // Expected: orphaned files should be reported/deleted
+
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn(['Vich\\UploaderBundle\\Tests\\DummyEntity']);
+
+        // getUploadableFields is called twice: once for processing and once for finding sample field
+        $reader->expects(self::exactly(2))
+            ->method('getUploadableFields')
+            ->with('Vich\\UploaderBundle\\Tests\\DummyEntity', 'test_mapping')
+            ->willReturn([
+                'file' => [
+                    'mapping' => 'test_mapping',
+                    'propertyName' => 'file',
+                    'fileNameProperty' => 'fileName',
+                ],
+            ]);
+
+        // Create a mock storage that returns 3 files (older than 2 hours to pass min-age filter)
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects(self::once())
+            ->method('listFiles')
+            ->willReturn([
+                new \Vich\UploaderBundle\Storage\StoredFile('file1.txt', \time() - 7200), // 2 hours old
+                new \Vich\UploaderBundle\Storage\StoredFile('file2.txt', \time() - 7200), // 2 hours old
+                new \Vich\UploaderBundle\Storage\StoredFile('orphaned.txt', \time() - 7200), // 2 hours old
+            ]); // 3 files in storage
+
+        // Create mock mapping
+        $mapping = $this->createMock(PropertyMapping::class);
+        $mapping->expects(self::atLeastOnce())
+            ->method('getMappingName')
+            ->willReturn('test_mapping');
+        $mapping->expects(self::atLeastOnce())
+            ->method('getFileName')
+            ->willReturnOnConsecutiveCalls('file1.txt', 'file2.txt'); // Only 2 files referenced
+        $mapping->expects(self::any())
+            ->method('getUploadDir')
+            ->willReturn('');
+
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+        $mappingFactory->expects(self::any())
+            ->method('fromField')
+            ->willReturn($mapping);
+
+        // Create mock entities (2 entities with files)
+        $entity1 = new \stdClass();
+        $entity2 = new \stdClass();
+
+        // Create mock query builder and repository
+        $qb = $this->createQueryBuilderMock([$entity1, $entity2]);
+        $repository = $this->createRepositoryMock($qb);
+
+        // Create mock object manager
+        $objectManager = $this->createObjectManagerMock($repository, 'Vich\\UploaderBundle\\Tests\\DummyEntity');
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->expects(self::once())
+            ->method('getManagers')
+            ->willReturn([$objectManager]);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [$managerRegistry],
+            ['test_mapping' => ['upload_destination' => '/tmp']]
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--dry-run' => true]);
+
+        // Verify the command detected orphaned file
+        self::assertStringContainsString('Found 2 referenced file(s) in database', $output);
+        self::assertStringContainsString('Found 3 file(s) in storage', $output);
+        self::assertStringContainsString('Found 1 orphaned file(s)', $output);
+    }
+
+    public function testCommandWithNoOrphanedFiles(): void
+    {
+        // This test verifies the scenario where all files in storage are referenced in database
+        // Expected: no orphaned files should be reported
+
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn(['Vich\\UploaderBundle\\Tests\\DummyEntity']);
+
+        $reader->expects(self::exactly(2))
+            ->method('getUploadableFields')
+            ->with('Vich\\UploaderBundle\\Tests\\DummyEntity', 'test_mapping')
+            ->willReturn([
+                'file' => [
+                    'mapping' => 'test_mapping',
+                    'propertyName' => 'file',
+                    'fileNameProperty' => 'fileName',
+                ],
+            ]);
+
+        // Storage has exactly the same files as in database (older than 2 hours to pass min-age filter)
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects(self::once())
+            ->method('listFiles')
+            ->willReturn([
+                new \Vich\UploaderBundle\Storage\StoredFile('file1.txt', \time() - 7200), // 2 hours old
+                new \Vich\UploaderBundle\Storage\StoredFile('file2.txt', \time() - 7200), // 2 hours old
+            ]); // 2 files in storage
+
+        $mapping = $this->createMock(PropertyMapping::class);
+        $mapping->expects(self::atLeastOnce())
+            ->method('getMappingName')
+            ->willReturn('test_mapping');
+        $mapping->expects(self::atLeastOnce())
+            ->method('getFileName')
+            ->willReturnOnConsecutiveCalls('file1.txt', 'file2.txt'); // 2 files referenced
+        $mapping->expects(self::any())
+            ->method('getUploadDir')
+            ->willReturn('');
+
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+        $mappingFactory->expects(self::any())
+            ->method('fromField')
+            ->willReturn($mapping);
+
+        $entity1 = new \stdClass();
+        $entity2 = new \stdClass();
+
+        $qb = $this->createQueryBuilderMock([$entity1, $entity2]);
+        $repository = $this->createRepositoryMock($qb);
+        $objectManager = $this->createObjectManagerMock($repository, 'Vich\\UploaderBundle\\Tests\\DummyEntity');
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->expects(self::once())
+            ->method('getManagers')
+            ->willReturn([$objectManager]);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [$managerRegistry],
+            ['test_mapping' => ['upload_destination' => '/tmp']]
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--force' => true]);
+
+        // Verify no orphaned files were found
+        self::assertStringContainsString('Found 2 referenced file(s) in database', $output);
+        self::assertStringContainsString('Found 2 file(s) in storage', $output);
+        self::assertStringContainsString('Found 0 orphaned file(s)', $output);
+    }
+
+    public function testCommandWithMissingFiles(): void
+    {
+        // This test verifies the scenario where database references MORE files than exist in storage
+        // Expected: command should not fail, just report fewer files in storage
+
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn(['Vich\\UploaderBundle\\Tests\\DummyEntity']);
+
+        $reader->expects(self::exactly(2))
+            ->method('getUploadableFields')
+            ->with('Vich\\UploaderBundle\\Tests\\DummyEntity', 'test_mapping')
+            ->willReturn([
+                'file' => [
+                    'mapping' => 'test_mapping',
+                    'propertyName' => 'file',
+                    'fileNameProperty' => 'fileName',
+                ],
+            ]);
+
+        // Storage has FEWER files than referenced in database (older than 2 hours to pass min-age filter)
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects(self::once())
+            ->method('listFiles')
+            ->willReturn([
+                new \Vich\UploaderBundle\Storage\StoredFile('file1.txt', \time() - 7200), // 2 hours old
+            ]); // Only 1 file in storage
+
+        $mapping = $this->createMock(PropertyMapping::class);
+        $mapping->expects(self::atLeastOnce())
+            ->method('getMappingName')
+            ->willReturn('test_mapping');
+        $mapping->expects(self::atLeastOnce())
+            ->method('getFileName')
+            ->willReturnOnConsecutiveCalls('file1.txt', 'file2.txt', 'file3.txt'); // 3 files referenced
+        $mapping->expects(self::any())
+            ->method('getUploadDir')
+            ->willReturn('');
+
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+        $mappingFactory->expects(self::any())
+            ->method('fromField')
+            ->willReturn($mapping);
+
+        $entity1 = new \stdClass();
+        $entity2 = new \stdClass();
+        $entity3 = new \stdClass();
+
+        $qb = $this->createQueryBuilderMock([$entity1, $entity2, $entity3]);
+        $repository = $this->createRepositoryMock($qb);
+        $objectManager = $this->createObjectManagerMock($repository, 'Vich\\UploaderBundle\\Tests\\DummyEntity');
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->expects(self::once())
+            ->method('getManagers')
+            ->willReturn([$objectManager]);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [$managerRegistry],
+            ['test_mapping' => ['upload_destination' => '/tmp']]
+        );
+
+        $output = $this->executeCommand('vich:cleanup', $command, ['--force' => true]);
+
+        // Verify the command handled missing files gracefully
+        self::assertStringContainsString('Found 3 referenced file(s) in database', $output);
+        self::assertStringContainsString('Found 1 file(s) in storage', $output);
+        self::assertStringContainsString('Found 0 orphaned file(s)', $output);
+    }
+
+    public function testCommandDeletesOrphanedFilesInRealMode(): void
+    {
+        // This test verifies the complete happy path: orphaned file is detected AND deleted
+        // Expected: storage->remove() is called with correct parameters
+
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn(['Vich\\UploaderBundle\\Tests\\DummyEntity']);
+
+        $reader->expects(self::exactly(2))
+            ->method('getUploadableFields')
+            ->with('Vich\\UploaderBundle\\Tests\\DummyEntity', 'test_mapping')
+            ->willReturn([
+                'file' => [
+                    'mapping' => 'test_mapping',
+                    'propertyName' => 'file',
+                    'fileNameProperty' => 'fileName',
+                ],
+            ]);
+
+        // Storage returns 3 files (2 hours old to pass min-age filter)
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects(self::once())
+            ->method('listFiles')
+            ->willReturn([
+                new \Vich\UploaderBundle\Storage\StoredFile('file1.txt', \time() - 7200),
+                new \Vich\UploaderBundle\Storage\StoredFile('file2.txt', \time() - 7200),
+                new \Vich\UploaderBundle\Storage\StoredFile('orphaned.txt', \time() - 7200),
+            ]);
+
+        // KEY ASSERTION: Verify remove() is called ONCE with correct parameters for orphaned file
+        $storage->expects(self::once())
+            ->method('remove')
+            ->with(
+                self::anything(), // object (temporary instance created by command)
+                self::callback(function ($mapping) {
+                    // Verify mapping is correct
+                    return $mapping instanceof PropertyMapping
+                        && 'test_mapping' === $mapping->getMappingName();
+                }),
+                '' // directory (empty string for root, as returned by getUploadDir)
+            );
+
+        // Mock mapping that returns 2 files (file1.txt, file2.txt) → orphaned.txt is orphan
+        $mapping = $this->createMock(PropertyMapping::class);
+        $mapping->expects(self::atLeastOnce())
+            ->method('getMappingName')
+            ->willReturn('test_mapping');
+        $mapping->expects(self::atLeastOnce())
+            ->method('getFileName')
+            ->willReturnOnConsecutiveCalls('file1.txt', 'file2.txt'); // Only 2 files referenced
+        $mapping->expects(self::any())
+            ->method('getUploadDir')
+            ->willReturn('');
+        $mapping->expects(self::any())
+            ->method('setFileName'); // Called when creating temp object for deletion
+
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+        $mappingFactory->expects(self::any())
+            ->method('fromField')
+            ->willReturn($mapping);
+
+        // Mock 2 entities with files
+        $entity1 = new \stdClass();
+        $entity2 = new \stdClass();
+
+        $qb = $this->createQueryBuilderMock([$entity1, $entity2]);
+        $repository = $this->createRepositoryMock($qb);
+        $objectManager = $this->createObjectManagerMock($repository, 'Vich\\UploaderBundle\\Tests\\DummyEntity');
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->expects(self::once())
+            ->method('getManagers')
+            ->willReturn([$objectManager]);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [$managerRegistry],
+            ['test_mapping' => ['upload_destination' => '/tmp']]
+        );
+
+        // Execute WITHOUT --dry-run (so remove() actually gets called)
+        $output = $this->executeCommand('vich:cleanup', $command, ['--force' => true]);
+
+        // Verify output shows the correct flow
+        self::assertStringContainsString('Found 2 referenced file(s) in database', $output);
+        self::assertStringContainsString('Found 3 file(s) in storage', $output);
+        self::assertStringContainsString('Found 1 orphaned file(s)', $output);
+        self::assertStringContainsString('1 orphaned file(s) deleted', $output); // "deleted" not "found"
+        self::assertStringNotContainsString('dry-run', \strtolower($output));
+    }
+
+    public function testMinAgeSkipsRecentFiles(): void
+    {
+        // This test verifies that --min-age properly skips files newer than the cutoff
+        // and only counts/deletes files that are old enough.
+
+        $reader = $this->mockMetadataReader();
+        $reader->expects(self::once())
+            ->method('getUploadableClasses')
+            ->willReturn(['Vich\\UploaderBundle\\Tests\\DummyEntity']);
+
+        // getUploadableFields is called twice: once for processing and once for finding sample field
+        $reader->expects(self::exactly(2))
+            ->method('getUploadableFields')
+            ->with('Vich\\UploaderBundle\\Tests\\DummyEntity', 'test_mapping')
+            ->willReturn([
+                'file' => [
+                    'mapping' => 'test_mapping',
+                    'propertyName' => 'file',
+                    'fileNameProperty' => 'fileName',
+                ],
+            ]);
+
+        // Storage returns 2 files: one recent (1 minute old) and one old (2 hours old)
+        $recent = new \Vich\UploaderBundle\Storage\StoredFile('recent.txt', \time() - 60);
+        $old = new \Vich\UploaderBundle\Storage\StoredFile('old.txt', \time() - 7200);
+
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects(self::once())
+            ->method('listFiles')
+            ->willReturn([$recent, $old]);
+        // In dry-run, no deletion should occur
+        $storage->expects(self::never())
+            ->method('remove');
+
+        // Mapping: we don't care about DB-referenced files here because we return 0 entities below
+        $mapping = $this->createMock(PropertyMapping::class);
+        $mapping->expects(self::any())
+            ->method('getMappingName')
+            ->willReturn('test_mapping');
+        $mapping->expects(self::any())
+            ->method('getUploadDir')
+            ->willReturn('');
+
+        $mappingFactory = $this->createMock(PropertyMappingFactory::class);
+        $mappingFactory->expects(self::any())
+            ->method('fromField')
+            ->willReturn($mapping);
+
+        // Doctrine mocks: repository returns 0 entities so there are no DB references
+        $qb = $this->createQueryBuilderMock([]);
+        $repository = $this->createRepositoryMock($qb);
+        $objectManager = $this->createObjectManagerMock($repository, 'Vich\\UploaderBundle\\Tests\\DummyEntity');
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->expects(self::once())
+            ->method('getManagers')
+            ->willReturn([$objectManager]);
+
+        $command = new CleanupCommand(
+            $storage,
+            $mappingFactory,
+            $reader,
+            [$managerRegistry],
+            ['test_mapping' => ['upload_destination' => '/tmp']]
+        );
+
+        // Set --min-age to 30 minutes so the recent file (1 minute old) is skipped
+        $output = $this->executeCommand('vich:cleanup', $command, ['--mapping' => 'test_mapping', '--min-age' => '30', '--dry-run' => true]);
+
+        // Verify output indicates the recent file was skipped and only the old file considered
+        self::assertStringContainsString('Skipped 1 file(s) younger than cutoff age', $output);
+        self::assertStringContainsString('Found 1 file(s) in storage (matching age criteria)', $output);
+        self::assertStringContainsString('Found 1 orphaned file(s)', $output);
+        // And since dry-run, wording should use "found" and not "deleted"
+        self::assertStringContainsString('1 orphaned file(s) found', $output);
+    }
+
+    /**
+     * Helper method to create a mock query builder.
+     * Uses a generic mock object instead of ORM-specific classes to be persistence-layer agnostic.
+     */
+    private function createQueryBuilderMock(array $entities): MockObject
+    {
+        // Create a generic query mock (not tied to ORM)
+        $query = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getSingleScalarResult', 'getResult'])
+            ->getMock();
+        $query->expects(self::any())
+            ->method('getSingleScalarResult')
+            ->willReturn(\count($entities));
+        $query->expects(self::any())
+            ->method('getResult')
+            ->willReturn($entities);
+
+        // Create a generic query builder mock (not tied to ORM)
+        $qb = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['select', 'setFirstResult', 'setMaxResults', 'getQuery'])
+            ->getMock();
+        $qb->expects(self::any())
+            ->method('select')
+            ->willReturnSelf();
+        $qb->expects(self::any())
+            ->method('setFirstResult')
+            ->willReturnSelf();
+        $qb->expects(self::any())
+            ->method('setMaxResults')
+            ->willReturnSelf();
+        $qb->expects(self::any())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        return $qb;
+    }
+
+    /**
+     * Helper method to create a mock repository.
+     * Uses ObjectRepository interface to be persistence-layer agnostic.
+     */
+    private function createRepositoryMock(MockObject $queryBuilder): MockObject
+    {
+        // Create a mock that implements ObjectRepository (agnostic) with createQueryBuilder method
+        $repository = $this->getMockBuilder(ObjectRepository::class)
+            ->onlyMethods(['find', 'findAll', 'findBy', 'findOneBy', 'getClassName'])
+            ->addMethods(['createQueryBuilder'])
+            ->getMock();
+        $repository->expects(self::any())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+        $repository->expects(self::any())
+            ->method('getClassName')
+            ->willReturn('Vich\\UploaderBundle\\Tests\\DummyEntity');
+
+        return $repository;
+    }
+
+    /**
+     * Helper method to create a mock object manager.
+     */
+    private function createObjectManagerMock(MockObject $repository, string $className): MockObject
+    {
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $metadataFactory->expects(self::once())
+            ->method('isTransient')
+            ->with($className)
+            ->willReturn(false);
+
+        $objectManager = $this->createMock(ObjectManager::class);
+        $objectManager->expects(self::once())
+            ->method('getMetadataFactory')
+            ->willReturn($metadataFactory);
+        $objectManager->expects(self::once())
+            ->method('getRepository')
+            ->with($className)
+            ->willReturn($repository);
+        $objectManager->expects(self::any())
+            ->method('clear');
+
+        return $objectManager;
+    }
+}

--- a/tests/Functional/CleanupCommandTest.php
+++ b/tests/Functional/CleanupCommandTest.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Vich\TestBundle\Entity\Image;
+
+/**
+ * End-to-end functional test for vich:cleanup command.
+ *
+ * This test creates real entities with uploaded files, deletes some rows
+ * directly from database (bypassing Doctrine), and verifies the cleanup
+ * command correctly identifies and removes orphaned files.
+ */
+final class CleanupCommandTest extends WebTestCase
+{
+    public function testCleanupCommandRemovesOrphanedFilesInRealScenario(): void
+    {
+        if (\headers_sent()) {
+            self::markTestSkipped('Headers already sent');
+        }
+
+        $client = self::createClient();
+        $this->loadFixtures($client);
+
+        $container = self::getKernelContainer($client);
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+        $uploadsDir = $this->getUploadsDir($client);
+
+        // Step 1: Create 4 images with actual uploaded files
+        $filenames = ['file1.png', 'file2.png', 'file3.png', 'file4.png'];
+
+        foreach ($filenames as $i => $filename) {
+            // Create temporary uploaded file
+            $sourceFile = $this->getImagesDir($client).\DIRECTORY_SEPARATOR.'symfony_black_03.png';
+            $tempFile = \sys_get_temp_dir().\DIRECTORY_SEPARATOR.$filename;
+            \copy($sourceFile, $tempFile);
+
+            $uploadedFile = new UploadedFile(
+                $tempFile,
+                $filename,
+                'image/png',
+                null,
+                true // Mark as test file
+            );
+
+            $image = new Image();
+            $image->setTitle('Image '.($i + 1));
+            $image->setImageFile($uploadedFile);
+
+            $em->persist($image);
+        }
+
+        $em->flush();
+
+        // Verify all 4 files exist in storage
+        foreach ($filenames as $filename) {
+            self::assertFileExists($uploadsDir.\DIRECTORY_SEPARATOR.$filename, "File $filename should exist after upload");
+        }
+
+        // Step 2: Get image IDs before deleting
+        $em->clear(); // Clear to ensure we're working with fresh data
+        $imageRepo = $em->getRepository(Image::class);
+        $allImages = $imageRepo->findAll();
+        self::assertCount(4, $allImages, 'Should have 4 images in database');
+
+        $imageIdsToDelete = [$allImages[1]->getId(), $allImages[3]->getId()]; // Delete image 2 and 4
+        $orphanedFiles = [$filenames[1], $filenames[3]]; // file2.png and file4.png will be orphaned
+        $referencedFiles = [$filenames[0], $filenames[2]]; // file1.png and file3.png remain referenced
+
+        // Step 3: Delete 2 images DIRECTLY from database (bypassing Doctrine events)
+        // This simulates a scenario where files are left orphaned (e.g., CASCADE DELETE, manual DB operation)
+        $connection = $em->getConnection();
+        $platform = $connection->getDatabasePlatform();
+        $tableName = $em->getClassMetadata(Image::class)->getTableName();
+
+        foreach ($imageIdsToDelete as $id) {
+            $connection->executeStatement(
+                "DELETE FROM {$platform->quoteIdentifier($tableName)} WHERE id = ?",
+                [$id]
+            );
+        }
+
+        // Clear entity manager to reflect database changes
+        $em->clear();
+
+        // Verify only 2 images remain in database
+        $remainingImages = $imageRepo->findAll();
+        self::assertCount(2, $remainingImages, 'Should have 2 images after deletion');
+
+        // Verify all 4 files still exist in storage (orphaned files not yet cleaned up)
+        foreach ($filenames as $filename) {
+            self::assertFileExists($uploadsDir.\DIRECTORY_SEPARATOR.$filename, "File $filename should still exist before cleanup");
+        }
+
+        // Step 4: Wait 1 second to ensure files are older than any potential min-age filter
+        // (The default min-age is 60 minutes, but we'll use --min-age=0 for faster test)
+        \sleep(1);
+
+        // Step 5: Run vich:cleanup command with --force and --min-age=0
+        $application = new Application($client->getKernel());
+        $command = $application->find('vich:cleanup');
+        $commandTester = new CommandTester($command);
+
+        $exitCode = $commandTester->execute([
+            '--force' => true,
+            '--min-age' => '0', // Allow immediate cleanup for testing
+        ]);
+
+        self::assertSame(0, $exitCode, 'Command should exit successfully');
+
+        $output = $commandTester->getDisplay();
+
+        // Step 6: Verify command output
+        self::assertStringContainsString('Found 2 referenced file(s) in database', $output);
+        self::assertStringContainsString('Found 4 file(s) in storage', $output);
+        self::assertStringContainsString('Found 2 orphaned file(s)', $output);
+        self::assertStringContainsString('2 orphaned file(s) deleted', $output);
+
+        // Step 7: Verify orphaned files were deleted
+        foreach ($orphanedFiles as $filename) {
+            self::assertFileDoesNotExist(
+                $uploadsDir.\DIRECTORY_SEPARATOR.$filename,
+                "Orphaned file $filename should be deleted"
+            );
+        }
+
+        // Step 8: Verify referenced files still exist
+        foreach ($referencedFiles as $filename) {
+            self::assertFileExists(
+                $uploadsDir.\DIRECTORY_SEPARATOR.$filename,
+                "Referenced file $filename should NOT be deleted"
+            );
+        }
+    }
+
+    public function testCleanupCommandDryRunDoesNotDeleteFiles(): void
+    {
+        if (\headers_sent()) {
+            self::markTestSkipped('Headers already sent');
+        }
+
+        $client = self::createClient();
+
+        // Load fixtures to ensure clean state (removes files from previous tests)
+        $this->loadFixtures($client);
+
+        $container = self::getKernelContainer($client);
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+        $uploadsDir = $this->getUploadsDir($client);
+
+        // Clean uploads directory from previous tests
+        if (\is_dir($uploadsDir)) {
+            foreach (\scandir($uploadsDir) as $file) {
+                if ('.' !== $file && '..' !== $file) {
+                    @\unlink($uploadsDir.\DIRECTORY_SEPARATOR.$file);
+                }
+            }
+        }
+
+        // Create 2 images
+        $filenames = ['dryrun1.png', 'dryrun2.png'];
+
+        foreach ($filenames as $i => $filename) {
+            $sourceFile = $this->getImagesDir($client).\DIRECTORY_SEPARATOR.'symfony_black_03.png';
+            $tempFile = \sys_get_temp_dir().\DIRECTORY_SEPARATOR.$filename;
+            \copy($sourceFile, $tempFile);
+
+            $uploadedFile = new UploadedFile($tempFile, $filename, 'image/png', null, true);
+
+            $image = new Image();
+            $image->setTitle('DryRun Image '.($i + 1));
+            $image->setImageFile($uploadedFile);
+
+            $em->persist($image);
+        }
+
+        $em->flush();
+
+        // Delete 1 image directly from database
+        $em->clear();
+        $allImages = $em->getRepository(Image::class)->findAll();
+        $imageId = $allImages[0]->getId();
+
+        $connection = $em->getConnection();
+        $platform = $connection->getDatabasePlatform();
+        $tableName = $em->getClassMetadata(Image::class)->getTableName();
+        $connection->executeStatement(
+            "DELETE FROM {$platform->quoteIdentifier($tableName)} WHERE id = ?",
+            [$imageId]
+        );
+
+        $em->clear();
+
+        \sleep(1);
+
+        // Run command with --dry-run
+        $application = new Application($client->getKernel());
+        $command = $application->find('vich:cleanup');
+        $commandTester = new CommandTester($command);
+
+        $exitCode = $commandTester->execute([
+            '--dry-run' => true,
+            '--min-age' => '0',
+        ]);
+
+        self::assertSame(0, $exitCode);
+
+        $output = $commandTester->getDisplay();
+
+        // Verify dry-run output
+        self::assertStringContainsString('Running in dry-run mode', $output);
+        self::assertStringContainsString('No files will be deleted', $output);
+        self::assertStringContainsString('Found 1 orphaned file(s)', $output);
+        self::assertStringContainsString('1 orphaned file(s) found', $output); // "found" not "deleted"
+
+        // Verify files still exist (dry-run should not delete)
+        foreach ($filenames as $filename) {
+            self::assertFileExists(
+                $uploadsDir.\DIRECTORY_SEPARATOR.$filename,
+                "File $filename should still exist after dry-run"
+            );
+        }
+    }
+
+    public function testCleanupCommandRespectsMinAgeFilter(): void
+    {
+        if (\headers_sent()) {
+            self::markTestSkipped('Headers already sent');
+        }
+
+        $client = self::createClient();
+
+        // Load fixtures to ensure clean state (removes files from previous tests)
+        $this->loadFixtures($client);
+
+        $container = self::getKernelContainer($client);
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+        $uploadsDir = $this->getUploadsDir($client);
+
+        // Clean uploads directory from previous tests
+        if (\is_dir($uploadsDir)) {
+            foreach (\scandir($uploadsDir) as $file) {
+                if ('.' !== $file && '..' !== $file) {
+                    @\unlink($uploadsDir.\DIRECTORY_SEPARATOR.$file);
+                }
+            }
+        }
+
+        // Create 1 image
+        $filename = 'recent.png';
+        $sourceFile = $this->getImagesDir($client).\DIRECTORY_SEPARATOR.'symfony_black_03.png';
+        $tempFile = \sys_get_temp_dir().\DIRECTORY_SEPARATOR.$filename;
+        \copy($sourceFile, $tempFile);
+
+        $uploadedFile = new UploadedFile($tempFile, $filename, 'image/png', null, true);
+
+        $image = new Image();
+        $image->setTitle('Recent Image');
+        $image->setImageFile($uploadedFile);
+
+        $em->persist($image);
+        $em->flush();
+
+        // Delete image directly
+        $em->clear();
+        $imageId = $em->getRepository(Image::class)->findAll()[0]->getId();
+
+        $connection = $em->getConnection();
+        $platform = $connection->getDatabasePlatform();
+        $tableName = $em->getClassMetadata(Image::class)->getTableName();
+        $connection->executeStatement(
+            "DELETE FROM {$platform->quoteIdentifier($tableName)} WHERE id = ?",
+            [$imageId]
+        );
+
+        $em->clear();
+
+        // Run command with --min-age=60 (file is too recent, should be skipped)
+        $application = new Application($client->getKernel());
+        $command = $application->find('vich:cleanup');
+        $commandTester = new CommandTester($command);
+
+        $exitCode = $commandTester->execute([
+            '--force' => true,
+            '--min-age' => '60', // 60 minutes - file is too recent
+        ]);
+
+        self::assertSame(0, $exitCode);
+
+        $output = $commandTester->getDisplay();
+
+        // Verify file was skipped due to min-age
+        self::assertStringContainsString('Skipped 1 file(s) younger than cutoff age', $output);
+        self::assertStringContainsString('Found 0 file(s) in storage (matching age criteria)', $output);
+
+        // Verify file still exists (skipped due to age)
+        self::assertFileExists(
+            $uploadsDir.\DIRECTORY_SEPARATOR.$filename,
+            "File should still exist because it's too recent"
+        );
+    }
+}


### PR DESCRIPTION
Introduced a new `vich:cleanup` console command to detect and delete files no longer referenced in the database. Extended storage layer to support file listing and safe removal across backends. Wired the command via service config and compiler pass, and added documentation and tests.

Fix #1124 