### PR TITLE
🐛 Do not erase file properties when the entity is being removed

### DIFF
--- a/src/Mapping/PropertyMapping.php
+++ b/src/Mapping/PropertyMapping.php
@@ -5,6 +5,7 @@ namespace Vich\UploaderBundle\Mapping;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
 use Vich\UploaderBundle\Naming\NamerInterface;
 use Vich\UploaderBundle\Util\PropertyPathUtils;
@@ -16,6 +17,12 @@ use Vich\UploaderBundle\Util\PropertyPathUtils;
  */
 final class PropertyMapping
 {
+    private const UNKNOWN_PROPERTY_MESSAGE = 'Unknown property %s';
+    private const SETTER_PREFIX = 'set';
+    private const PROPERTY_WORD_SEPARATORS = ['_', '-'];
+    private const PROPERTY_WORD_SEPARATOR = ' ';
+    private const EMPTY_STRING = '';
+
     private ?NamerInterface $namer = null;
 
     private ?DirectoryNamerInterface $directoryNamer = null;
@@ -122,8 +129,84 @@ final class PropertyMapping
         }
 
         foreach (['name', 'size', 'mimeType', 'originalName', 'dimensions'] as $property) {
-            $this->writeProperty($obj, $property, null);
+            // Only null out properties that actually accept null. A non-nullable typed
+            // property (or setter) would raise a \TypeError here, e.g. when the whole
+            // entity is being removed (see #1117).
+            if ($this->isNullable($obj, $property)) {
+                $this->writeProperty($obj, $property, null);
+            }
         }
