### PR TITLE
Give each mapping its own namer configuration

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,10 @@
+# Upgrading from v3.0 to v3.1
+
+## Deprecations
+
+* `ConfigurableInterface` is deprecated in favor of `ImmutableConfigurableInterface`, which declares `withOptions(array $options): static` instead of `configure(array $options): void`. Namer services are shared, so configuring one in place makes every mapping observe the options of the last one resolved. `withOptions()` must return a new instance with independent mutable configuration, preserving service defaults; it is called for every configurable namer, including those inside chains and mappings without options. `ConfigurableNamerTrait` implements it when a shallow clone is enough; see the [custom namer guide](docs/file_namer/howto/create_a_custom_file_namer.md#configurable-custom-namer).
+* Namers implementing only `ConfigurableInterface` keep working, without configuration isolation, until its removal in 4.0. A `configure()` method is still usable for service-level defaults.
+
 # Upgrading from v2.9 to v3.0
 
 ## Breaking Changes

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/config": "^6.4 || ^7.4 || ^8.0",
         "symfony/console": "^6.4 || ^7.4 || ^8.0",
         "symfony/dependency-injection": "^6.4 || ^7.4 || ^8.0",
+        "symfony/deprecation-contracts": "^3.0",
         "symfony/event-dispatcher-contracts": "^3.1",
         "symfony/http-foundation": "^6.4 || ^7.4 || ^8.0",
         "symfony/http-kernel": "^6.4 || ^7.4 || ^8.0",

--- a/docs/directory_namer/howto/create_a_custom_directory_namer.md
+++ b/docs/directory_namer/howto/create_a_custom_directory_namer.md
@@ -20,6 +20,12 @@ vich_uploader:
             directory_namer: my.directory_namer.product
 ```
 
+## Configurable directory namers
+
+To accept mapping options, also implement `ImmutableConfigurableInterface`. Directory namers use the
+same [`withOptions()` contract and trait](../../file_namer/howto/create_a_custom_file_namer.md#configurable-custom-namer)
+as file namers. This also applies when your namer is used inside a `ChainDirectoryNamer`.
+
 ## That was it!
 
 Check out the docs for information on how to use the bundle! [Return to the

--- a/docs/file_namer/howto/create_a_custom_file_namer.md
+++ b/docs/file_namer/howto/create_a_custom_file_namer.md
@@ -39,7 +39,7 @@ class MyNamer implements NamerInterface
 ## Configurable Custom Namer
 
 If you want your namer to support configuration options (including the `namer_keep_extension` option),
-implement the `Vich\UploaderBundle\Naming\ConfigurableInterface`:
+implement the `Vich\UploaderBundle\Naming\ImmutableConfigurableInterface`:
 
 ```php
 <?php
@@ -47,11 +47,12 @@ implement the `Vich\UploaderBundle\Naming\ConfigurableInterface`:
 namespace App\Naming;
 
 use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
-use Vich\UploaderBundle\Naming\ConfigurableInterface;
+use Vich\UploaderBundle\Naming\ImmutableConfigurableInterface;
 use Vich\UploaderBundle\Naming\NamerInterface;
 
-class MyConfigurableNamer implements NamerInterface, ConfigurableInterface
+class MyConfigurableNamer implements NamerInterface, ImmutableConfigurableInterface
 {
+    use \Vich\UploaderBundle\Naming\ConfigurableNamerTrait;
     use \Vich\UploaderBundle\Naming\Polyfill\FileExtensionTrait;
 
     private bool $keepExtension = false;
@@ -74,6 +75,23 @@ class MyConfigurableNamer implements NamerInterface, ConfigurableInterface
     }
 }
 ```
+
+`withOptions()` is the only method the interface declares. The bundle calls it for each mapping,
+including mappings without options, to get a separate configured instance. `ConfigurableNamerTrait`
+implements it by cloning the service and calling `configure()` on the copy; that method is no
+longer required, but stays useful for service-level defaults.
+
+The trait fits this example's scalar properties. Copy mutable configuration objects in
+`__clone()`, or implement `withOptions()` yourself — note that a `readonly` property does not make
+its contents immutable, and a service that cannot be cloned can build a new instance instead.
+Decorators must also copy the inner namer, e.g. `$this->inner->withOptions($options)`. Always
+return a new instance, leaving the source and earlier copies untouched: returning `$this` throws
+a `LogicException`.
+
+The older `ConfigurableInterface`, declaring `configure(array $options): void`, is deprecated
+since 3.1 and will be removed in 4.0. Namers implementing only that interface still get their
+options, but the bundle configures the shared service itself, so every mapping using it ends up
+with the options of the last one resolved.
 
 With a configurable namer, you can use options in your configuration:
 

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -149,7 +149,7 @@ $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile($filePat
 $entity->setFile( $uploadedFile );
 ```
 
-Be aware that these files will be _moved_ to the designated location by VichUploader, so if you want to keep the
+Be aware that these files will be *moved* to the designated location by VichUploader, so if you want to keep the
 original files intact, copy them to a temporary location first. If you plan to upload the same file multiple times,
 you will need multiple different locations, otherwise the handler on the first VichUploader field will move the file
 and accessing that file will fail on subsequent tries.

