### PR TITLE
Initialize nullable promoted file properties on load

### DIFF
--- a/src/Injector/FileInjector.php
+++ b/src/Injector/FileInjector.php
@@ -23,6 +23,8 @@ final class FileInjector implements FileInjectorInterface
 
         if (null !== $path) {
             $mapping->setFile($obj, new File($path, false));
+        } else {
+            $mapping->setFile($obj, null);
         }
     }
 }

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -69,7 +69,7 @@ final class PropertyMapping
     /**
      * Modifies the file property value for the given object.
      *
-     * @param object   $obj  The object
+     * @param object    $obj  The object
      * @param File|null $file The new file
      *
      * @throws \InvalidArgumentException

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -70,12 +70,12 @@ final class PropertyMapping
      * Modifies the file property value for the given object.
      *
      * @param object $obj  The object
-     * @param File   $file The new file
+     * @param File|null $file The new file
      *
      * @throws \InvalidArgumentException
      * @throws \TypeError
      */
-    public function setFile(object $obj, File $file): void
+    public function setFile(object $obj, ?File $file): void
     {
         $this->writeProperty($obj, 'file', $file);
     }

--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -69,7 +69,7 @@ final class PropertyMapping
     /**
      * Modifies the file property value for the given object.
      *
-     * @param object $obj  The object
+     * @param object   $obj  The object
      * @param File|null $file The new file
      *
      * @throws \InvalidArgumentException

--- a/tests/Fixtures/PromotedFileEntity.php
+++ b/tests/Fixtures/PromotedFileEntity.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\File\File;
+
+final class PromotedFileEntity
+{
+    public function __construct(private ?File $file = null)
+    {
+    }
+
+    public function getFile(): ?File
+    {
+        return $this->file;
+    }
+
+    public function setFile(?File $file): void
+    {
+        $this->file = $file;
+    }
+}

--- a/tests/Injector/FileInjectorTest.php
+++ b/tests/Injector/FileInjectorTest.php
@@ -4,8 +4,10 @@ namespace Vich\UploaderBundle\Tests\Injector;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use Vich\UploaderBundle\Injector\FileInjector;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Storage\GaufretteStorage;
 use Vich\UploaderBundle\Tests\DummyEntity;
+use Vich\UploaderBundle\Tests\Fixtures\PromotedFileEntity;
 use Vich\UploaderBundle\Tests\TestCase;
 
 /**
@@ -65,5 +67,22 @@ final class FileInjectorTest extends TestCase
 
         $inject = new FileInjector($this->storage);
         $inject->injectFile($obj, $fileMapping);
+    }
+
+    public function testInitializesNullablePromotedFilePropertyWhenFileNamePropertyIsNull(): void
+    {
+        $obj = (new \ReflectionClass(PromotedFileEntity::class))->newInstanceWithoutConstructor();
+        $mapping = new PropertyMapping('file', 'file_name');
+
+        $this->storage
+            ->expects(self::once())
+            ->method('resolvePath')
+            ->with($obj, 'file')
+            ->willReturn(null);
+
+        $inject = new FileInjector($this->storage);
+        $inject->injectFile($obj, $mapping);
+
+        self::assertNull($obj->getFile());
     }
 }


### PR DESCRIPTION
Fixes #1411

When a nullable uploadable field is constructor-promoted, Doctrine can hydrate the entity without running its constructor. If no stored filename exists, the injector previously skipped the setter, leaving the promoted property uninitialized and causing an UninitializedPropertyException on access.

This change explicitly writes null on the no-path branch and allows PropertyMapping::setFile() to accept nullable files. The regression test exercises an instance created without its constructor and verifies the getter returns null after injection.

Verification:
- git diff --check passed
- PHPUnit could not be run because Docker Desktop's Linux engine is unavailable in this environment

The scope follows the solution proposed by the issue reporter and the collaborator response there: https://github.com/dustin10/VichUploaderBundle/issues/1411#issuecomment-1821309747