+    }
+
+    /**
+     * Tells whether the mapped property can be set to null, i.e. whether erasing it is safe.
+     *
+     * A property is considered non-nullable when the write path used by the property
+     * accessor (a typed setter, or the typed property itself) does not allow null.
+     * Unconfigured, dynamic or non-introspectable targets are treated as nullable so the
+     * previous behavior is preserved.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function isNullable(object $obj, string $property): bool
+    {
+        if (!\array_key_exists($property, $this->propertyPaths)) {
+            throw new \InvalidArgumentException(\sprintf(self::UNKNOWN_PROPERTY_MESSAGE, $property));
+        }
+
+        if (!$this->propertyPaths[$property]) {
+            // not configured: writeProperty() is a no-op
+            return true;
+        }
+
+        $propertyPath = new PropertyPath(PropertyPathUtils::fixPropertyPath($obj, $this->propertyPaths[$property]));
+        $lastIndex = $propertyPath->getLength() - 1;
+
+        if ($propertyPath->isIndex($lastIndex)) {
+            // writing into an array offset: no scalar type to violate
+            return true;
+        }
+
+        $target = $obj;
+        if ($lastIndex > 0) {
+            $target = $this->getAccessor()->getValue($obj, $propertyPath->getParent());
+        }
+
+        if (!\is_object($target)) {
+            return true;
+        }
+
+        return $this->acceptsNull($target, (string) $propertyPath->getElement($lastIndex));
+    }
+
+    private function acceptsNull(object $target, string $name): bool
+    {
+        // Mirror the property accessor write path: a public camelized setter first,
+        // then a public property. Anything else (magic __set, dynamic property) has no
+        // static type constraint to violate.
+        $setter = self::SETTER_PREFIX.self::camelize($name);
+        if (\method_exists($target, $setter) && ($method = new \ReflectionMethod($target, $setter))->isPublic()) {
+            $type = ($method->getParameters()[0] ?? null)?->getType();
+
+            return null === $type || $type->allowsNull();
+        }
+
+        if (\property_exists($target, $name) && ($property = new \ReflectionProperty($target, $name))->isPublic()) {
+            $type = $property->getType();
+
+            return null === $type || $type->allowsNull();
+        }
+
+        return true;
+    }
+
+    private static function camelize(string $string): string
+    {
+        return \str_replace(
+            self::PROPERTY_WORD_SEPARATOR,
+            self::EMPTY_STRING,
+            \ucwords(\str_replace(self::PROPERTY_WORD_SEPARATORS, self::PROPERTY_WORD_SEPARATOR, $string))
+        );
     }
 
     /**
@@ -139,7 +222,7 @@ final class PropertyMapping
     public function readProperty(object|array $obj, string $property): mixed
     {
         if (!\array_key_exists($property, $this->propertyPaths)) {
-            throw new \InvalidArgumentException(\sprintf('Unknown property %s', $property));
+            throw new \InvalidArgumentException(\sprintf(self::UNKNOWN_PROPERTY_MESSAGE, $property));
         }
 
         if (!$this->propertyPaths[$property]) {
@@ -167,7 +250,7 @@ final class PropertyMapping
     public function writeProperty(object $obj, string $property, mixed $value): void
     {
         if (!\array_key_exists($property, $this->propertyPaths)) {
-            throw new \InvalidArgumentException(\sprintf('Unknown property %s', $property));
+            throw new \InvalidArgumentException(\sprintf(self::UNKNOWN_PROPERTY_MESSAGE, $property));
         }
 
         if (!$this->propertyPaths[$property]) {

--- a/tests/Fixtures/TestBundle/src/Entity/NotNullableArticle.php
+++ b/tests/Fixtures/TestBundle/src/Entity/NotNullableArticle.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Vich\TestBundle\Entity;
+
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
+
+/**
+ * Entity whose file name is a non-nullable property, like the media object described in #1117.
+ */
+#[Vich\Uploadable]
+class NotNullableArticle
+{
+    #[Vich\UploadableField(mapping: 'dummy_image', fileNameProperty: 'imageName', size: 'sizeField')]
+    protected ?object $image = null;
+
+    protected string $imageName = '';
+
+    protected ?string $sizeField = null;
+
+    // Non-nullable, written directly by the property accessor (no setter).
+    public int $publicSize = 0;
+
+    public function getImage(): ?object
+    {
+        return $this->image;
+    }
+
+    public function setImage(?object $image): void
+    {
+        $this->image = $image;
+    }
+
+    public function getImageName(): string
+    {
+        return $this->imageName;
+    }
+
+    public function setImageName(string $imageName): void
+    {
+        $this->imageName = $imageName;
+    }
+
+    public function getSizeField(): ?string
+    {
+        return $this->sizeField;
+    }
+
+    public function setSizeField(?string $sizeField): void
+    {
+        $this->sizeField = $sizeField;
+    }
+}

--- a/tests/Mapping/PropertyMappingTest.php
+++ b/tests/Mapping/PropertyMappingTest.php
@@ -218,7 +218,7 @@ class PropertyMappingTest extends TestCase
         $arrayOffset = new PropertyMapping('image', '[imageName]');
         self::assertTrue($arrayOffset->isNullable(new \ArrayObject(), 'name'));
 
