### PR TITLE
Modernize Docker test images & fix PHP 8.3 / 8.5

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Keep the build context small and avoid shipping host-built artifacts.
+.git
+.github
+.idea
+.DS_Store
+.*.cache
+.phpunit.result.cache
+vendor/
+composer.lock
+coverage/
+docs/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.dockerfile*     export-ignore
 /.git*            export-ignore
 /.php-cs-fixer*   export-ignore
 /CONTRIBUTING.md  export-ignore

--- a/docker/Dockerfile83
+++ b/docker/Dockerfile83
@@ -1,43 +1,20 @@
 FROM php:8.3-alpine
 
-ARG MONGODB_VERSION=1.17.0
+ARG MONGODB_VERSION=2.3.3
 
-# Install mongo
-RUN set -eux; \
-	apk add --no-cache --virtual .build-deps \
-		$PHPIZE_DEPS \
-    	openssl-dev \
-	; \
-	pecl install \
-	    mongodb-${MONGODB_VERSION} \
-    ; \
-	docker-php-ext-enable \
-	    mongodb \
-	; \
-	pecl clear-cache; \
-	\
-	runDeps="$( \
-    scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-      | tr ',' '\n' \
-      | sort -u \
-      | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-cache --virtual .api-add-phpexts-rundeps $runDeps \
-	curl \
-	;
-
-RUN curl -s https://getcomposer.org/installer | php
-
-RUN mv composer.phar /usr/local/bin/composer
+# Install the mongodb extension and Composer.
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions; \
+	install-php-extensions mongodb-${MONGODB_VERSION} @composer
 
 WORKDIR /srv/vich-uploader
 
-# prevent the reinstallation of vendors at every changes in the source code
-
 COPY . ./
 
-RUN set -eux; \
-	composer update --prefer-dist --ignore-platform-reqs; \
-	composer clear-cache
+# No lock file is committed, so dependencies are resolved on every build and the
+# suite always runs against the latest compatible versions. A BuildKit cache mount
+# keeps Composer's download cache across builds to make this fast.
+RUN --mount=type=cache,target=/tmp/composer-cache \
+	COMPOSER_CACHE_DIR=/tmp/composer-cache composer update --prefer-dist
 
 CMD ["/init"]

--- a/docker/Dockerfile84
+++ b/docker/Dockerfile84
@@ -1,43 +1,20 @@
 FROM php:8.4-alpine
 
-ARG MONGODB_VERSION=1.21.0
+ARG MONGODB_VERSION=2.3.3
 
-# Install mongo
-RUN set -eux; \
-	apk add --no-cache --virtual .build-deps \
-		$PHPIZE_DEPS \
-    	openssl-dev \
-	; \
-	pecl install \
-	    mongodb-${MONGODB_VERSION} \
-    ; \
-	docker-php-ext-enable \
-	    mongodb \
-	; \
-	pecl clear-cache; \
-	\
-	runDeps="$( \
-    scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-      | tr ',' '\n' \
-      | sort -u \
-      | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-cache --virtual .api-add-phpexts-rundeps $runDeps \
-	curl \
-	;
-
-RUN curl -s https://getcomposer.org/installer | php
-
-RUN mv composer.phar /usr/local/bin/composer
+# Install the mongodb extension and Composer.
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions; \
+	install-php-extensions mongodb-${MONGODB_VERSION} @composer
 
 WORKDIR /srv/vich-uploader
 
-# prevent the reinstallation of vendors at every changes in the source code
-
 COPY . ./
 
-RUN set -eux; \
-	composer update --prefer-dist --ignore-platform-reqs; \
-	composer clear-cache
+# No lock file is committed, so dependencies are resolved on every build and the
+# suite always runs against the latest compatible versions. A BuildKit cache mount
+# keeps Composer's download cache across builds to make this fast.
+RUN --mount=type=cache,target=/tmp/composer-cache \
+	COMPOSER_CACHE_DIR=/tmp/composer-cache composer update --prefer-dist
 
 CMD ["/init"]

