### PR TITLE
Fix race condition in FileSystemStorage directory creation

### DIFF
--- a/src/Storage/FileSystemStorage.php
+++ b/src/Storage/FileSystemStorage.php
@@ -17,10 +17,8 @@ final class FileSystemStorage extends AbstractStorage
     {
         $uploadDir = $mapping->getUploadDestination().\DIRECTORY_SEPARATOR.$dir;
 
-        if (!\file_exists($uploadDir)) {
-            if (!\mkdir($uploadDir, recursive: true)) {
-                throw new \Exception('Could not create directory "'.$uploadDir.'"');
-            }
+        if (!\file_exists($uploadDir) && !@\mkdir($uploadDir, recursive: true) && !\is_dir($uploadDir)) {
+            throw new \Exception('Could not create directory "'.$uploadDir.'"');
         }
         if (!\is_dir($uploadDir)) {
             throw new \Exception('Tried to move file to directory "'.$uploadDir.'" but it is a file');


### PR DESCRIPTION
## Problem

When two uploads concurrently target the same not-yet-existing directory, one of them throws `Could not create directory "..."`.

This is most likely to surface with a date-based `DirectoryNamer` (e.g. `CurrentDateTimeDirectoryNamer` with format `Y/m/d`), where the first uploads of a new day race to create the new subdirectory. It also reproduces any time multiple uploads run in parallel against a fresh upload destination.

## Root cause

In `FileSystemStorage::doUpload()`:

```php
if (!\file_exists($uploadDir)) {
    if (!\mkdir($uploadDir, recursive: true)) {
        throw new \Exception('Could not create directory "'.$uploadDir.'"');
    }
}
```

The classic TOCTOU race:

1. Request A — `file_exists()` returns `false`
2. Request B — `file_exists()` returns `false` (concurrent)
3. Request A — `mkdir(..., recursive: true)` succeeds
4. Request B — `mkdir(..., recursive: true)` returns `false` (emits a `mkdir(): File exists` warning) and throws

The directory ends up created by request A, but request B fails for the user.

## Fix

Use the standard race-safe idiom: suppress the warning and re-check `is_dir()` after `mkdir()` returns false. If a concurrent process created the directory in between, accept it as success.

```php
if (!\file_exists($uploadDir) && !@\mkdir($uploadDir, recursive: true) && !\is_dir($uploadDir)) {
    throw new \Exception('Could not create directory "'.$uploadDir.'"');
}
```

This mirrors the same pattern already used in this bundle's own `src/Metadata/CacheWarmer.php`:

```php
if (!\mkdir($concurrentDirectory = $this->dir, 0o777, true) && !\is_dir($concurrentDirectory)) {
```

## Compatibility

- Exception class and message are unchanged — callers relying on either continue to work.
- Genuine failures (permissions denied, parent path is a file, disk full, …) still throw the same exception, because `is_dir()` still returns `false` for them.
- The follow-up `if (!\is_dir($uploadDir))` "directory is a file" guard is preserved.

## Notes

No new tests added — the existing `FileSystemStorageTest` does not cover the failure branch, and a reliable race-condition test would require either fork/threading or filesystem mocking that the suite doesn't currently use. Happy to add one if reviewers prefer a specific approach (e.g. with `vfsStream` simulating a pre-existing directory).