--- a/docs/namers.md
+++ b/docs/namers.md
@@ -270,6 +270,10 @@ vich_uploader:
                     separator: '/'  # optional, defaults to '/'
 ```
 
+Entries can be chains themselves, and the same service can appear several times with different
+options: each entry keeps its own options and children. An explicit `namers: []` creates an
+empty chain; omitting `namers` keeps the children configured on the service.
+
 This configuration will create directories like `2024/01/electronics` for a product in the
 "electronics" category uploaded in January 2024.
 
@@ -283,6 +287,17 @@ the `upload_destination` configuration option.
 ### How-tos
 
 * [Writing a custom directory namer](directory_namer/howto/create_a_custom_directory_namer.md)
+
+## Configuration isolation
+
+Namers implementing `ImmutableConfigurableInterface` get their own configured copy per mapping,
+built-in and custom alike, including entries in a chain and mappings without options. Reusing
+such a service with different options leaves the other mappings untouched, whatever the
+resolution order. See the
+[`withOptions()` contract](file_namer/howto/create_a_custom_file_namer.md#configurable-custom-namer).
+
+Namers implementing only the deprecated `ConfigurableInterface` are still configured in place:
+every mapping using the service gets the options of the last one resolved.
 
 ## That was it!
 

--- a/src/Mapping/PropertyMappingResolver.php
+++ b/src/Mapping/PropertyMappingResolver.php
@@ -6,6 +6,7 @@ use Vich\UploaderBundle\Exception\MappingNotFoundException;
 use Vich\UploaderBundle\Naming\ChainDirectoryNamer;
 use Vich\UploaderBundle\Naming\ConfigurableInterface;
 use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
+use Vich\UploaderBundle\Naming\ImmutableConfigurableInterface;
 use Vich\UploaderBundle\Naming\NamerInterface;
 use Vich\UploaderBundle\Util\ClassUtils;
 
@@ -51,51 +52,85 @@ final readonly class PropertyMappingResolver implements PropertyMappingResolverI
 
             // Handle namer_keep_extension option
             if (isset($config['namer_keep_extension']) && $config['namer_keep_extension']) {
-                if (!$namer instanceof ConfigurableInterface) {
-                    throw new \LogicException(\sprintf('Namer %s does not implement ConfigurableInterface but namer_keep_extension option is set to true in mapping "%s". Either make the namer implement ConfigurableInterface or remove the namer_keep_extension option.', $namerConfig['service'], $mappingData['mapping']));
+                if (!$namer instanceof ImmutableConfigurableInterface && !$namer instanceof ConfigurableInterface) {
+                    throw new \LogicException(\sprintf('Namer %s does not implement ImmutableConfigurableInterface but namer_keep_extension option is set to true in mapping "%s". Either make the namer implement ImmutableConfigurableInterface or remove the namer_keep_extension option.', $namerConfig['service'], $mappingData['mapping']));
                 }
                 $options['keep_extension'] = $config['namer_keep_extension'];
             }
 
-            if (!empty($options)) {
-                if (!$namer instanceof ConfigurableInterface) {
-                    throw new \LogicException(\sprintf('Namer %s can not receive options as it does not implement ConfigurableInterface.', $namerConfig['service']));
-                }
-                $namer->configure($options);
-            }
+            $namer = $this->configureNamer($namer, $options, $namerConfig['service']);
 
             $mapping->setNamer($namer);
         }
 
         if (!empty($config['directory_namer']) && null !== $config['directory_namer']['service']) {
-            $namerConfig = $config['directory_namer'];
-            $namer = $this->getDirectoryNamer($mappingData['mapping'], $namerConfig['service']);
-
-            // Handle ChainDirectoryNamer specially - resolve nested namers
-            if ($namer instanceof ChainDirectoryNamer && !empty($namerConfig['options']['namers'])) {
-                $chainedNamers = [];
-                foreach ($namerConfig['options']['namers'] as $nestedConfig) {
-                    $nestedNamer = $this->getDirectoryNamer($mappingData['mapping'], $nestedConfig['service']);
-                    if (!empty($nestedConfig['options']) && $nestedNamer instanceof ConfigurableInterface) {
-                        $nestedNamer->configure($nestedConfig['options']);
-                    }
-                    $chainedNamers[] = $nestedNamer;
-                }
-                $namer->setNamers($chainedNamers);
-            }
-
-            // Configure the namer itself (e.g., separator option for ChainDirectoryNamer)
-            if (!empty($namerConfig['options'])) {
-                if (!$namer instanceof ConfigurableInterface) {
-                    throw new \LogicException(\sprintf('Namer %s can not receive options as it does not implement ConfigurableInterface.', $namerConfig['service']));
-                }
-                $namer->configure($namerConfig['options']);
-            }
-
-            $mapping->setDirectoryNamer($namer);
+            $mapping->setDirectoryNamer($this->resolveDirectoryNamer($mappingData['mapping'], $config['directory_namer']));
         }
 
         return $mapping;
+    }
+
+    /**
+     * @param array{service: string, options?: array<string, mixed>|null} $config
+     */
+    private function resolveDirectoryNamer(string $mappingName, array $config): DirectoryNamerInterface
+    {
+        $namer = $this->getDirectoryNamer($mappingName, $config['service']);
+        $options = $config['options'] ?? [];
+
+        if ($namer instanceof ChainDirectoryNamer && \array_key_exists('namers', $options)) {
+            if (!\is_array($options['namers'])) {
+                throw new \InvalidArgumentException('The "namers" option of ChainDirectoryNamer must be an array.');
+            }
+            $children = [];
+            foreach ($options['namers'] as $nestedConfig) {
+                if (!\is_array($nestedConfig) || !isset($nestedConfig['service']) || !\is_string($nestedConfig['service'])) {
+                    throw new \InvalidArgumentException('Each chained directory namer must specify a service.');
+                }
+                $children[] = $this->resolveDirectoryNamer($mappingName, $nestedConfig);
+            }
+            $options['namers'] = $children;
+        }
+
+        return $this->configureNamer($namer, $options, $config['service']);
+    }
+
+    /**
+     * @template T of NamerInterface|DirectoryNamerInterface
+     *
+     * @param T                    $namer
+     * @param array<string, mixed> $options
+     *
+     * @return T
+     */
+    private function configureNamer(NamerInterface|DirectoryNamerInterface $namer, array $options, string $service): NamerInterface|DirectoryNamerInterface
+    {
+        if ($namer instanceof ImmutableConfigurableInterface) {
+            $configured = $namer->withOptions($options);
+            if ($configured === $namer) {
+                throw new \LogicException(\sprintf('Namer "%s" must return a new instance from withOptions().', $service));
+            }
+
+            return $configured;
+        }
+
+        // Legacy path: the shared service is configured in place, so every mapping using it ends
+        // up with the options of the last one resolved.
+        if ($namer instanceof ConfigurableInterface) {
+            if ([] !== $options) {
+                trigger_deprecation('vich/uploader-bundle', '3.1', 'Configuring namer "%s" through "%s" is deprecated, implement "%s" instead.', $service, ConfigurableInterface::class, ImmutableConfigurableInterface::class);
+
+                $namer->configure($options);
+            }
+
+            return $namer;
+        }
+
+        if ([] !== $options) {
+            throw new \LogicException(\sprintf('Namer %s can not receive options as it does not implement ImmutableConfigurableInterface.', $service));
+        }
+
+        return $namer;
     }
 
     private function getNamer(string $name, string $service): NamerInterface

--- a/src/Naming/Base64Namer.php
+++ b/src/Naming/Base64Namer.php
@@ -10,8 +10,10 @@ use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
  *
  * @author Keleti Márton <tejes@hac.hu>
  */
-class Base64Namer implements NamerInterface, ConfigurableInterface
+class Base64Namer implements NamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     use Polyfill\FileExtensionTrait;
 
     protected const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_';

--- a/src/Naming/ChainDirectoryNamer.php
+++ b/src/Naming/ChainDirectoryNamer.php
@@ -9,27 +9,58 @@ use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
  *
  * @author Guillaume Sainthillier <guillaume@silarhi.fr>
  */
-final class ChainDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface
+final class ChainDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
     /** @var array<DirectoryNamerInterface> */
     private array $namers = [];
 
     private string $separator = '/';
 
+    public function withOptions(array $options): static
+    {
+        $chain = clone $this;
+        $chain->configure($options);
+
+        // Every child is copied, wherever it comes from: withOptions() is public API and the
+        // children it receives may be shared services, not copies made by the resolver. Children
+        // implementing only the deprecated ConfigurableInterface have no copy contract and stay shared.
+        foreach ($chain->namers as $index => $namer) {
+            if (!$namer instanceof ImmutableConfigurableInterface) {
+                continue;
+            }
+            $configured = $namer->withOptions([]);
+            if ($configured === $namer) {
+                throw new \LogicException(\sprintf('Namer "%s" must return a new instance from withOptions().', $namer::class));
+            }
+            $chain->namers[$index] = $configured;
+        }
+
+        return $chain;
+    }
+
     /**
      * @param array<DirectoryNamerInterface> $namers
      */
     public function setNamers(array $namers): void
     {
+        foreach ($namers as $namer) {
+            if (!$namer instanceof DirectoryNamerInterface) {
+                throw new \InvalidArgumentException('Chained namers must implement DirectoryNamerInterface.');
+            }
+        }
         $this->namers = $namers;
     }
 
     /**
      * @param array $options Options for this namer. The following options are accepted:
+     *                       - namers: resolved directory namer instances
      *                       - separator: the separator between directory names (default: '/')
      */
     public function configure(array $options): void
     {
+        if (\array_key_exists('namers', $options)) {
+            $this->setNamers($options['namers']);
+        }
         if (isset($options['separator'])) {
             $this->separator = (string) $options['separator'];
         }

--- a/src/Naming/ConfigurableDirectoryNamer.php
+++ b/src/Naming/ConfigurableDirectoryNamer.php
@@ -7,8 +7,10 @@ use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
 /**
  * Directory namer that can create subfolder which path is given in the directory namer's options.
  */
-class ConfigurableDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface
+class ConfigurableDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     private string $directoryPath = '';
 
     /**

--- a/src/Naming/ConfigurableInterface.php
+++ b/src/Naming/ConfigurableInterface.php
@@ -8,6 +8,9 @@ namespace Vich\UploaderBundle\Naming;
  * Allows namers to receive configuration options.
  *
  * @author Kévin Gomez <contact@kevingomez.fr>
+ *
+ * @deprecated since 3.1, use {@see ImmutableConfigurableInterface} instead: configuring a shared
+ *             namer service in place gives every mapping the options of the last one resolved.
  */
 interface ConfigurableInterface
 {

--- a/src/Naming/ConfigurableNamerTrait.php
+++ b/src/Naming/ConfigurableNamerTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+/**
+ * Implements configuration copies for namers whose mutable state can be safely cloned.
+ *
+ * Namers holding mutable configuration objects must implement __clone() to copy that state,
+ * or implement withOptions() themselves. Read-only dependencies can remain shared.
+ */
+trait ConfigurableNamerTrait
+{
+    public function withOptions(array $options): static
+    {
+        $namer = clone $this;
+        if ([] !== $options) {
+            $namer->configure($options);
+        }
+
+        return $namer;
+    }
+
+    abstract public function configure(array $options): void;
+}

--- a/src/Naming/CurrentDateTimeDirectoryNamer.php
+++ b/src/Naming/CurrentDateTimeDirectoryNamer.php
@@ -11,8 +11,10 @@ use Vich\UploaderBundle\Util\PropertyPathUtils;
  *
  * @author Vyacheslav Startsev <vyacheslav.startsev@gmail.com>
  */
-final class CurrentDateTimeDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface
+final class CurrentDateTimeDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     private string $dateTimeFormat = 'Y/m/d';
 
     private ?string $dateTimeProperty = null;

--- a/src/Naming/HashNamer.php
+++ b/src/Naming/HashNamer.php
@@ -9,8 +9,10 @@ use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
  *
  * @author Konstantin Myakshin <koc-dp@yandex.ru>
  */
-class HashNamer implements NamerInterface, ConfigurableInterface
+class HashNamer implements NamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     use Polyfill\FileExtensionTrait;
 
     private static ?\Random\Randomizer $randomizer = null;

--- a/src/Naming/ImmutableConfigurableInterface.php
+++ b/src/Naming/ImmutableConfigurableInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Vich\UploaderBundle\Naming;
+
+/**
+ * Allows namers to receive per-mapping configuration options without shared mutable state.
+ *
+ * Namer services are shared: implement this interface to hand out an independent copy per mapping.
+ */
+interface ImmutableConfigurableInterface
+{
+    /**
+     * Returns a new namer with independent mutable configuration, preserving service defaults.
+     *
+     * Neither this instance nor previously returned instances may be modified. This also applies
+     * to mutable configuration stored in dependencies, decorators and nested namers. An empty
+     * array must still return an independent instance with the current configuration.
+     *
+     * @param array<string, mixed> $options
+     */
+    public function withOptions(array $options): static;
+}

--- a/src/Naming/OrignameNamer.php
+++ b/src/Naming/OrignameNamer.php
@@ -10,8 +10,10 @@ use Vich\UploaderBundle\Util\Transliterator;
 /**
  * @author Ivan Borzenkov <ivan.borzenkov@gmail.com>
  */
-final class OrignameNamer implements NamerInterface, ConfigurableInterface
+final class OrignameNamer implements NamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     use Polyfill\FileExtensionTrait;
 
     private bool $transliterate = false;

--- a/src/Naming/PropertyDirectoryNamer.php
+++ b/src/Naming/PropertyDirectoryNamer.php
@@ -14,8 +14,10 @@ use Vich\UploaderBundle\Util\Transliterator;
  *
  * @author Raynald Coupé <raynald@easi-services.fr>
  */
-final class PropertyDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface
+final class PropertyDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     private ?string $propertyPath = null;
 
     private bool $transliterate = false;

--- a/src/Naming/PropertyNamer.php
+++ b/src/Naming/PropertyNamer.php
@@ -11,8 +11,10 @@ use Vich\UploaderBundle\Util\Transliterator;
 /**
  * @author Kévin Gomez <contact@kevingomez.fr>
  */
-final class PropertyNamer implements NamerInterface, ConfigurableInterface
+final class PropertyNamer implements NamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     use Polyfill\FileExtensionTrait;
 
     private string $propertyPath;

--- a/src/Naming/SlugNamer.php
+++ b/src/Naming/SlugNamer.php
@@ -10,8 +10,10 @@ use Vich\UploaderBundle\Util\Transliterator;
  *
  * @author Massimiliano Arione <garakkio@gmail.com>
  */
-final class SlugNamer implements NamerInterface, ConfigurableInterface
+final class SlugNamer implements NamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     use Polyfill\FileExtensionTrait;
 
     private bool $keepExtension = false;

--- a/src/Naming/SmartUniqueNamer.php
+++ b/src/Naming/SmartUniqueNamer.php
@@ -11,8 +11,10 @@ use Vich\UploaderBundle\Util\Transliterator;
  *
  * @author Massimiliano Arione <garakkio@gmail.com>
  */
-final class SmartUniqueNamer implements NamerInterface, ConfigurableInterface
+final class SmartUniqueNamer implements NamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     use Polyfill\FileExtensionTrait;
 
     private bool $keepExtension = false;

--- a/src/Naming/SubdirDirectoryNamer.php
+++ b/src/Naming/SubdirDirectoryNamer.php
@@ -9,8 +9,10 @@ use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
  *
  * @author Konstantin Myakshin <koc-dp@yandex.ru>
  */
-final class SubdirDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface
+final class SubdirDirectoryNamer implements DirectoryNamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     private int $charsPerDir = 2;
 
     private int $dirs = 1;

--- a/src/Naming/UniqidNamer.php
+++ b/src/Naming/UniqidNamer.php
@@ -7,8 +7,10 @@ use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
 /**
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-final class UniqidNamer implements NamerInterface, ConfigurableInterface
+final class UniqidNamer implements NamerInterface, ConfigurableInterface, ImmutableConfigurableInterface
 {
+    use ConfigurableNamerTrait;
+
     use Polyfill\FileExtensionTrait;
 
     private bool $keepExtension = false;

--- a/tests/DependencyInjection/NamerIsolationTest.php
+++ b/tests/DependencyInjection/NamerIsolationTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Vich\UploaderBundle\DependencyInjection\VichUploaderExtension;
+use Vich\UploaderBundle\Mapping\PropertyMappingResolver;
+use Vich\UploaderBundle\Naming\ChainDirectoryNamer;
+use Vich\UploaderBundle\Tests\Fixtures\IsolatedNamer;
+use Vich\UploaderBundle\Tests\Fixtures\IsolatedNamerDecorator;
+use Vich\UploaderBundle\Tests\Fixtures\IsolatedNamerFactory;
+use Vich\UploaderBundle\Tests\TestCase;
+
+final class NamerIsolationTest extends TestCase
+{
+    public static function serviceKinds(): iterable
+    {
+        yield 'regular service' => ['regular'];
+        yield 'singleton factory' => ['factory'];
+        yield 'decorator' => ['decorator'];
+    }
+
+    #[DataProvider('serviceKinds')]
+    public function testCustomServicesWithNestedStateRemainIndependent(string $kind): void
+    {
+        $builder = $this->builder([
+            'configured' => ['namer' => ['service' => 'custom', 'options' => ['prefix' => 'configured']]],
+            'plain' => ['namer' => 'custom'],
+        ]);
+        $builder->register('state', \stdClass::class)->setProperty('prefix', 'service-default');
+        $definition = $builder->register('custom', IsolatedNamer::class)
+            ->setArguments([new Reference('state')])->addTag('vich_uploader.namer')->setPublic(true);
+        if ('factory' === $kind) {
+            $builder->register('source', IsolatedNamer::class)->setArguments([new Reference('state')]);
+            $builder->register('factory', IsolatedNamerFactory::class)->setArguments([new Reference('source')]);
+            $definition->setFactory([new Reference('factory'), 'create'])->setArguments([]);
+        } elseif ('decorator' === $kind) {
+            $builder->register('decorator', IsolatedNamerDecorator::class)
+                ->setDecoratedService('custom')->setArguments([new Reference('decorator.inner')])->setPublic(true);
+        }
+        $container = $this->compile($builder);
+        $resolver = $this->resolver($container);
+        $object = new \stdClass();
+        $plain = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+        $configured = $resolver->resolve($object, 'file', ['mapping' => 'configured']);
+        $plainAgain = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+        $prefix = 'decorator' === $kind ? 'decorated-' : '';
+
+        self::assertNotSame($plain->getNamer(), $configured->getNamer());
+        self::assertNotSame($plain->getNamer(), $plainAgain->getNamer());
+        self::assertSame($prefix.'configured', $configured->getUploadName($object));
+        self::assertSame($prefix.'service-default', $plain->getUploadName($object));
+        self::assertSame($prefix.'service-default', $plainAgain->getUploadName($object));
+        self::assertSame($prefix.'service-default', $container->get('custom')->name($object, $plain));
+    }
+
+    public function testLazyServiceConfigurationRemainsIndependent(): void
+    {
+        $builder = $this->builder([
+            'configured' => ['namer' => ['service' => 'hash', 'options' => ['length' => 8]]],
+            'plain' => ['namer' => 'hash'],
+        ]);
+        $builder->register('hash', \Vich\UploaderBundle\Naming\HashNamer::class)
+            ->setLazy(true)->addTag('vich_uploader.namer');
+        $resolver = $this->resolver($this->compile($builder));
+        $object = (object) ['file' => new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/../Fixtures/App/app/Resources/images/symfony_black_03.png', 'image.png')];
+        $plain = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+        $configured = $resolver->resolve($object, 'file', ['mapping' => 'configured']);
+
+        self::assertNotSame($plain->getNamer(), $configured->getNamer());
+        self::assertMatchesRegularExpression('/^[a-f0-9]{8}\\.png$/', $configured->getUploadName($object));
+        self::assertMatchesRegularExpression('/^[a-f0-9]{40}\\.png$/', $plain->getUploadName($object));
+    }
+
+    public function testFileDirectoryAndNestedChainRolesDoNotShareOptions(): void
+    {
+        $builder = $this->builder([
+            'product.photos' => [
+                'namer' => ['service' => 'custom', 'options' => ['prefix' => 'file']],
+                'directory_namer' => [
+                    'service' => ChainDirectoryNamer::class,
+                    'options' => ['namers' => [
+                        ['service' => 'custom', 'options' => ['prefix' => 'first']],
+                        ['service' => ChainDirectoryNamer::class, 'options' => ['namers' => [
+                            ['service' => 'custom', 'options' => ['prefix' => 'second']],
+                            ['service' => 'custom'],
+                        ], 'separator' => '-']],
+                    ]],
+                ],
+            ],
+            'plain' => ['directory_namer' => IsolatedNamer::class],
+        ]);
+        $builder->register('custom', IsolatedNamer::class)
+            ->addTag('vich_uploader.namer')->addTag('vich_uploader.dir_namer');
+        $resolver = $this->resolver($this->compile($builder));
+        $object = new \stdClass();
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'product.photos']);
+        $plain = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+
+        self::assertSame('file', $mapping->getUploadName($object));
+        self::assertSame('first/second-default', $mapping->getDirectoryNamer()->directoryName($object, $mapping));
+        self::assertSame('default', $plain->getDirectoryNamer()->directoryName($object, $plain));
+    }
+
+    public function testNonSharedServicesAreStillResolvedOnEveryCall(): void
+    {
+        $builder = $this->builder(['products' => ['namer' => 'custom']]);
+        $builder->register('source', IsolatedNamer::class);
+        $builder->register('factory', IsolatedNamerFactory::class)->setArguments([new Reference('source')]);
+        $builder->register('custom', IsolatedNamer::class)->setShared(false)
+            ->setFactory([new Reference('factory'), 'createNext'])->addTag('vich_uploader.namer');
+        $resolver = $this->resolver($this->compile($builder));
+        $object = new \stdClass();
+        $first = $resolver->resolve($object, 'file', ['mapping' => 'products']);
+        $second = $resolver->resolve($object, 'file', ['mapping' => 'products']);
+
+        self::assertSame('1', $first->getUploadName($object));
+        self::assertSame('2', $second->getUploadName($object));
+    }
+
+    private function builder(array $mappings): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        foreach (['kernel.bundles' => [], 'kernel.bundles_metadata' => [], 'kernel.project_dir' => \sys_get_temp_dir(), 'kernel.cache_dir' => \sys_get_temp_dir(), 'kernel.build_dir' => \sys_get_temp_dir(), 'kernel.debug' => true] as $name => $value) {
+            $container->setParameter($name, $value);
+        }
+        foreach ($mappings as &$mapping) {
+            $mapping['upload_destination'] = \sys_get_temp_dir();
+        }
+        unset($mapping);
+        (new VichUploaderExtension())->load([['db_driver' => 'orm', 'mappings' => $mappings]], $container);
+        $container->register('slugger', AsciiSlugger::class);
+        $container->register('property_accessor', PropertyAccessor::class);
+        $container->register('event_dispatcher')->setSynthetic(true);
+        $container->getDefinition('vich_uploader.property_mapping_resolver')->setPublic(true);
+
+        return $container;
+    }
+
+    private function compile(ContainerBuilder $builder): Container
+    {
+        $builder->compile();
+        $class = 'NamerIsolationContainer'.\str_replace('.', '', \uniqid('', true));
+        $path = \tempnam(\sys_get_temp_dir(), 'vich_namers_');
+        try {
+            \file_put_contents($path, (new PhpDumper($builder))->dump(['class' => $class]));
+            require $path;
+
+            return new $class();
+        } finally {
+            \unlink($path);
+        }
+    }
+
+    private function resolver(Container $container): PropertyMappingResolver
+    {
+        $resolver = $container->get('vich_uploader.property_mapping_resolver');
+        self::assertInstanceOf(PropertyMappingResolver::class, $resolver);
+
+        return $resolver;
+    }
+}

--- a/tests/Fixtures/IsolatedNamer.php
+++ b/tests/Fixtures/IsolatedNamer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Fixtures;
+
+use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
+use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
+use Vich\UploaderBundle\Naming\ImmutableConfigurableInterface;
+use Vich\UploaderBundle\Naming\NamerInterface;
+
+final class IsolatedNamer implements NamerInterface, DirectoryNamerInterface, ImmutableConfigurableInterface
+{
+    public function __construct(private \stdClass $configuration = new \stdClass())
+    {
+    }
+
+    public static function getId(): string
+    {
+        return 'custom';
+    }
+
+    private function __clone()
+    {
+    }
+
+    public function withOptions(array $options): static
+    {
+        $namer = new self(clone $this->configuration);
+        $namer->configure($options);
+
+        return $namer;
+    }
+
+    public function configure(array $options): void
+    {
+        if (isset($options['prefix'])) {
+            $this->configuration->prefix = $options['prefix'];
+        }
+    }
+
+    public function name(object|array $object, PropertyMappingInterface $mapping): string
+    {
+        return $this->configuration->prefix ?? 'default';
+    }
+
+    public function directoryName(object|array $object, PropertyMappingInterface $mapping): string
+    {
+        return $this->name($object, $mapping);
+    }
+}

--- a/tests/Fixtures/IsolatedNamerDecorator.php
+++ b/tests/Fixtures/IsolatedNamerDecorator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Fixtures;
+
+use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
+use Vich\UploaderBundle\Naming\ImmutableConfigurableInterface;
+use Vich\UploaderBundle\Naming\NamerInterface;
+
+final class IsolatedNamerDecorator implements NamerInterface, ImmutableConfigurableInterface
+{
+    public function __construct(private readonly NamerInterface&ImmutableConfigurableInterface $inner)
+    {
+    }
+
+    public static function getId(): string
+    {
+        return 'custom';
+    }
+
+    public function withOptions(array $options): static
+    {
+        return new self($this->inner->withOptions($options));
+    }
+
+    public function name(object|array $object, PropertyMappingInterface $mapping): string
+    {
+        return 'decorated-'.$this->inner->name($object, $mapping);
+    }
+}

--- a/tests/Fixtures/IsolatedNamerFactory.php
+++ b/tests/Fixtures/IsolatedNamerFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Fixtures;
+
+final class IsolatedNamerFactory
+{
+    private int $calls = 0;
+
+    public function __construct(private readonly IsolatedNamer $namer)
+    {
+    }
+
+    public function createNext(): IsolatedNamer
+    {
+        return $this->namer->withOptions(['prefix' => (string) ++$this->calls]);
+    }
+
+    public function create(): IsolatedNamer
+    {
+        return $this->namer;
+    }
+}

--- a/tests/Mapping/PropertyMappingResolverChainTest.php
+++ b/tests/Mapping/PropertyMappingResolverChainTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Mapping;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
+use Vich\UploaderBundle\Mapping\PropertyMappingResolver;
+use Vich\UploaderBundle\Naming\ChainDirectoryNamer;
+use Vich\UploaderBundle\Naming\ConfigurableDirectoryNamer;
+use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
+use Vich\UploaderBundle\Naming\ImmutableConfigurableInterface;
+use Vich\UploaderBundle\Tests\Fixtures\IsolatedNamer;
+use Vich\UploaderBundle\Tests\TestCase;
+
+final class PropertyMappingResolverChainTest extends TestCase
+{
+    public function testRepeatedServicesHaveIndependentOptionsInsideAChain(): void
+    {
+        $shared = new IsolatedNamer();
+        $resolver = $this->resolver([
+            'chain_mapping' => self::chain([
+                ['service' => 'custom', 'options' => ['prefix' => 'first']],
+                ['service' => 'custom', 'options' => ['prefix' => 'second']],
+            ]),
+            'plain' => ['service' => 'custom'],
+        ], ['custom' => $shared]);
+        $mapping = $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'chain_mapping']);
+        $plain = $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'plain']);
+
+        self::assertSame('first/second', self::directory($mapping));
+        self::assertSame('default', self::directory($plain));
+        self::assertSame('default', $shared->directoryName(new \stdClass(), $mapping));
+    }
+
+    public static function resolutionOrders(): iterable
+    {
+        yield 'configured first' => [false];
+        yield 'plain first' => [true];
+    }
+
+    #[DataProvider('resolutionOrders')]
+    public function testChainsKeepTheirChildrenAndSeparatorsAcrossMappings(bool $reverse): void
+    {
+        $resolver = $this->resolver([
+            'first' => self::chain([self::directoryConfig('one'), self::directoryConfig('two')], '-'),
+            'second' => self::chain([self::directoryConfig('three'), self::directoryConfig('four')]),
+            'empty' => ['service' => 'chain'],
+        ]);
+        $mappings = [];
+        foreach ($reverse ? ['empty', 'second', 'first'] : ['first', 'second', 'empty'] as $name) {
+            $mappings[$name] = $resolver->resolve(new \stdClass(), 'file', ['mapping' => $name]);
+        }
+        $again = $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'first']);
+
+        self::assertSame('one-two', self::directory($mappings['first']));
+        self::assertSame('three/four', self::directory($mappings['second']));
+        self::assertSame('', self::directory($mappings['empty']));
+        self::assertSame('one-two', self::directory($again));
+        self::assertNotSame($mappings['first']->getDirectoryNamer(), $again->getDirectoryNamer());
+    }
+
+    public function testNestedChainsResolveRecursivelyEvenWhenTheyUseTheSameService(): void
+    {
+        $resolver = $this->resolver([
+            'nested' => self::chain([
+                self::directoryConfig('root'),
+                self::chain([self::directoryConfig('year'), self::directoryConfig('month')], '_'),
+            ]),
+        ]);
+        $mapping = $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'nested']);
+
+        self::assertSame('root/year_month', self::directory($mapping));
+    }
+
+    public function testPresetChildrenAreCopiedAndAnExplicitEmptyListClearsThem(): void
+    {
+        $child = new IsolatedNamer();
+        $child->configure(['prefix' => 'preset']);
+        $chain = new ChainDirectoryNamer();
+        $chain->setNamers([$child]);
+        $resolver = $this->resolver([
+            'defaults' => ['service' => 'chain'],
+            'empty' => self::chain([]),
+        ], ['chain' => $chain]);
+        $defaults = $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'defaults']);
+        $empty = $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'empty']);
+        $child->configure(['prefix' => 'changed']);
+
+        self::assertSame('preset', self::directory($defaults));
+        self::assertSame('', self::directory($empty));
+        self::assertSame('changed', $chain->directoryName(new \stdClass(), $defaults));
+    }
+
+    public function testOptionsOnANonConfigurableNestedNamerAreRejected(): void
+    {
+        $plain = new class() implements DirectoryNamerInterface {
+            public function directoryName(object|array $object, PropertyMappingInterface $mapping): string
+            {
+                return 'plain';
+            }
+        };
+        $resolver = $this->resolver([
+            'invalid' => self::chain([['service' => 'plain', 'options' => ['prefix' => 'ignored']]]),
+        ], ['plain' => $plain]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Namer plain can not receive options');
+        $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'invalid']);
+    }
+
+    public function testReturningTheSharedInstanceViolatesTheContract(): void
+    {
+        $broken = new class() implements DirectoryNamerInterface, ImmutableConfigurableInterface {
+            public function withOptions(array $options): static
+            {
+                return $this;
+            }
+
+            public function directoryName(object|array $object, PropertyMappingInterface $mapping): string
+            {
+                return 'shared';
+            }
+        };
+        $resolver = $this->resolver(['invalid' => self::chain([['service' => 'broken']])], ['broken' => $broken]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Namer "broken" must return a new instance from withOptions().');
+        $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'invalid']);
+    }
+
+    public static function malformedChildren(): iterable
+    {
+        yield 'not an array' => ['invalid'];
+        yield 'missing service' => [[['options' => []]]];
+        yield 'invalid service' => [[['service' => 123]]];
+    }
+
+    #[DataProvider('malformedChildren')]
+    public function testMalformedChainConfigurationFailsClearly(mixed $children): void
+    {
+        $resolver = $this->resolver(['invalid' => ['service' => 'chain', 'options' => ['namers' => $children]]]);
+        $this->expectException(\InvalidArgumentException::class);
+        $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'invalid']);
+    }
+
+    private static function chain(array $namers, ?string $separator = null): array
+    {
+        $options = ['namers' => $namers];
+        if (null !== $separator) {
+            $options['separator'] = $separator;
+        }
+
+        return ['service' => 'chain', 'options' => $options];
+    }
+
+    private static function directoryConfig(string $path): array
+    {
+        return ['service' => 'directory', 'options' => ['directory_path' => $path]];
+    }
+
+    private function resolver(array $configurations, array $services = []): PropertyMappingResolver
+    {
+        $mappings = [];
+        foreach ($configurations as $name => $configuration) {
+            $mappings[$name] = ['upload_destination' => '/tmp', 'directory_namer' => $configuration];
+        }
+
+        return new PropertyMappingResolver([], $services + [
+            'chain' => new ChainDirectoryNamer(),
+            'directory' => new ConfigurableDirectoryNamer(),
+        ], $mappings);
+    }
+
+    private static function directory(PropertyMappingInterface $mapping): ?string
+    {
+        return $mapping->getUploadDir(new \stdClass());
+    }
+}

--- a/tests/Mapping/PropertyMappingResolverConfigurationTest.php
+++ b/tests/Mapping/PropertyMappingResolverConfigurationTest.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Mapping;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
+use Vich\UploaderBundle\Mapping\PropertyMappingResolver;
+use Vich\UploaderBundle\Naming\Base64Namer;
+use Vich\UploaderBundle\Naming\ConfigurableDirectoryNamer;
+use Vich\UploaderBundle\Naming\CurrentDateTimeDirectoryNamer;
+use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
+use Vich\UploaderBundle\Naming\HashNamer;
+use Vich\UploaderBundle\Naming\NamerInterface;
+use Vich\UploaderBundle\Naming\OrignameNamer;
+use Vich\UploaderBundle\Naming\PropertyDirectoryNamer;
+use Vich\UploaderBundle\Naming\PropertyNamer;
+use Vich\UploaderBundle\Naming\SlugNamer;
+use Vich\UploaderBundle\Naming\SmartUniqueNamer;
+use Vich\UploaderBundle\Naming\SubdirDirectoryNamer;
+use Vich\UploaderBundle\Naming\UniqidNamer;
+use Vich\UploaderBundle\Tests\TestCase;
+use Vich\UploaderBundle\Util\Transliterator;
+
+/**
+ * Namers are shared services and configure() only overwrites the options it receives, so a mapping
+ * which does not set an option must not inherit the value set by the mapping resolved before it.
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class PropertyMappingResolverConfigurationTest extends TestCase
+{
+    private const NAMER_SERVICE = 'namer_service';
+
+    private const DIRECTORY_NAMER_SERVICE = 'directory_namer_service';
+
+    private const NO_NAMER = ['service' => null, 'options' => null];
+
+    /**
+     * @return array<string, array{NamerInterface, array<string, mixed>, array<string, mixed>, string}>
+     */
+    public static function namerProvider(): array
+    {
+        $transliterator = new Transliterator(new AsciiSlugger());
+
+        return [
+            'keep_extension of the UniqidNamer' => [
+                new UniqidNamer(),
+                ['keep_extension' => true],
+                [],
+                '/\.txt$/',
+            ],
+            'keep_extension of the SlugNamer' => [
+                new SlugNamer($transliterator, new class() {
+                    public ?object $existingFile = null;
+
+                    public function find(string $name): ?object
+                    {
+                        return $this->existingFile;
+                    }
+                }, 'find'),
+                ['keep_extension' => true],
+                [],
+                '/\.txt$/',
+            ],
+            'transliterate of the OrignameNamer' => [
+                new OrignameNamer($transliterator),
+                ['transliterate' => true],
+                [],
+                '/^[a-z0-9]{13}_Fôo Bàr\.txt$/u',
+            ],
+            'transliterate of the PropertyNamer' => [
+                new PropertyNamer($transliterator),
+                ['property' => 'title', 'transliterate' => true],
+                ['property' => 'title'],
+                '/^Tîtle Wîth Accents\.txt$/u',
+            ],
+            'algorithm and length of the HashNamer' => [
+                new HashNamer(),
+                ['algorithm' => 'md5', 'length' => 8],
+                [],
+                '/^[[:xdigit:]]{40}\.txt$/',
+            ],
+            'length of the Base64Namer' => [
+                new Base64Namer(),
+                ['length' => 40],
+                [],
+                '/^[\w-]{10}\.txt$/',
+            ],
+        ];
+    }
+
+    #[DataProvider('namerProvider')]
+    public function testNamerOptionsAreNotLeakedToAMappingSharingTheSameNamer(NamerInterface $namer, array $configuredOptions, array $plainOptions, string $expectedName): void
+    {
+        $resolver = $this->createNamerResolver($namer, $configuredOptions, $plainOptions);
+        $object = self::createObject();
+
+        $resolver->resolve($object, 'file', ['mapping' => 'configured', 'propertyName' => 'file']);
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'plain', 'propertyName' => 'file']);
+
+        self::assertMatchesRegularExpression($expectedName, $mapping->getNamer()->name($object, $this->createFileMapping(isset($configuredOptions['keep_extension']) ? 'Fôo Bàr.xyz' : 'Fôo Bàr.txt')));
+    }
+
+    /**
+     * @return array<string, array{DirectoryNamerInterface, array<string, mixed>, array<string, mixed>, string}>
+     */
+    public static function directoryNamerProvider(): array
+    {
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        return [
+            'directory_path of the ConfigurableDirectoryNamer' => [
+                new ConfigurableDirectoryNamer(),
+                ['directory_path' => 'configured'],
+                [],
+                '',
+            ],
+            'chars_per_dir and dirs of the SubdirDirectoryNamer' => [
+                new SubdirDirectoryNamer(),
+                ['chars_per_dir' => 3, 'dirs' => 2],
+                [],
+                '01',
+            ],
+            'transliterate of the PropertyDirectoryNamer' => [
+                new PropertyDirectoryNamer($propertyAccessor, new Transliterator(new AsciiSlugger())),
+                ['property' => 'title', 'transliterate' => true],
+                ['property' => 'title'],
+                'Tîtle Wîth Accents',
+            ],
+            'date_time_format of the CurrentDateTimeDirectoryNamer' => [
+                new CurrentDateTimeDirectoryNamer($propertyAccessor),
+                ['date_time_property' => 'createdAt', 'date_time_format' => 'Y-m'],
+                ['date_time_property' => 'createdAt'],
+                '2018/09/23',
+            ],
+        ];
+    }
+
+    #[DataProvider('directoryNamerProvider')]
+    public function testDirectoryNamerOptionsAreNotLeakedToAMappingSharingTheSameNamer(DirectoryNamerInterface $namer, array $configuredOptions, array $plainOptions, string $expectedName): void
+    {
+        $resolver = $this->createDirectoryNamerResolver($namer, $configuredOptions, $plainOptions);
+        $object = self::createObject();
+
+        $resolver->resolve($object, 'file', ['mapping' => 'configured', 'propertyName' => 'file']);
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'plain', 'propertyName' => 'file']);
+
+        self::assertSame($expectedName, $mapping->getDirectoryNamer()->directoryName($object, $this->createFileMapping()));
+    }
+
+    /**
+     * The namer_keep_extension option is turned into a namer option by the resolver, so it leaks
+     * the same way: a mapping which does not enable it kept the extension declared by the client
+     * instead of the guessed one.
+     */
+    public function testKeepExtensionIsNotLeakedToAMappingSharingTheSameNamer(): void
+    {
+        $namer = new SmartUniqueNamer($this->getTransliterator());
+        $resolver = $this->createNamerResolver($namer, [], [], true);
+        $object = self::createObject();
+
+        $resolver->resolve($object, 'file', ['mapping' => 'configured', 'propertyName' => 'file']);
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'plain', 'propertyName' => 'file']);
+
+        self::assertMatchesRegularExpression('/^test-[[:xdigit:]]{22}\.txt$/', $mapping->getNamer()->name($object, $this->createFileMapping('test.xyz')));
+    }
+
+    /**
+     * The options belong to the mapping, so they are applied to a copy of the namer: the service
+     * itself keeps its default configuration, whoever else uses it.
+     */
+    public function testTheSharedNamerServiceIsNotConfigured(): void
+    {
+        $namer = new HashNamer();
+        $resolver = $this->createNamerResolver($namer, ['algorithm' => 'md5', 'length' => 8], []);
+        $object = self::createObject();
+
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'configured', 'propertyName' => 'file']);
+
+        self::assertNotSame($namer, $mapping->getNamer());
+        self::assertMatchesRegularExpression('/^[[:xdigit:]]{40}\.txt$/', $namer->name($object, $this->createFileMapping()));
+    }
+
+    public function testRetainedMappingsKeepTheirOptionsInBothResolutionOrders(): void
+    {
+        $resolver = $this->createNamerResolver(new SmartUniqueNamer($this->getTransliterator()), [], [], true);
+        $object = self::createObject();
+        $fileMapping = $this->createFileMapping('test.php');
+        $plain = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+        $keeping = $resolver->resolve($object, 'file', ['mapping' => 'configured']);
+        $plainAgain = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+
+        self::assertStringEndsWith('.txt', $plain->getNamer()->name($object, $fileMapping));
+        self::assertStringEndsWith('.php', $keeping->getNamer()->name($object, $fileMapping));
+        self::assertStringEndsWith('.txt', $plainAgain->getNamer()->name($object, $fileMapping));
+    }
+
+    public function testExplicitKeepExtensionOptionIsPreserved(): void
+    {
+        $resolver = $this->createNamerResolver(new SmartUniqueNamer($this->getTransliterator()), ['keep_extension' => true], []);
+        $object = self::createObject();
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'configured']);
+
+        self::assertStringEndsWith('.xyz', $mapping->getNamer()->name($object, $this->createFileMapping('test.xyz')));
+    }
+
+    public function testServiceConfigurationIsPreservedWithoutMappingOptions(): void
+    {
+        $namer = new PropertyNamer($this->getTransliterator());
+        $namer->configure(['property' => 'title']);
+        $resolver = $this->createNamerResolver($namer, [], []);
+        $object = self::createObject();
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+
+        self::assertSame('Tîtle Wîth Accents.txt', $mapping->getNamer()->name($object, $this->createFileMapping('Fôo Bàr.xyz')));
+    }
+
+    public function testSubclassesInheritTheConfigurationCopyContract(): void
+    {
+        $namer = new class() extends HashNamer {};
+        $resolver = $this->createNamerResolver($namer, ['length' => 8], []);
+        $object = self::createObject();
+        $configured = $resolver->resolve($object, 'file', ['mapping' => 'configured']);
+        $plain = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+
+        self::assertNotSame($namer, $configured->getNamer());
+        self::assertMatchesRegularExpression('/^[[:xdigit:]]{8}\.txt$/', $configured->getNamer()->name($object, $this->createFileMapping()));
+        self::assertMatchesRegularExpression('/^[[:xdigit:]]{40}\.txt$/', $plain->getNamer()->name($object, $this->createFileMapping()));
+    }
+
+    public function testMappingsWithoutOptionsRetainTheServiceConfigurationAtResolution(): void
+    {
+        $namer = new SmartUniqueNamer($this->getTransliterator());
+        $resolver = $this->createNamerResolver($namer, [], []);
+        $object = self::createObject();
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+        $namer->configure(['keep_extension' => true]);
+
+        self::assertStringEndsWith('.txt', $mapping->getNamer()->name($object, $this->createFileMapping('test.php')));
+        self::assertStringEndsWith('.php', $namer->name($object, $this->createFileMapping('test.php')));
+    }
+
+    /**
+     * @param array<string, mixed> $configuredOptions options of the mapping which sets them
+     * @param array<string, mixed> $plainOptions      options of the mapping which must not inherit them
+     */
+    private function createNamerResolver(NamerInterface $namer, array $configuredOptions, array $plainOptions, bool $keepExtension = false): PropertyMappingResolver
+    {
+        return new PropertyMappingResolver(
+            [self::NAMER_SERVICE => $namer],
+            [],
+            [
+                'configured' => self::createMappingConfiguration(['service' => self::NAMER_SERVICE, 'options' => $configuredOptions], self::NO_NAMER, $keepExtension),
+                'plain' => self::createMappingConfiguration(['service' => self::NAMER_SERVICE, 'options' => $plainOptions], self::NO_NAMER),
+            ]
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $configuredOptions options of the mapping which sets them
+     * @param array<string, mixed> $plainOptions      options of the mapping which must not inherit them
+     */
+    private function createDirectoryNamerResolver(DirectoryNamerInterface $namer, array $configuredOptions, array $plainOptions): PropertyMappingResolver
+    {
+        return new PropertyMappingResolver(
+            [],
+            [self::DIRECTORY_NAMER_SERVICE => $namer],
+            [
+                'configured' => self::createMappingConfiguration(self::NO_NAMER, ['service' => self::DIRECTORY_NAMER_SERVICE, 'options' => $configuredOptions]),
+                'plain' => self::createMappingConfiguration(self::NO_NAMER, ['service' => self::DIRECTORY_NAMER_SERVICE, 'options' => $plainOptions]),
+            ]
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $namer
+     * @param array<string, mixed> $directoryNamer
+     *
+     * @return array<string, mixed>
+     */
+    private static function createMappingConfiguration(array $namer, array $directoryNamer, bool $keepExtension = false): array
+    {
+        return [
+            'upload_destination' => '/tmp',
+            'uri_prefix' => '/',
+            'namer' => $namer,
+            'directory_namer' => $directoryNamer,
+            'delete_on_remove' => true,
+            'erase_fields' => true,
+            'delete_on_update' => true,
+            'inject_on_load' => false,
+            'namer_keep_extension' => $keepExtension,
+            'db_driver' => 'orm',
+        ];
+    }
+
+    private static function createObject(): object
+    {
+        return new class() {
+            public string $title = 'Tîtle Wîth Accents';
+
+            public \DateTimeImmutable $createdAt;
+
+            public function __construct()
+            {
+                $this->createdAt = new \DateTimeImmutable('2018-09-23 12:34:56');
+            }
+        };
+    }
+
+    /**
+     * The mapping the namers read the file and the file name from, which is not the one under
+     * test: the resolved mapping is only used for the configuration it applies to the namer.
+     */
+    private function createFileMapping(string $originalName = 'Fôo Bàr.txt'): PropertyMappingInterface
+    {
+        $file = $this->getUploadedFileMock();
+        $file->method('getClientOriginalName')->willReturn($originalName);
+        $file->method('guessExtension')->willReturn('txt');
+
+        $mapping = $this->getPropertyMappingMock();
+        $mapping->method('getFile')->willReturn($file);
+        $mapping->method('getFileName')->willReturn('0123456789.jpg');
+
+        return $mapping;
+    }
+}

--- a/tests/Mapping/PropertyMappingResolverLegacyConfigurableTest.php
+++ b/tests/Mapping/PropertyMappingResolverLegacyConfigurableTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Vich\UploaderBundle\Tests\Mapping;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use Vich\UploaderBundle\Mapping\PropertyMappingInterface;
+use Vich\UploaderBundle\Mapping\PropertyMappingResolver;
+use Vich\UploaderBundle\Naming\ConfigurableInterface;
+use Vich\UploaderBundle\Naming\NamerInterface;
+use Vich\UploaderBundle\Tests\TestCase;
+
+/**
+ * Namers implementing only the deprecated ConfigurableInterface have no copy contract, so the
+ * shared service keeps being configured in place, as before 3.1.
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class PropertyMappingResolverLegacyConfigurableTest extends TestCase
+{
+    private const NAMER_SERVICE = 'namer_service';
+
+    private const NO_NAMER = ['service' => null, 'options' => null];
+
+    private const DEPRECATION = 'Since vich/uploader-bundle 3.1: Configuring namer "namer_service" through "Vich\UploaderBundle\Naming\ConfigurableInterface" is deprecated, implement "Vich\UploaderBundle\Naming\ImmutableConfigurableInterface" instead.';
+
+    #[IgnoreDeprecations]
+    public function testTheSharedServiceIsConfiguredInPlace(): void
+    {
+        $this->expectUserDeprecationMessage(self::DEPRECATION);
+
+        $namer = self::createLegacyNamer();
+        $resolver = $this->createResolver($namer, ['prefix' => 'configured']);
+        $object = new \stdClass();
+
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'configured']);
+
+        self::assertSame($namer, $mapping->getNamer());
+        self::assertSame('configured', $mapping->getNamer()->name($object, $this->createFileMapping()));
+    }
+
+    public function testAMappingWithoutOptionsDoesNotConfigureTheNamer(): void
+    {
+        $namer = self::createLegacyNamer();
+        $namer->configure(['prefix' => 'service']);
+        $resolver = $this->createResolver($namer, []);
+        $object = new \stdClass();
+
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'plain']);
+
+        self::assertSame($namer, $mapping->getNamer());
+        self::assertSame('service', $mapping->getNamer()->name($object, $this->createFileMapping()));
+    }
+
+    #[IgnoreDeprecations]
+    public function testKeepExtensionIsStillAcceptedByLegacyNamers(): void
+    {
+        $this->expectUserDeprecationMessage(self::DEPRECATION);
+
+        $namer = self::createLegacyNamer();
+        $resolver = $this->createResolver($namer, [], true);
+        $object = new \stdClass();
+
+        $mapping = $resolver->resolve($object, 'file', ['mapping' => 'configured']);
+
+        self::assertSame('keeping', $mapping->getNamer()->name($object, $this->createFileMapping()));
+    }
+
+    public function testANamerImplementingNeitherInterfaceCanNotReceiveOptions(): void
+    {
+        $namer = new class() implements NamerInterface {
+            public function name(object|array $object, PropertyMappingInterface $mapping): string
+            {
+                return 'plain';
+            }
+        };
+        $resolver = $this->createResolver($namer, ['prefix' => 'configured']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Namer namer_service can not receive options as it does not implement ImmutableConfigurableInterface.');
+        $resolver->resolve(new \stdClass(), 'file', ['mapping' => 'configured']);
+    }
+
+    private static function createLegacyNamer(): NamerInterface&ConfigurableInterface
+    {
+        return new class() implements NamerInterface, ConfigurableInterface {
+            private string $prefix = 'default';
+
+            public function configure(array $options): void
+            {
+                if (isset($options['keep_extension'])) {
+                    $this->prefix = 'keeping';
+                }
+                $this->prefix = $options['prefix'] ?? $this->prefix;
+            }
+
+            public function name(object|array $object, PropertyMappingInterface $mapping): string
+            {
+                return $this->prefix;
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function createResolver(NamerInterface $namer, array $options, bool $keepExtension = false): PropertyMappingResolver
+    {
+        return new PropertyMappingResolver(
+            [self::NAMER_SERVICE => $namer],
+            [],
+            [
+                'configured' => self::createMappingConfiguration(['service' => self::NAMER_SERVICE, 'options' => $options], $keepExtension),
+                'plain' => self::createMappingConfiguration(['service' => self::NAMER_SERVICE, 'options' => []]),
+            ]
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $namer
+     *
+     * @return array<string, mixed>
+     */
+    private static function createMappingConfiguration(array $namer, bool $keepExtension = false): array
+    {
+        return [
+            'upload_destination' => '/tmp',
+            'uri_prefix' => '/',
+            'namer' => $namer,
+            'directory_namer' => self::NO_NAMER,
+            'delete_on_remove' => true,
+            'erase_fields' => true,
+            'delete_on_update' => true,
+            'inject_on_load' => false,
+            'namer_keep_extension' => $keepExtension,
+            'db_driver' => 'orm',
+        ];
+    }
+
+    private function createFileMapping(): PropertyMappingInterface
+    {
+        $file = $this->getUploadedFileMock();
+        $file->method('getClientOriginalName')->willReturn('Fôo Bàr.txt');
+        $file->method('guessExtension')->willReturn('txt');
+
+        $mapping = $this->getPropertyMappingMock();
+        $mapping->method('getFile')->willReturn($file);
+
+        return $mapping;
+    }
+}

--- a/tests/Mapping/PropertyMappingResolverNonConfigurableTest.php
+++ b/tests/Mapping/PropertyMappingResolverNonConfigurableTest.php
@@ -44,7 +44,7 @@ final class PropertyMappingResolverNonConfigurableTest extends TestCase
         ];
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Namer non_configurable_namer does not implement ConfigurableInterface but namer_keep_extension option is set to true in mapping "test_mapping"');
+        $this->expectExceptionMessage('Namer non_configurable_namer does not implement ImmutableConfigurableInterface but namer_keep_extension option is set to true in mapping "test_mapping"');
 
         $resolver->resolve($object, 'file', $mappingData);
     }

--- a/tests/Naming/ChainDirectoryNamerTest.php
+++ b/tests/Naming/ChainDirectoryNamerTest.php
@@ -5,6 +5,7 @@ namespace Vich\UploaderBundle\Tests\Naming;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Vich\UploaderBundle\Naming\ChainDirectoryNamer;
 use Vich\UploaderBundle\Naming\DirectoryNamerInterface;
+use Vich\UploaderBundle\Naming\SubdirDirectoryNamer;
 use Vich\UploaderBundle\Tests\DummyEntity;
 use Vich\UploaderBundle\Tests\TestCase;
 
@@ -13,6 +14,30 @@ use Vich\UploaderBundle\Tests\TestCase;
  */
 final class ChainDirectoryNamerTest extends TestCase
 {
+    /**
+     * withOptions() is public API: the children it receives may well be shared services, so the
+     * chain has to copy them whether they come from the resolver or from a direct call.
+     */
+    public function testChildrenGivenToWithOptionsAreCopied(): void
+    {
+        $child = new SubdirDirectoryNamer();
+        $child->configure(['dirs' => 1]);
+
+        $chain = new ChainDirectoryNamer();
+        $first = $chain->withOptions(['namers' => [$child]]);
+        $second = $chain->withOptions(['namers' => [$child]]);
+
+        $child->configure(['dirs' => 3]);
+
+        $entity = new DummyEntity();
+        $entity->setFileName('0123456789.jpg');
+        $mapping = $this->getPropertyMappingMock();
+        $mapping->expects(self::any())->method('getFileName')->willReturn('0123456789.jpg');
+
+        self::assertSame('01', $first->directoryName($entity, $mapping));
+        self::assertSame('01', $second->directoryName($entity, $mapping));
+    }
+
     public static function chainDataProvider(): array
     {
         return [


### PR DESCRIPTION
# Give each mapping its own namer configuration

## The problem

Mappings referencing the same shared namer service use the same instance. The resolver calls
`configure()` on that instance, so options set by one mapping can carry over to another.

```yaml
vich_uploader:
    mappings:
        product_image:
            upload_destination: '%kernel.project_dir%/public/uploads/products'
            namer:
                service: Vich\UploaderBundle\Naming\OrignameNamer
                options: { transliterate: true }

        user_avatar:
            upload_destination: '%kernel.project_dir%/public/uploads/avatars'
            namer: Vich\UploaderBundle\Naming\OrignameNamer
