### PR TITLE
Normalize URI path separators

### DIFF
--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -17,6 +17,8 @@ use Vich\UploaderBundle\Mapping\PropertyMappingFactory;
  */
 abstract class AbstractStorage implements StorageInterface
 {
+    private const URI_SEPARATOR = '/';
+
     public function __construct(protected readonly PropertyMappingFactory $factory)
     {
     }
@@ -109,9 +111,10 @@ abstract class AbstractStorage implements StorageInterface
         }
 
         $dir = $mapping->getUploadDir($obj);
-        $path = (\is_string($dir) && '' !== $dir) ? $dir.'/'.$filename : $filename;
+        $dir = \is_string($dir) ? \trim($dir, self::URI_SEPARATOR) : $dir;
+        $path = (\is_string($dir) && '' !== $dir) ? $dir.self::URI_SEPARATOR.$filename : $filename;
 
-        return $mapping->getUriPrefix().'/'.$path;
+        return \rtrim($mapping->getUriPrefix(), self::URI_SEPARATOR).self::URI_SEPARATOR.$path;
     }
 
     public function resolveStream(object|array $obj, ?string $fieldName = null, ?string $className = null)

--- a/src/Storage/FileSystemStorage.php
+++ b/src/Storage/FileSystemStorage.php
@@ -13,6 +13,8 @@ use Vich\UploaderBundle\Mapping\PropertyMapping;
  */
 final class FileSystemStorage extends AbstractStorage
 {
+    private const URI_SEPARATOR = '/';
+
     protected function doUpload(PropertyMapping $mapping, File $file, ?string $dir, string $name): ?File
     {
         $uploadDir = $mapping->getUploadDestination().\DIRECTORY_SEPARATOR.$dir;
@@ -69,10 +71,10 @@ final class FileSystemStorage extends AbstractStorage
             return null;
         }
 
-        $uploadDir = $this->convertWindowsDirectorySeparator($mapping->getUploadDir($obj));
-        $uploadDir = ('' !== $uploadDir) ? $uploadDir.'/' : '';
+        $uploadDir = \trim($this->convertWindowsDirectorySeparator($mapping->getUploadDir($obj)), self::URI_SEPARATOR);
+        $uploadDir = ('' !== $uploadDir) ? $uploadDir.self::URI_SEPARATOR : '';
 
-        return \sprintf('%s/%s', $mapping->getUriPrefix(), $uploadDir.$name);
+        return \rtrim($mapping->getUriPrefix(), self::URI_SEPARATOR).self::URI_SEPARATOR.$uploadDir.$name;
     }
 
     private function convertWindowsDirectorySeparator(string $string): string

--- a/tests/Storage/FileSystemStorageTest.php
+++ b/tests/Storage/FileSystemStorageTest.php
@@ -249,6 +249,10 @@ final class FileSystemStorageTest extends StorageTestCase
                 '/uploads/dir/sub-dir/file.txt',
             ],
             [
+                '/dir/sub-dir',
+                '/uploads/dir/sub-dir/file.txt',
+            ],
+            [
                 'dir\\sub-dir',
                 '/uploads/dir/sub-dir/file.txt',
             ],

--- a/tests/Storage/Flysystem/PsrContainerFlysystemStorageTest.php
+++ b/tests/Storage/Flysystem/PsrContainerFlysystemStorageTest.php
@@ -10,6 +10,34 @@ use Psr\Container\ContainerInterface;
  */
 final class PsrContainerFlysystemStorageTest extends AbstractFlysystemStorageTestCase
 {
+    public function testResolveUriWithAbsoluteDirectory(): void
+    {
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUriPrefix')
+            ->willReturn('');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getUploadDir')
+            ->willReturn('/dir');
+
+        $this->mapping
+            ->expects(self::once())
+            ->method('getFileName')
+            ->willReturn('file.txt');
+
+        $this->factory
+            ->expects(self::once())
+            ->method('fromField')
+            ->with($this->object, 'file_field')
+            ->willReturn($this->mapping);
+
+        $path = $this->getStorage()->resolveUri($this->object, 'file_field');
+
+        self::assertEquals('/dir/file.txt', $path);
+    }
+
     protected function createRegistry(FilesystemOperator $filesystem): ContainerInterface
     {
         $locator = $this->createMock(ContainerInterface::class);


### PR DESCRIPTION
## Summary

Normalize directory and URI-prefix boundary separators when resolving file URIs.

Directory namers may return paths with leading or trailing slashes. Both the shared storage resolver used by Flysystem and the filesystem-specific resolver previously added another separator unconditionally, producing paths such as `//dir/file.txt`.

Fixes #1378.

## Test verification (RED → GREEN)

Tested with PHP 8.3 in the repository Docker environment.

RED on unmodified `origin/master` with only the regression tests:

```text
Expected: /uploads/dir/sub-dir/file.txt
Actual:   /uploads//dir/sub-dir/file.txt

Expected: /dir/file.txt
Actual:   //dir/file.txt

FAILURES!
Tests: 61, Assertions: 220, Failures: 2.
```

GREEN with the fix:

```text
Tests: 61, Assertions: 224, Skipped: 18.
```

Full local CI replay was iso-or-better than the upstream baseline: both runs retain the same pre-existing `GaufretteStorageTest` error and the same 32 skipped/15 risky tests; PHPStan and PHP-CS-Fixer pass. Changed executable-line coverage: `6/6` (100%).
