### PR TITLE
Re-add MappingCollector null-safety

### DIFF
--- a/src/DataCollector/MappingCollector.php
+++ b/src/DataCollector/MappingCollector.php
@@ -43,11 +43,13 @@ final class MappingCollector extends DataCollector
 
     public function getMappingsCount(): int
     {
-        return \is_countable($this->data['mappings']) ? \count($this->data['mappings']) : 0;
+        $mappings = $this->data['mappings'] ?? [];
+
+        return \is_countable($mappings) ? \count($mappings) : 0;
     }
 
     public function getMappings(): array
     {
-        return $this->data['mappings'];
+        return $this->data['mappings'] ?? [];
     }
 }

--- a/tests/DataCollector/MappingCollectorTest.php
+++ b/tests/DataCollector/MappingCollectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\DataCollector;
+
+use Metadata\AdvancedMetadataFactoryInterface;
+use PHPUnit\Framework\TestCase;
+use Vich\UploaderBundle\DataCollector\MappingCollector;
+use Vich\UploaderBundle\Metadata\MetadataReader;
+use Vich\UploaderBundle\Tests\DummyEntity;
+
+final class MappingCollectorTest extends TestCase
+{
+    public function testResetClearsCollectedMappings(): void
+    {
+        $metadataReader = new MetadataReader($this->createStub(AdvancedMetadataFactoryInterface::class));
+
+        $collector = new MappingCollector($metadataReader);
+        $this->setCollectorData($collector, [
+            'mappings' => [
+                DummyEntity::class => ['fileName' => 'field-metadata'],
+            ],
+        ]);
+
+        self::assertSame(1, $collector->getMappingsCount());
+
+        $collector->reset();
+
+        self::assertSame(0, $collector->getMappingsCount());
+        self::assertSame([], $collector->getMappings());
+    }
+
+    private function setCollectorData(MappingCollector $collector, array $data): void
+    {
+        $property = new \ReflectionProperty($collector, 'data');
+        $property->setValue($collector, $data);
+    }
+}


### PR DESCRIPTION
Guard `$this->data['mappings']` with `?? []` so the profiler collector tolerates a missing/empty mappings entry