### PR TITLE
Fix property namer empty check for "0" values

### DIFF
--- a/src/Naming/PropertyDirectoryNamer.php
+++ b/src/Naming/PropertyDirectoryNamer.php
@@ -56,7 +56,7 @@ final class PropertyDirectoryNamer implements DirectoryNamerInterface, Configura
             throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s does not exist.', $this->propertyPath), $e->getCode(), $e);
         }
 
-        if (empty($name)) {
+        if (null === $name || '' === $name) {
             throw new NameGenerationException(\sprintf('Directory name could not be generated: property %s is empty.', $this->propertyPath));
         }
 

--- a/src/Naming/PropertyNamer.php
+++ b/src/Naming/PropertyNamer.php
@@ -58,7 +58,7 @@ final class PropertyNamer implements NamerInterface, ConfigurableInterface
             throw new NameGenerationException(\sprintf('File name could not be generated: property %s does not exist.', $this->propertyPath), $e->getCode(), $e);
         }
 
-        if (empty($name)) {
+        if (null === $name || '' === $name) {
             throw new NameGenerationException(\sprintf('File name could not be generated: property %s is empty.', $this->propertyPath));
         }
 

--- a/tests/Naming/PropertyDirectoryNamerTest.php
+++ b/tests/Naming/PropertyDirectoryNamerTest.php
@@ -44,6 +44,19 @@ class PropertyDirectoryNamerTest extends TestCase
         self::assertSame($expectedDirectoryName, $namer->directoryName($entity, $mapping));
     }
 
+    public function testDirectoryNameAcceptsZeroAsName(): void
+    {
+        $entity = new DummyEntity();
+        $entity->someProperty = '0';
+
+        $mapping = $this->getPropertyMappingMock();
+
+        $namer = new PropertyDirectoryNamer(null, $this->getTransliterator());
+        $namer->configure(['property' => 'someProperty']);
+
+        self::assertSame('0', $namer->directoryName($entity, $mapping));
+    }
+
     public function testNameFailsIfThePropertyDoesNotExist(): void
     {
         $this->expectException(\Vich\UploaderBundle\Exception\NameGenerationException::class);

--- a/tests/Naming/PropertyNamerTest.php
+++ b/tests/Naming/PropertyNamerTest.php
@@ -59,6 +59,31 @@ class PropertyNamerTest extends TestCase
         self::assertSame($expectedFileName, $namer->name($entity, $mapping));
     }
 
+    public function testNameAcceptsZeroAsName(): void
+    {
+        $entity = new DummyEntity();
+        $entity->someProperty = '0';
+
+        $file = $this->getUploadedFileMock();
+        $file
+            ->method('getClientOriginalName')
+            ->willReturn('some-file-name');
+        $file
+            ->method('guessExtension')
+            ->willReturn(null);
+
+        $mapping = $this->getPropertyMappingMock();
+        $mapping->expects(self::once())
+            ->method('getFile')
+            ->with($entity)
+            ->willReturn($file);
+
+        $namer = new PropertyNamer($this->getTransliterator());
+        $namer->configure(['property' => 'someProperty']);
+
+        self::assertSame('0', $namer->name($entity, $mapping));
+    }
+
     public function testNameFailsIfThePropertyDoesNotExist(): void
     {
         $this->expectException(NameGenerationException::class);


### PR DESCRIPTION
Replace empty() with strict null/empty-string checks in PropertyNamer and PropertyDirectoryNamer so numeric names like "0" are accepted.

Fix #1584 