```

Uploading `Fôo Bàr.txt` to `user_avatar` preserves the original name after the generated prefix
when that mapping is resolved first, but produces `<prefix>_foo-bar.txt` if `product_image`
was resolved earlier in the same process. Resolving mappings also happens during form rendering,
URI resolution and file removal, so an upload is not required to trigger the configuration change.

This affects configurable file and directory namers generally: transliteration, hash algorithms,
name lengths, directory layouts and date formats can all leak between mappings. It also affects
`keep_extension`: a mapping can preserve the client-provided extension because another mapping
enabled that option, even though it did not request this behavior itself.

`ChainDirectoryNamer` shares both the chain instance and its configurable children. For example:

```yaml
vich_uploader:
    mappings:
        invoice:
            upload_destination: '%kernel.project_dir%/public/uploads/invoices'
            directory_namer:
                service: Vich\UploaderBundle\Naming\ChainDirectoryNamer
                options:
                    namers:
                        - service: Vich\UploaderBundle\Naming\CurrentDateTimeDirectoryNamer
                          options: { date_time_property: createdAt, date_time_format: 'Y-m' }

        product_image:
            upload_destination: '%kernel.project_dir%/public/uploads/products'
            directory_namer:
                service: Vich\UploaderBundle\Naming\ChainDirectoryNamer
                options:
                    namers:
                        - service: Vich\UploaderBundle\Naming\CurrentDateTimeDirectoryNamer
                          options: { date_time_property: createdAt }
