### PR TITLE
Fix "null as array offset" deprecation in FileExtensionTrait

### DIFF
--- a/src/Naming/Polyfill/FileExtensionTrait.php
+++ b/src/Naming/Polyfill/FileExtensionTrait.php
@@ -50,7 +50,7 @@ trait FileExtensionTrait
             return $this->getOriginalExtension($file);
         }
 
-        if ('' !== ($extension = $file->guessExtension())) {
+        if (null !== ($extension = $file->guessExtension()) && '' !== $extension) {
             if (isset(self::$keep[$extension])) {
                 $originalExtension = \pathinfo($file->getClientOriginalName(), \PATHINFO_EXTENSION);
                 if (\in_array($originalExtension, self::$keep[$extension], true)) {


### PR DESCRIPTION
`guessExtension()` can return null, which reached `isset(self::$keep[null])`. Guard against it explicitly; behavior unchanged.