--- a/docker/Dockerfile85
+++ b/docker/Dockerfile85
@@ -1,43 +1,20 @@
-FROM php:8.5.0rc3-alpine
+FROM php:8.5-alpine
 
-ARG MONGODB_VERSION=2.1.2
+ARG MONGODB_VERSION=2.3.3
 
-# Install mongo
-RUN set -eux; \
-	apk add --no-cache --virtual .build-deps \
-		$PHPIZE_DEPS \
-    	openssl-dev \
-	; \
-	pecl install \
-	    mongodb-${MONGODB_VERSION} \
-    ; \
-	docker-php-ext-enable \
-	    mongodb \
-	; \
-	pecl clear-cache; \
-	\
-	runDeps="$( \
-    scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-      | tr ',' '\n' \
-      | sort -u \
-      | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-cache --virtual .api-add-phpexts-rundeps $runDeps \
-	curl \
-	;
-
-RUN curl -s https://getcomposer.org/installer | php
-
-RUN mv composer.phar /usr/local/bin/composer
+# Install the mongodb extension and Composer.
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions; \
+	install-php-extensions mongodb-${MONGODB_VERSION} @composer
 
 WORKDIR /srv/vich-uploader
 
-# prevent the reinstallation of vendors at every changes in the source code
-
 COPY . ./
 
-RUN set -eux; \
-	composer update --prefer-dist --ignore-platform-reqs; \
-	composer clear-cache
+# No lock file is committed, so dependencies are resolved on every build and the
+# suite always runs against the latest compatible versions. A BuildKit cache mount
+# keeps Composer's download cache across builds to make this fast.
+RUN --mount=type=cache,target=/tmp/composer-cache \
+	COMPOSER_CACHE_DIR=/tmp/composer-cache composer update --prefer-dist
 
 CMD ["/init"]


### PR DESCRIPTION
The `docker/Dockerfile{83,84,85}` images used by `make tests` were built with the
now-deprecated `pecl install`, shipped the developer's local `vendor/` into the
image, and forced an incompatible Symfony version on PHP 8.3.

### Changes
- **pecl → [docker-php-extension-installer](https://github.com/mlocati/docker-php-extension-installer)** for the `mongodb` extension and Composer. `pecl` is officially deprecated by the MongoDB PHP driver. Build deps are now auto-removed.
- **Unify `mongodb` on `2.3.3`** across all three images (was 1.17.0 / 1.21.0 / 2.1.2).
- **Pin 8.5 to stable `php:8.5-alpine`** (was `8.5.0rc3-alpine` which is unavailable) — the suite now runs on PHP 8.5.
- **Drop `--ignore-platform-reqs`**: on the PHP 8.3 image it let Composer install Symfony 8.x (which requires `php >=8.4.1`) instead of the highest compatible release, so the whole suite failed to load with a `ParseError` on Symfony's property-hook syntax. Without the flag, PHP 8.3 resolves Symfony 7.4 and the suite passes. `composer check-platform-reqs` is green on all three images, so the flag was only bypassing the PHP version constraint — no required extension is missing.
- **Add `.dockerignore`** so a `vendor/` built on the developer's machine is no longer copied into the Linux image.
- **BuildKit cache mount** for Composer's download cache (replaces `composer clear-cache`): fast rebuilds without freezing dependency resolution.

### Results

| Metric | PHP 8.3 | PHP 8.4 | PHP 8.5 |
|---|---|---|---|
| Image size before | 498 MB | 503 MB | 529 MB |
| Image size after | **190 MB** | **194 MB** | **221 MB** |
| Reduction | −62% | −61% | −58% |
| Tests | ✅ 356 | ✅ 356 | ✅ 356 (was broken) |

| Build metric | Before | After |
|---|---|---|
| Build context transferred | ~50 MB | **17.8 kB** |
| Composer re-download on rebuild | full | **0** (cache mount) |
| Composer step (warm cache) | 5.0 s | **2.4 s** |

All 356 tests pass on PHP 8.3, 8.4 and 8.5.
