### PR TITLE
Fix unrelated attribute instantiation

### DIFF
--- a/src/Metadata/Driver/AttributeReader.php
+++ b/src/Metadata/Driver/AttributeReader.php
@@ -119,13 +119,12 @@ final class AttributeReader
 
         foreach ($attributes as $attribute) {
             $attributeName = $attribute->getName();
-            $instance = $attribute->newInstance();
 
-            if (!$instance instanceof AttributeInterface) {
+            if (!\is_a($attributeName, AttributeInterface::class, true)) {
                 continue;
             }
 
-            $instances[$attributeName] = $instance;
+            $instances[$attributeName] = $attribute->newInstance();
         }
 
         return $instances;

--- a/tests/Metadata/Driver/AttributeReaderTest.php
+++ b/tests/Metadata/Driver/AttributeReaderTest.php
@@ -102,6 +102,17 @@ final class AttributeReaderTest extends TestCase
         );
     }
 
+    public function testDoesNotInstantiateUnrelatedAttributes(): void
+    {
+        $reader = new AttributeReader();
+        $class = new \ReflectionClass(EntityWithUnrelatedAttribute::class);
+
+        $this->assertEquals(
+            [AttributeUploadable::class => new AttributeUploadable()],
+            $reader->getClassAttributes($class)
+        );
+    }
+
     /**
      * Test new Attribute namespace methods work correctly.
      */
@@ -155,5 +166,20 @@ final class AttributeReaderTest extends TestCase
             new UploadableField('dummy_file', 'fileName'),
             $reader->getPropertyAttribute($property, UploadableField::class)
         );
+    }
+}
+
+#[AttributeUploadable]
+#[UnrelatedAttribute]
+final class EntityWithUnrelatedAttribute
+{
+}
+
+#[\Attribute]
+final class UnrelatedAttribute
+{
+    public function __construct()
+    {
+        throw new \LogicException();
     }
 }


### PR DESCRIPTION
## Summary

Ignore unrelated PHP attributes before instantiating upload mapping attributes.

The reader previously instantiated every reflected attribute and only then checked whether it implemented `AttributeInterface`. Unrelated attributes could therefore throw or trigger side effects while Vich metadata was read.

Fixes #1442.

## Test verification (RED → GREEN)

Tested with PHP 8.3 in the repository Docker environment.

RED on unmodified `origin/master` with only the regression test:

```text
LogicException
tests/Metadata/Driver/AttributeReaderTest.php:183
src/Metadata/Driver/AttributeReader.php:122
ERRORS!
Tests: 9, Assertions: 12, Errors: 1.
```

GREEN with the fix:

```text
OK (9 tests, 13 assertions)
```

Full local CI replay was iso-or-better than the upstream baseline: both runs retain the same pre-existing `GaufretteStorageTest` error; PHPStan and PHP-CS-Fixer pass. Changed executable-line coverage: `2/2` (100%).