-        $nestedTarget = new class {
+        $nestedTarget = new class() {
             public ?object $metadata = null;
         };
         $nestedProperty = new PropertyMapping('image', 'metadata.imageName');

--- a/tests/Mapping/PropertyMappingTest.php
+++ b/tests/Mapping/PropertyMappingTest.php
@@ -4,6 +4,7 @@ namespace Vich\UploaderBundle\Tests\Mapping;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Vich\TestBundle\Entity\Article;
+use Vich\TestBundle\Entity\NotNullableArticle;
 use Vich\TestBundle\Naming\DummyNamer;
 use Vich\UploaderBundle\Mapping\PropertyMapping;
 use Vich\UploaderBundle\Naming\ConfigurableDirectoryNamer;
@@ -157,6 +158,74 @@ class PropertyMappingTest extends TestCase
         self::assertNull($object->getOriginalNameField());
         self::assertNull($object->getMimeTypeField());
         self::assertNull($object->getSizeField());
+    }
+
+    public function testEraseKeepsNonNullableProperties(): void
+    {
+        $object = new NotNullableArticle();
+        $object->setImageName('generated.jpeg');
+        $object->setSizeField('100');
+
+        $prop = new PropertyMapping('image', 'imageName', ['size' => 'sizeField']);
+
+        // The file name property is non-nullable: erasing must skip it (would raise a
+        // \TypeError otherwise, see #1117) while still erasing the nullable size property.
+        $prop->erase($object);
+
+        self::assertSame('generated.jpeg', $object->getImageName());
+        self::assertNull($object->getSizeField());
+    }
+
+    public function testIsNullable(): void
+    {
+        $prop = new PropertyMapping('image', 'imageName', ['size' => 'sizeField']);
+
+        // Nullable setter/property on Article.
+        self::assertTrue($prop->isNullable(new Article(), 'name'));
+        self::assertTrue($prop->isNullable(new Article(), 'size'));
+
+        // Non-nullable file name, nullable size on NotNullableArticle.
+        self::assertFalse($prop->isNullable(new NotNullableArticle(), 'name'));
+        self::assertTrue($prop->isNullable(new NotNullableArticle(), 'size'));
+
+        // Unconfigured property path is treated as nullable (write is a no-op).
+        self::assertTrue($prop->isNullable(new Article(), 'mimeType'));
+    }
+
+    public function testIsNullableMatchesTheAccessorWritePath(): void
+    {
+        // Snake_case path: the accessor camelizes it to setImageName(string), non-nullable.
+        $snakeCased = new PropertyMapping('image', 'image_name');
+        self::assertFalse($snakeCased->isNullable(new NotNullableArticle(), 'name'));
+
+        // Non-nullable public property written directly (no setter).
+        $publicProperty = new PropertyMapping('image', 'imageName', ['size' => 'publicSize']);
+        self::assertFalse($publicProperty->isNullable(new NotNullableArticle(), 'size'));
+    }
+
+    public function testIsNullableRejectsUnknownMappingProperty(): void
+    {
+        $prop = new PropertyMapping('image', 'imageName');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown property unused');
+
+        $prop->isNullable(new Article(), 'unused');
+    }
+
+    public function testIsNullableTreatsNonTypedWriteTargetsAsNullable(): void
+    {
+        $arrayOffset = new PropertyMapping('image', '[imageName]');
+        self::assertTrue($arrayOffset->isNullable(new \ArrayObject(), 'name'));
+
+        $nestedTarget = new class {
+            public ?object $metadata = null;
+        };
+        $nestedProperty = new PropertyMapping('image', 'metadata.imageName');
+        self::assertTrue($nestedProperty->isNullable($nestedTarget, 'name'));
+
+        $dynamicProperty = new PropertyMapping('image', 'imageName');
+        self::assertTrue($dynamicProperty->isNullable(new \stdClass(), 'name'));
     }
 
     public function testWithArray(): void


### PR DESCRIPTION
### Failing Test

| Q | A |
| --- | --- |
| BC Break | no |
| Version | 2.x (master) |

#### Summary

Fixes #1117.

`PropertyMapping::erase()` resets mapped file properties to `null`. When a mapped target is non-nullable, such as `setFilename(string $filename)` or a public typed property, Symfony's property accessor raises a `TypeError`.

#### Change

Add `PropertyMapping::isNullable()` and use it to erase only mapped targets that can accept `null`. The check follows the property accessor's write path: a public camelized setter first, then a public property. Unconfigured, indexed, dynamic, or otherwise non-introspectable targets retain the previous behavior.

This keeps property erasure generic, including during entity deletion, while avoiding invalid null writes to non-nullable targets.

#### Test verification (RED → GREEN)

On unmodified `master` with the regression tests applied:

```text
4 errors, 1 failure across 18 focused tests
```

With the fix:

```text
18 focused tests passed
```

The full PHP 8.3 local CI replay is iso-baseline: `master` ran 348 tests and this branch ran 353 tests, with identical counts of 1 deprecation, 132 notices, 32 skipped tests, and 15 risky tests; neither run had failures.

PHP-CS-Fixer verification for the review follow-up: 1 fixable file before → 0 fixable files after.