```

For an entity created on 2024-01-15, `product_image` uses `2024/01/15` when resolved first,
but inherits `2024-01` after `invoice` is resolved. Resolving another chain can also replace
the children or separator used by an already resolved mapping.

## The fix

`ConfigurableInterface` now declares `withOptions(array $options): static` instead of
`configure()`. The resolver uses the returned instance for the mapping and leaves the shared
service unchanged. This applies to built-in and custom configurable namers, including subclasses
and decorators.

- Each call must return a new instance with independent mutable configuration, preserving service
  defaults. Empty options still produce a separate instance with the defaults at resolution time.
- Chains copy their configurable children, including those supplied directly to `withOptions()`.
  The resolver supports nested chains and repeated services with different options.
  Non-configurable children remain shared. Explicit `namers: []` clears the chain.
- Returning `$this` raises a `LogicException`. Implementations remain responsible for isolating
  any mutable configuration held in dependencies or nested objects.

The eleven other built-in namers use `ConfigurableNamerTrait`, which clones the instance and
calls `configure()` on the copy when options are non-empty. Their `configure()` methods remain
available for service-level defaults, but are no longer required by the interface.

## Upgrading a custom namer

Existing mapping configuration needs no changes. Custom implementations of `ConfigurableInterface`
must provide `withOptions()`. When a shallow clone isolates the configuration, adding the trait
to the existing class is sufficient:

```php
class MyNamer implements NamerInterface, ConfigurableInterface
{
    use \Vich\UploaderBundle\Naming\ConfigurableNamerTrait;

    // Existing configure() and name() implementations.
}
```

For mutable configuration objects, copy them in `__clone()` or implement `withOptions()` by
constructing a new instance. Decorators must obtain an independent inner namer and wrap it,
for example `return new self($this->inner->withOptions($options));`. A `readonly` property alone
does not make the object it holds immutable.

Migration details are included in `UPGRADE.md` and the custom namer guides.

## Relation to the 2.10 patch

The proposed 2.10.x patch isolates the eleven built-in namer classes without changing the public
interface. This 3.x change introduces an explicit contract for custom configurable namers,
subclasses and decorators, and handles chains and their configurable children recursively.